### PR TITLE
feat(#25): Field Access

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/InstanceField.java
+++ b/src/main/java/org/eolang/opeo/ast/InstanceField.java
@@ -24,6 +24,7 @@
 package org.eolang.opeo.ast;
 
 import org.xembly.Directive;
+import org.xembly.Directives;
 
 /**
  * Access to a field.
@@ -58,6 +59,10 @@ public final class InstanceField implements AstNode {
 
     @Override
     public Iterable<Directive> toXmir() {
-        return null;
+        return new Directives()
+            .append(this.source.toXmir())
+            .add("o")
+            .attr("base", String.format(".%s", this.name))
+            .up();
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/InstanceField.java
+++ b/src/main/java/org/eolang/opeo/ast/InstanceField.java
@@ -60,9 +60,9 @@ public final class InstanceField implements AstNode {
     @Override
     public Iterable<Directive> toXmir() {
         return new Directives()
-            .append(this.source.toXmir())
             .add("o")
             .attr("base", String.format(".%s", this.name))
+            .append(this.source.toXmir())
             .up();
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/InstanceField.java
+++ b/src/main/java/org/eolang/opeo/ast/InstanceField.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import org.xembly.Directive;
+
+/**
+ * Access to a field.
+ * @since 0.1
+ */
+public final class InstanceField implements AstNode {
+
+    /**
+     * Object reference from which the field is accessed.
+     */
+    private final AstNode source;
+
+    /**
+     * Field name.
+     */
+    private final String name;
+
+    /**
+     * Constructor.
+     * @param source Object reference from which the field is accessed
+     * @param name Field name
+     */
+    public InstanceField(final AstNode source, final String name) {
+        this.source = source;
+        this.name = name;
+    }
+
+    @Override
+    public String print() {
+        return String.format("%s.%s", this.source.print(), this.name);
+    }
+
+    @Override
+    public Iterable<Directive> toXmir() {
+        return null;
+    }
+}

--- a/src/main/java/org/eolang/opeo/vmachine/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/vmachine/DecompilerMachine.java
@@ -108,6 +108,7 @@ public final class DecompilerMachine {
             new MapEntry<>(Opcodes.BIPUSH, new BipushHandler()),
             new MapEntry<>(Opcodes.INVOKESPECIAL, new InvokespecialHandler()),
             new MapEntry<>(Opcodes.INVOKEVIRTUAL, new InvokevirtualHandler()),
+            new MapEntry<>(Opcodes.GETFIELD, new GetFieldHandler()),
             new MapEntry<>(Opcodes.LDC, new LdcHandler()),
             new MapEntry<>(Opcodes.POP, new PopHandler()),
             new MapEntry<>(Opcodes.RETURN, new ReturnHandler())
@@ -209,6 +210,19 @@ public final class DecompilerMachine {
             DecompilerMachine.this.stack.push(new Reference());
         }
 
+    }
+
+    /**
+     * Getfield instruction handler.
+     * @since 0.1
+     */
+    private class GetFieldHandler implements InstructionHandler {
+
+        @Override
+        public void handle(final Instruction instruction) {
+            final String variable = (String) instruction.operand(1);
+            final AstNode ref = DecompilerMachine.this.stack.pop();
+        }
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/vmachine/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/vmachine/DecompilerMachine.java
@@ -36,6 +36,7 @@ import org.eolang.opeo.Instruction;
 import org.eolang.opeo.ast.Add;
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.Constructor;
+import org.eolang.opeo.ast.InstanceField;
 import org.eolang.opeo.ast.Invocation;
 import org.eolang.opeo.ast.Literal;
 import org.eolang.opeo.ast.Opcode;
@@ -220,8 +221,12 @@ public final class DecompilerMachine {
 
         @Override
         public void handle(final Instruction instruction) {
-            final String variable = (String) instruction.operand(1);
-            final AstNode ref = DecompilerMachine.this.stack.pop();
+            DecompilerMachine.this.stack.push(
+                new InstanceField(
+                    DecompilerMachine.this.stack.pop(),
+                    (String) instruction.operand(1)
+                )
+            );
         }
     }
 

--- a/src/test/java/org/eolang/opeo/ast/InstanceFieldTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InstanceFieldTest.java
@@ -27,6 +27,7 @@ import com.jcabi.matchers.XhtmlMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.xembly.Directives;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
@@ -47,14 +48,23 @@ class InstanceFieldTest {
 
     @Test
     void convertsToXmir() throws ImpossibleModificationException {
-        final String actual = new Xembler(new InstanceField(new This(), "bar").toXmir()).xml();
+        final String actual = new Xembler(
+            new Directives()
+                .add("o")
+                .attr("name", "method")
+                .append(new InstanceField(new This(), "bar").toXmir())
+                .up()
+        ).xml();
         MatcherAssert.assertThat(
             String.format(
                 "Can't convert to a field access construct, actual result is : %n%s%n",
                 actual
             ),
             actual,
-            XhtmlMatchers.hasXPath("/o[@base='this']/a[@name='bar']")
+            XhtmlMatchers.hasXPaths(
+                "./o[@name='method']/o[@base='$']",
+                "./o[@name='method']/o[@base='.bar']"
+            )
         );
     }
 }

--- a/src/test/java/org/eolang/opeo/ast/InstanceFieldTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InstanceFieldTest.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link InstanceField}.
+ * @since 0.1
+ */
+class InstanceFieldTest {
+
+    @Test
+    void printsField() {
+        MatcherAssert.assertThat(
+            "We can't print a field access, actual result is wrong",
+            new InstanceField(new This(), "bar").print(),
+            Matchers.equalTo("this.bar")
+        );
+    }
+
+    @Test
+    void convertsToXmir() throws ImpossibleModificationException {
+        final String actual = new Xembler(new InstanceField(new This(), "bar").toXmir()).xml();
+        MatcherAssert.assertThat(
+            String.format(
+                "Can't convert to a field access construct, actual result is : %n%s%n",
+                actual
+            ),
+            actual,
+            XhtmlMatchers.hasXPath("/o[@base='this']/a[@name='bar']")
+        );
+    }
+}

--- a/src/test/java/org/eolang/opeo/ast/InstanceFieldTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InstanceFieldTest.java
@@ -62,8 +62,9 @@ class InstanceFieldTest {
             ),
             actual,
             XhtmlMatchers.hasXPaths(
-                "./o[@name='method']/o[@base='$']",
-                "./o[@name='method']/o[@base='.bar']"
+                "./o[@name='method']",
+                "./o[@name='method']/o[@base='.bar']",
+                "./o[@name='method']/o[@base='.bar']/o[@base='$']"
             )
         );
     }

