### PR TITLE
feat(#22): enable integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>jeo-maven-plugin</artifactId>
-      <version>0.2.11</version>
+      <version>0.2.12</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/src/main/java/org/eolang/opeo/ast/Opcode.java
+++ b/src/main/java/org/eolang/opeo/ast/Opcode.java
@@ -49,6 +49,16 @@ public final class Opcode implements AstNode {
     private final List<Object> operands;
 
     /**
+     * Opcodes counting.
+     * Do we add number to opcode name or not?
+     * if true then we add number to opcode name:
+     *   RETURN -> RETURN-1
+     * if false then we do not add number to opcode name:
+     *   RETURN -> RETURN
+     */
+    private final boolean counting;
+
+    /**
      * Constructor.
      * @param opcode Opcode
      * @param operands Opcode operands
@@ -63,8 +73,19 @@ public final class Opcode implements AstNode {
      * @param operands Opcode operands
      */
     public Opcode(final int opcode, final List<Object> operands) {
-        this.bytecode = opcode;
+        this(opcode, operands, true);
+    }
+
+    /**
+     * Constructor.
+     * @param bytecode Bytecode
+     * @param operands Opcode operands
+     * @param counting Opcodes counting
+     */
+    public Opcode(final int bytecode, final List<Object> operands, final boolean counting) {
+        this.bytecode = bytecode;
         this.operands = operands;
+        this.counting = counting;
     }
 
     @Override
@@ -74,7 +95,7 @@ public final class Opcode implements AstNode {
 
     @Override
     public Iterable<Directive> toXmir() {
-        return new DirectivesInstruction(this.bytecode, this.operands.toArray());
+        return new DirectivesInstruction(this.bytecode, this.counting, this.operands.toArray());
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/jeo/JeoDecompiler.java
+++ b/src/main/java/org/eolang/opeo/jeo/JeoDecompiler.java
@@ -25,13 +25,11 @@ package org.eolang.opeo.jeo;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.eolang.jeo.representation.xmir.XmlMethod;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.jeo.representation.xmir.XmlProgram;
-import org.eolang.opeo.Instruction;
 import org.eolang.opeo.vmachine.DecompilerMachine;
 import org.w3c.dom.Node;
 import org.xembly.Transformers;

--- a/src/main/java/org/eolang/opeo/jeo/JeoDecompiler.java
+++ b/src/main/java/org/eolang/opeo/jeo/JeoDecompiler.java
@@ -26,6 +26,7 @@ package org.eolang.opeo.jeo;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.eolang.jeo.representation.xmir.XmlMethod;
 import org.eolang.jeo.representation.xmir.XmlNode;
@@ -72,14 +73,15 @@ public final class JeoDecompiler {
      * @param method Method.
      */
     private static void decompile(final XmlMethod method) {
-        final DecompilerMachine machine = new DecompilerMachine();
-        final Instruction[] instructions = new JeoInstructions(method).instructions();
-        final List<XmlNode> collect = new XmlNode(
-            new Xembler(
-                machine.decompileToXmir(instructions),
-                new Transformers.Node()
-            ).xmlQuietly()
-        ).children().collect(Collectors.toList());
-        method.replaceInstructions(collect.toArray(XmlNode[]::new));
+        method.replaceInstructions(
+            new XmlNode(
+                new Xembler(
+                    new DecompilerMachine(Map.of("counting", "false")).decompileToXmir(
+                        new JeoInstructions(method).instructions()
+                    ),
+                    new Transformers.Node()
+                ).xmlQuietly()
+            ).children().collect(Collectors.toList()).toArray(XmlNode[]::new)
+        );
     }
 }

--- a/src/main/java/org/eolang/opeo/vmachine/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/vmachine/DecompilerMachine.java
@@ -25,6 +25,7 @@ package org.eolang.opeo.vmachine;
 
 import java.util.Arrays;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -63,19 +64,33 @@ public final class DecompilerMachine {
     private final Map<Integer, InstructionHandler> handlers;
 
     /**
+     * Arguments provided to decompiler.
+     */
+    private final Map<String, String> arguments;
+
+    /**
      * Constructor.
      */
     public DecompilerMachine() {
-        this(new LinkedList<>());
+        this(new HashMap<>());
+    }
+
+    /**
+     * Constructor.
+     * @param args Arguments provided to decompiler.
+     */
+    public DecompilerMachine(final Map<String, String> args) {
+        this(new LinkedList<>(), args);
     }
 
     /**
      * Constructor.
      * @param stack Operand stack.
      */
-    private DecompilerMachine(final Deque<Object> stack) {
+    private DecompilerMachine(final Deque<Object> stack, final Map<String, String> arguments) {
         this.stack = stack;
         this.root = new Root();
+        this.arguments = arguments;
         this.handlers = new MapOf<>(
             new MapEntry<>(Opcodes.ICONST_1, new IconstHandler()),
             new MapEntry<>(Opcodes.ICONST_2, new IconstHandler()),
@@ -167,7 +182,11 @@ public final class DecompilerMachine {
                 DecompilerMachine.this.stack.push("this");
             }
             DecompilerMachine.this.root.append(
-                new Opcode(instruction.opcode(), instruction.operands())
+                new Opcode(
+                    instruction.opcode(),
+                    instruction.operands(),
+                    DecompilerMachine.this.counting()
+                )
             );
         }
     }
@@ -228,7 +247,11 @@ public final class DecompilerMachine {
         @Override
         public void handle(final Instruction instruction) {
             DecompilerMachine.this.root.append(
-                new Opcode(instruction.opcode(), instruction.operands())
+                new Opcode(
+                    instruction.opcode(),
+                    instruction.operands(),
+                    DecompilerMachine.this.counting()
+                )
             );
         }
     }
@@ -247,7 +270,11 @@ public final class DecompilerMachine {
             }
             if (instruction.operand(0).equals("java/lang/Object")) {
                 DecompilerMachine.this.root.append(
-                    new Opcode(instruction.opcode(), instruction.operands())
+                    new Opcode(
+                        instruction.opcode(),
+                        instruction.operands(),
+                        DecompilerMachine.this.counting()
+                    )
                 );
             } else {
                 final List<AstNode> args = DecompilerMachine.this.popArguments(
@@ -302,7 +329,11 @@ public final class DecompilerMachine {
         @Override
         public void handle(final Instruction instruction) {
             DecompilerMachine.this.root.append(
-                new Opcode(instruction.opcode(), instruction.operands())
+                new Opcode(
+                    instruction.opcode(),
+                    instruction.operands(),
+                    DecompilerMachine.this.counting()
+                )
             );
         }
     }
@@ -339,4 +370,16 @@ public final class DecompilerMachine {
         }
     }
 
+
+    /**
+     * Do we add number to opcode name or not?
+     * if true then we add number to opcode name:
+     *  RETURN -> RETURN-1
+     * if false then we do not add number to opcode name:
+     *  RETURN -> RETURN
+     * @return Opcodes counting.
+     */
+    private boolean counting() {
+        return this.arguments.getOrDefault("counting", "true").equals("true");
+    }
 }

--- a/src/main/java/org/eolang/opeo/vmachine/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/vmachine/DecompilerMachine.java
@@ -86,11 +86,12 @@ public final class DecompilerMachine {
     /**
      * Constructor.
      * @param stack Operand stack.
+     * @param args Arguments provided to decompiler.
      */
-    private DecompilerMachine(final Deque<Object> stack, final Map<String, String> arguments) {
+    private DecompilerMachine(final Deque<Object> stack, final Map<String, String> args) {
         this.stack = stack;
         this.root = new Root();
-        this.arguments = arguments;
+        this.arguments = args;
         this.handlers = new MapOf<>(
             new MapEntry<>(Opcodes.ICONST_1, new IconstHandler()),
             new MapEntry<>(Opcodes.ICONST_2, new IconstHandler()),
@@ -132,6 +133,18 @@ public final class DecompilerMachine {
     }
 
     /**
+     * Do we add number to opcode name or not?
+     * if true then we add number to opcode name:
+     *  RETURN -> RETURN-1
+     * if false then we do not add number to opcode name:
+     *  RETURN -> RETURN
+     * @return Opcodes counting.
+     */
+    private boolean counting() {
+        return this.arguments.getOrDefault("counting", "true").equals("true");
+    }
+
+    /**
      * Get instruction handler.
      * @param opcode Instruction opcode.
      * @return Instruction handler.
@@ -146,15 +159,15 @@ public final class DecompilerMachine {
      * @return List of arguments.
      */
     private List<AstNode> popArguments(final int number) {
-        final List<AstNode> arguments = new LinkedList<>();
+        final List<AstNode> args = new LinkedList<>();
         for (int index = 0; index < number; ++index) {
             final Object arg = this.stack.pop();
             final AstNode node = this.root.child(String.valueOf(arg))
                 .orElseGet(() -> new Literal(arg));
             this.root.disconnect(node);
-            arguments.add(node);
+            args.add(node);
         }
-        return arguments;
+        return args;
     }
 
     /**
@@ -162,6 +175,7 @@ public final class DecompilerMachine {
      * @since 0.1
      */
     private interface InstructionHandler {
+
         /**
          * Handle instruction.
          * @param instruction Instruction to handle.
@@ -189,6 +203,7 @@ public final class DecompilerMachine {
                 )
             );
         }
+
     }
 
     /**
@@ -202,6 +217,7 @@ public final class DecompilerMachine {
                 new ObjectReference((String) instruction.operand(0)).toString()
             );
         }
+
     }
 
     /**
@@ -213,6 +229,7 @@ public final class DecompilerMachine {
         public void handle(final Instruction instruction) {
             DecompilerMachine.this.stack.push(DecompilerMachine.this.stack.peek());
         }
+
     }
 
     /**
@@ -224,6 +241,7 @@ public final class DecompilerMachine {
         public void handle(final Instruction instruction) {
             DecompilerMachine.this.stack.push(instruction.operand(0));
         }
+
     }
 
     /**
@@ -237,6 +255,7 @@ public final class DecompilerMachine {
                 DecompilerMachine.this.stack.pop();
             }
         }
+
     }
 
     /**
@@ -254,6 +273,7 @@ public final class DecompilerMachine {
                 )
             );
         }
+
     }
 
     /**
@@ -289,6 +309,7 @@ public final class DecompilerMachine {
                 );
             }
         }
+
     }
 
     /**
@@ -308,6 +329,7 @@ public final class DecompilerMachine {
                 new Invocation(source, method, args)
             );
         }
+
     }
 
     /**
@@ -319,6 +341,7 @@ public final class DecompilerMachine {
         public void handle(final Instruction instruction) {
             DecompilerMachine.this.stack.push(instruction.operand(0));
         }
+
     }
 
     /**
@@ -336,6 +359,7 @@ public final class DecompilerMachine {
                 )
             );
         }
+
     }
 
     /**
@@ -368,18 +392,6 @@ public final class DecompilerMachine {
                     );
             }
         }
-    }
 
-
-    /**
-     * Do we add number to opcode name or not?
-     * if true then we add number to opcode name:
-     *  RETURN -> RETURN-1
-     * if false then we do not add number to opcode name:
-     *  RETURN -> RETURN
-     * @return Opcodes counting.
-     */
-    private boolean counting() {
-        return this.arguments.getOrDefault("counting", "true").equals("true");
     }
 }

--- a/src/test/java/it/TrasformationPacksTest.java
+++ b/src/test/java/it/TrasformationPacksTest.java
@@ -60,17 +60,12 @@ import org.junit.jupiter.params.ParameterizedTest;
  * 3. Transform XMIR into EO code
  * 4. Compare EO code with expected EO code
  * @since 0.1
- * @todo #11:90min Enable tests in TrasformationPacksTest.
- *  Currently, tests in TrasformationPacksTest are disabled by the following reason:
- *  https://github.com/objectionary/jeo-maven-plugin/issues/354
- *  When the issue will be fixed, we should enable tests in TrasformationPacksTest.
  */
 final class TrasformationPacksTest {
 
     @ParameterizedTest
     @ClasspathSource(value = "packs", glob = "**.yaml")
     @EnabledIf(value = "hasJavaCompiler", disabledReason = "Java compiler is not available")
-    @Disabled
     void checksPack(final String pack, @TempDir final Path where) throws IOException {
         final JavaEoPack jeopack = new JavaEoPack(pack);
         //@checkstyle MethodBodyCommentsCheck (10 lines)
@@ -110,7 +105,6 @@ final class TrasformationPacksTest {
      * @throws IOException If fails.
      */
     @Test
-    @Disabled
     void decompilesSimpleExample(@TempDir final Path where) throws Exception {
         final XML decompiled = new JeoDecompiler(
             new BytecodeRepresentation(

--- a/src/test/java/it/TrasformationPacksTest.java
+++ b/src/test/java/it/TrasformationPacksTest.java
@@ -46,7 +46,6 @@ import org.eolang.opeo.jeo.JeoDecompiler;
 import org.eolang.parser.XMIR;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.io.TempDir;

--- a/src/test/resources/packs/simple_objects.yaml
+++ b/src/test/resources/packs/simple_objects.yaml
@@ -45,15 +45,15 @@ eo:
         * > exceptions
         seq > @
           tuple
-            opcode > ALOAD-39
+            opcode > ALOAD
               25
               0
-            opcode > INVOKESPECIAL-3A
+            opcode > INVOKESPECIAL
               183
               "java/lang/Object"
               "<init>"
               "()V"
-            opcode > RETURN-3B
+            opcode > RETURN
               177
         tuple > trycatchblocks
       [arg__[Ljava/lang/String;__0] > j$main
@@ -69,9 +69,10 @@ eo:
               .new
                 42
             .bar
-            opcode > RETURN-3C
+            opcode > RETURN
               177
         tuple > trycatchblocks
+
   A.eo: |
     +package com.example
     +alias org.eolang.jeo.opcode
@@ -93,26 +94,26 @@ eo:
         * > exceptions
         seq > @
           tuple
-            opcode > ALOAD-22
+            opcode > ALOAD
               25
               0
-            opcode > INVOKESPECIAL-23
+            opcode > INVOKESPECIAL
               183
               "java/lang/Object"
               "<init>"
               "()V"
-            opcode > ALOAD-24
+            opcode > ALOAD
               25
               0
-            opcode > ILOAD-25
+            opcode > ILOAD
               21
               1
-            opcode > PUTFIELD-26
+            opcode > PUTFIELD
               181
               "com/example/A"
               "x"
               "I"
-            opcode > RETURN-27
+            opcode > RETURN
               177
         tuple > trycatchblocks
       [] > j$foo
@@ -122,19 +123,20 @@ eo:
         * > exceptions
         seq > @
           tuple
-            opcode > ALOAD-28
+            opcode > ALOAD
               25
               0
-            opcode > GETFIELD-29
+            opcode > GETFIELD
               180
               "com/example/A"
               "x"
               "I"
-            opcode > IMUL-2A
+            opcode > IMUL
               104
-            opcode > IRETURN-2B
+            opcode > IRETURN
               172
         tuple > trycatchblocks
+
   B.eo: |
     +package com.example
     +alias org.eolang.jeo.opcode
@@ -156,26 +158,26 @@ eo:
         * > exceptions
         seq > @
           tuple
-            opcode > ALOAD-D
+            opcode > ALOAD
               25
               0
-            opcode > INVOKESPECIAL-E
+            opcode > INVOKESPECIAL
               183
               "java/lang/Object"
               "<init>"
               "()V"
-            opcode > ALOAD-F
+            opcode > ALOAD
               25
               0
-            opcode > ALOAD-10
+            opcode > ALOAD
               25
               1
-            opcode > PUTFIELD-11
+            opcode > PUTFIELD
               181
               "com/example/B"
               "a"
               "Lcom/example/A;"
-            opcode > RETURN-12
+            opcode > RETURN
               177
         tuple > trycatchblocks
       [] > j$bar
@@ -185,18 +187,18 @@ eo:
         * > exceptions
         seq > @
           tuple
-            opcode > ALOAD-13
+            opcode > ALOAD
               25
               0
-            opcode > GETFIELD-14
+            opcode > GETFIELD
               180
               "com/example/B"
               "a"
               "Lcom/example/A;"
             "this"
             .foo
-            opcode > IADD-15
+            opcode > IADD
               96
-            opcode > IRETURN-16
+            opcode > IRETURN
               172
         tuple > trycatchblocks

--- a/src/test/resources/simple.eo
+++ b/src/test/resources/simple.eo
@@ -13,15 +13,15 @@
     * > exceptions
     seq > @
       tuple
-        opcode > ALOAD-C
+        opcode > ALOAD
           25
           0
-        opcode > INVOKESPECIAL-D
+        opcode > INVOKESPECIAL
           183
           "java/lang/Object"
           "<init>"
           "()V"
-        opcode > RETURN-E
+        opcode > RETURN
           177
     tuple > trycatchblocks
   [arg__[Ljava/lang/String;__0] > j$main
@@ -36,6 +36,6 @@
           "abc"
         .append
           1
-        opcode > RETURN-F
+        opcode > RETURN
           177
     tuple > trycatchblocks


### PR DESCRIPTION
Enable packs integration tests.

Closes: #22.
____
History:
- feat(#22): repair one of the integration tests
- feat(#22): repair all of the rest integration tests
- feat(#22): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating dependencies and making changes to the codebase for better readability and maintainability.

### Detailed summary
- Updated the version of `jeo-maven-plugin` dependency from 0.2.11 to 0.2.12 in `pom.xml`.
- Modified the `Opcode` class to include a boolean flag for counting opcodes.
- Updated the `JeoDecompiler` class to use the new `Opcode` constructor with the counting flag.
- Added a new constructor to `DecompilerMachine` to accept arguments for the decompiler.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->