### PR TITLE
feat(#35): use new features of jcabi-log 0.24.1

### DIFF
--- a/src/main/java/org/eolang/opeo/Compiler.java
+++ b/src/main/java/org/eolang/opeo/Compiler.java
@@ -81,8 +81,8 @@ public class Compiler {
         //  Currently we print dummy messages in order to pass 'decompile-compile' integration test.
         //  Implement this class and don't forget to add unit tests.
         //  Also, you might need to change some checks in the 'decompile-compile' integration test.
-        Logger.info(this, "Compiling EO sources from %s", this.xmirs);
-        Logger.info(this, "Saving new compiled EO sources to %s", this.output);
+        Logger.info(this, "Compiling EO sources from %[file]s", this.xmirs);
+        Logger.info(this, "Saving new compiled EO sources to %[file]s", this.output);
         Logger.info(this, "Compiled app.eo (545 bytes)");
         Logger.info(this, "Compiled main.eo (545 bytes)");
         Logger.info(this, "Compiled %d EO sources", 2);


### PR DESCRIPTION
Now, in all the places where we use `jcabi` logger, we use `%[file]s`

Closes: #35.


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The PR focuses on updating the format of log messages in the `Compiler` class.
- The log messages now use the `%[file]s` format specifier to display file paths.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->