--- a/src/test/java/org/eolang/opeo/vmachine/DecompilerMachineTest.java
+++ b/src/test/java/org/eolang/opeo/vmachine/DecompilerMachineTest.java
@@ -23,11 +23,15 @@
  */
 package org.eolang.opeo.vmachine;
 
+import org.cactoos.text.TextOf;
+import org.eolang.opeo.Instruction;
 import org.eolang.opeo.OpcodeInstruction;
+import org.eolang.parser.XMIR;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
+import org.xembly.Xembler;
 
 /**
  * Test case for {@link DecompilerMachine}.
@@ -254,13 +258,44 @@ final class DecompilerMachineTest {
             new DecompilerMachine().decompile(
                 new OpcodeInstruction(Opcodes.ALOAD, 0),
                 new OpcodeInstruction(Opcodes.GETFIELD, "App", "a", "Ljava/lang/Integer;"),
-                new OpcodeInstruction(Opcodes.ALOAD, 0),
                 new OpcodeInstruction(Opcodes.INVOKEVIRTUAL, "App", "intValue", "()I"),
                 new OpcodeInstruction(Opcodes.ICONST_1),
                 new OpcodeInstruction(Opcodes.IADD)
             ),
             Matchers.equalTo(
                 "((this.a).intValue) + (1)"
+            )
+        );
+    }
+
+    @Test
+    void decompilesFieldAccessAndMethodInvocationToEo() {
+        final String xml = new Xembler(
+            new DecompilerMachine().decompileToXmir(
+                new OpcodeInstruction(Opcodes.ALOAD, 0),
+                new OpcodeInstruction(Opcodes.GETFIELD, "App", "a", "Ljava/lang/Integer;"),
+                new OpcodeInstruction(Opcodes.INVOKEVIRTUAL, "App", "intValue", "()I"),
+                new OpcodeInstruction(Opcodes.ICONST_1),
+                new OpcodeInstruction(Opcodes.IADD)
+            )
+        ).xmlQuietly();
+        MatcherAssert.assertThat(
+            String.format(
+                "Can't decompile field access and method invocation into EO for 'this.a.intValue() + 1;', received XML: %n%s%n",
+                xml
+            ),
+            new XMIR(new TextOf(xml)).toEO(),
+            Matchers.equalTo(
+                String.join(
+                    "\n",
+                    "tuple",
+                    "  $",
+                    "  .a",
+                    "  .intValue",
+                    "  .plus",
+                    "    1",
+                    ""
+                )
             )
         );
     }

--- a/src/test/java/org/eolang/opeo/vmachine/DecompilerMachineTest.java
+++ b/src/test/java/org/eolang/opeo/vmachine/DecompilerMachineTest.java
@@ -24,7 +24,6 @@
 package org.eolang.opeo.vmachine;
 
 import org.cactoos.text.TextOf;
-import org.eolang.opeo.Instruction;
 import org.eolang.opeo.OpcodeInstruction;
 import org.eolang.parser.XMIR;
 import org.hamcrest.MatcherAssert;

--- a/src/test/java/org/eolang/opeo/vmachine/DecompilerMachineTest.java
+++ b/src/test/java/org/eolang/opeo/vmachine/DecompilerMachineTest.java
@@ -238,4 +238,30 @@ final class DecompilerMachineTest {
             )
         );
     }
+
+    /**
+     * Test decompilation of instance field access and method invocation.
+     * <p>
+     *     {@code
+     *       this.a.intValue() + 1;
+     *     }
+     * </p>
+     */
+    @Test
+    void decompilesFieldAccessAndMethodInvocation() {
+        MatcherAssert.assertThat(
+            "Can't decompile field access and method invocation instructions for 'this.a.intValue() + 1;'",
+            new DecompilerMachine().decompile(
+                new OpcodeInstruction(Opcodes.ALOAD, 0),
+                new OpcodeInstruction(Opcodes.GETFIELD, "App", "a", "Ljava/lang/Integer;"),
+                new OpcodeInstruction(Opcodes.ALOAD, 0),
+                new OpcodeInstruction(Opcodes.INVOKEVIRTUAL, "App", "intValue", "()I"),
+                new OpcodeInstruction(Opcodes.ICONST_1),
+                new OpcodeInstruction(Opcodes.IADD)
+            ),
+            Matchers.equalTo(
+                "((this.a).intValue) + (1)"
+            )
+        );
+    }
 }

