### PR TITLE
feat(#6): copy integration test from jeo repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,12 @@ SOFTWARE.
       <!-- version from the parent pom -->
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eolang</groupId>
+      <artifactId>jucs</artifactId>
+      <version>0.2.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/src/test/java/it/TrasformationPacksTest.java
+++ b/src/test/java/it/TrasformationPacksTest.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package it;
+
+import org.eolang.jucs.ClasspathSource;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+
+/**
+ * Integration tests that verify that java code transforms into EO correctly.
+ * The test logic is as follows:
+ * 1. Compile java code into bytecode
+ * 2. Transform bytecode into XMIR
+ * 3. Compile expected EO into XMIR
+ * 4. Compare XMIRs
+ * @since 0.1
+ */
+final class TrasformationPacksTest {
+
+    @ParameterizedTest
+    @ClasspathSource(value = "packs", glob = "**.yaml")
+    void checksPack(final String pack) {
+        //@checkstyle MethodBodyCommentsCheck (10 lines)
+        // @todo #6:90min Implement primitive transformation test.
+        //  Currently we just get the pack name from the test and check that it is not null.
+        //  We have to implement proper transformation test. It will consist of the following steps:
+        //  1. Compile java code into bytecode
+        //  2. Transform bytecode into XMIR
+        //  3. Compile expected EO into XMIR
+        //  4. Compare XMIRs
+        MatcherAssert.assertThat(
+            "Pack is not null",
+            pack,
+            Matchers.notNullValue()
+        );
+    }
+}

--- a/src/test/java/it/package-info.java
+++ b/src/test/java/it/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/**
+ * Integration tests.
+ */
+package it;

--- a/src/test/resources/packs/simple_objects.yaml
+++ b/src/test/resources/packs/simple_objects.yaml
@@ -1,0 +1,61 @@
+java:
+  Application.java: |
+    package com.example;
+    public class Application {
+      public static void main(String[] args) {
+        new B(new A(42)).bar();
+      }
+    }
+  A.java: |
+    package com.example;
+    public class A {
+        private final int x;
+        public A(int x) {
+            this.x = x;
+        }
+        public int foo() {
+            return x * 2;
+        }
+    }
+  B.java: |
+    package com.example;
+    public class B {
+      private final A a;
+      public B(A a) {
+        this.a = a;
+      }
+      public int bar() {
+        return a.foo() + 1;
+      }
+    }
+eo:
+  Application.eo: |
+    package com.example
+    [] > Application
+      [args...] > main
+        seq > @
+          (b.new (a.new 42)).bar
+  A.eo: |
+    package com.example
+    [] > A
+      cage > x   
+      [xa] > new
+        seq > @
+          x.write xa 
+      [] > foo
+        seq > @
+          times 
+            x
+            2
+  B.eo: |
+    package com.example
+    [] > B
+      cage > a
+      [aa] > new
+        seq > @
+          a.write aa
+      [] > bar
+        seq > @
+          plus
+            a.foo
+            1


### PR DESCRIPTION
I copied the integration tests that we created to define our goals (what we want to get from bytecode transformation in order to provide simple inlining optimization.)

Closes: #6.


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new dependency `jucs` in `pom.xml` for testing purposes.
- Added new Java classes `Application`, `A`, and `B` in the `com.example` package.
- Added new EO classes `Application`, `A`, and `B` in the `com.example` package.
- Added new integration test classes `package-info` and `TrasformationPacksTest` in the `it` package.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->