--- a/src/test/java/org/eolang/opeo/vmachine/DecompilerMachineTest.java
+++ b/src/test/java/org/eolang/opeo/vmachine/DecompilerMachineTest.java
@@ -213,4 +213,29 @@ final class DecompilerMachineTest {
             )
         );
     }
+
+    /**
+     * Test decompilation of instance field access.
+     * <p>
+     *     {@code
+     *       this.a + this.b;
+     *     }
+     * </p>
+     */
+    @Test
+    void decompilesFieldAccess() {
+        MatcherAssert.assertThat(
+            "Can't decompile field access instructions for 'this.a + this.b;'",
+            new DecompilerMachine().decompile(
+                new OpcodeInstruction(Opcodes.ALOAD, 0),
+                new OpcodeInstruction(Opcodes.GETFIELD, "App", "a", "I"),
+                new OpcodeInstruction(Opcodes.ALOAD, 0),
+                new OpcodeInstruction(Opcodes.GETFIELD, "App", "b", "I"),
+                new OpcodeInstruction(Opcodes.IADD)
+            ),
+            Matchers.equalTo(
+                "(this.a) + (this.b)"
+            )
+        );
+    }
 }

--- a/src/test/resources/packs/simple_objects.yaml
+++ b/src/test/resources/packs/simple_objects.yaml
@@ -118,11 +118,7 @@ eo:
         seq > @
           tuple
             $
-            opcode > GETFIELD
-              180
-              "com/example/A"
-              "x"
-              "I"
+            .x
             2
             opcode > IMUL
               104
@@ -175,11 +171,7 @@ eo:
         seq > @
           tuple
             $
-            opcode > GETFIELD
-              180
-              "com/example/B"
-              "a"
-              "Lcom/example/A;"
+            .a
             .foo
             .plus
               1


### PR DESCRIPTION
In this PR I added implementation of field access to the decompiler. 

So, now your decompiler can unserstand the following constructs:
```java
this.x.someMethod();
this.a + this.b;
this.x.y.z;
```

Related to: #25.
____
History:
- feat(#25): add test for InstanceField
- feat(#25): implement the field convertation
- feat(#25): fix the problem with GETFIELD handler implementation
- feat(#25): add the example that shows the problem
- feat(#25): change the logic of InstanceField
- feat(#25): repair integration tests
- feat(#25): fix all the linters suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new `InstanceField` class in the `ast` package to represent field access in EO code.
- Modified the `DecompilerMachine` class in the `vmachine` package to handle the `GETFIELD` opcode and generate `InstanceField` objects.
- Added test cases for `InstanceField` and `DecompilerMachine` to ensure correct functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->