### PR TITLE
feat(#65): Decompilation of simple constructs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>jeo-maven-plugin</artifactId>
-      <version>0.2.15</version>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>jeo-maven-plugin</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>0.2.16</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/src/it/decompile-compile/target/generated-sources/xmir/org/eolang/jeo/Bar.xmir
+++ b/src/it/decompile-compile/target/generated-sources/xmir/org/eolang/jeo/Bar.xmir
@@ -59,7 +59,6 @@
                   </o>
                </o>
             </o>
-            <o base="tuple" name="trycatchblocks"/>
          </o>
          <o abstract="" name="j$foo">
             <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 01</o>
@@ -105,7 +104,6 @@
                   </o>
                </o>
             </o>
-            <o base="tuple" name="trycatchblocks"/>
          </o>
       </o>
    </objects>

--- a/src/main/java/org/eolang/opeo/ast/Add.java
+++ b/src/main/java/org/eolang/opeo/ast/Add.java
@@ -23,6 +23,10 @@
  */
 package org.eolang.opeo.ast;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -64,5 +68,14 @@ public final class Add implements AstNode {
             .append(this.left.toXmir())
             .append(this.right.toXmir())
             .up();
+    }
+
+    @Override
+    public List<Opcode> opcodes() {
+        final List<Opcode> res = new ArrayList<>(0);
+        res.addAll(this.left.opcodes());
+        res.addAll(this.right.opcodes());
+        res.add(new Opcode(Opcodes.IADD));
+        return res;
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Add.java
+++ b/src/main/java/org/eolang/opeo/ast/Add.java
@@ -25,7 +25,6 @@ package org.eolang.opeo.ast;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
 import org.xembly.Directives;

--- a/src/main/java/org/eolang/opeo/ast/Add.java
+++ b/src/main/java/org/eolang/opeo/ast/Add.java
@@ -71,8 +71,8 @@ public final class Add implements AstNode {
     }
 
     @Override
-    public List<Opcode> opcodes() {
-        final List<Opcode> res = new ArrayList<>(0);
+    public List<AstNode> opcodes() {
+        final List<AstNode> res = new ArrayList<>(0);
         res.addAll(this.left.opcodes());
         res.addAll(this.right.opcodes());
         res.add(new Opcode(Opcodes.IADD));

--- a/src/main/java/org/eolang/opeo/ast/AstNode.java
+++ b/src/main/java/org/eolang/opeo/ast/AstNode.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.opeo.ast;
 
+import java.util.List;
 import org.xembly.Directive;
 
 /**
@@ -42,4 +43,10 @@ public interface AstNode {
      * @return XMIR XML.
      */
     Iterable<Directive> toXmir();
+
+    /**
+     * Bytecode instructions.
+     * @return List of opcodes.
+     */
+    List<Opcode> opcodes();
 }

--- a/src/main/java/org/eolang/opeo/ast/AstNode.java
+++ b/src/main/java/org/eolang/opeo/ast/AstNode.java
@@ -48,5 +48,5 @@ public interface AstNode {
      * Bytecode instructions.
      * @return List of opcodes.
      */
-    List<Opcode> opcodes();
+    List<AstNode> opcodes();
 }

--- a/src/main/java/org/eolang/opeo/ast/Constructor.java
+++ b/src/main/java/org/eolang/opeo/ast/Constructor.java
@@ -86,6 +86,11 @@ public final class Constructor implements AstNode {
         return directives.up();
     }
 
+    @Override
+    public List<Opcode> opcodes() {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
     /**
      * Print arguments.
      * @return Arguments string.

--- a/src/main/java/org/eolang/opeo/ast/Constructor.java
+++ b/src/main/java/org/eolang/opeo/ast/Constructor.java
@@ -87,7 +87,7 @@ public final class Constructor implements AstNode {
     }
 
     @Override
-    public List<Opcode> opcodes() {
+    public List<AstNode> opcodes() {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 

--- a/src/main/java/org/eolang/opeo/ast/InstanceField.java
+++ b/src/main/java/org/eolang/opeo/ast/InstanceField.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.opeo.ast;
 
+import java.util.List;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -64,5 +65,10 @@ public final class InstanceField implements AstNode {
             .attr("base", String.format(".%s", this.name))
             .append(this.source.toXmir())
             .up();
+    }
+
+    @Override
+    public List<Opcode> opcodes() {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/InstanceField.java
+++ b/src/main/java/org/eolang/opeo/ast/InstanceField.java
@@ -68,7 +68,7 @@ public final class InstanceField implements AstNode {
     }
 
     @Override
-    public List<Opcode> opcodes() {
+    public List<AstNode> opcodes() {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Invocation.java
+++ b/src/main/java/org/eolang/opeo/ast/Invocation.java
@@ -112,7 +112,7 @@ public final class Invocation implements AstNode {
     }
 
     @Override
-    public List<Opcode> opcodes() {
+    public List<AstNode> opcodes() {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 

--- a/src/main/java/org/eolang/opeo/ast/Invocation.java
+++ b/src/main/java/org/eolang/opeo/ast/Invocation.java
@@ -111,6 +111,11 @@ public final class Invocation implements AstNode {
         return directives.up();
     }
 
+    @Override
+    public List<Opcode> opcodes() {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
     /**
      * Print arguments.
      * @return Arguments

--- a/src/main/java/org/eolang/opeo/ast/Label.java
+++ b/src/main/java/org/eolang/opeo/ast/Label.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.opeo.ast;
 
 import java.util.Collections;
@@ -5,10 +28,21 @@ import java.util.List;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
+/**
+ * Label ast node.
+ * @since 0.1
+ */
 public final class Label implements AstNode {
 
+    /**
+     * Label identifier.
+     */
     private final AstNode identifier;
 
+    /**
+     * Constructor.
+     * @param identifier Label identifier.
+     */
     public Label(final AstNode identifier) {
         this.identifier = identifier;
     }

--- a/src/main/java/org/eolang/opeo/ast/Label.java
+++ b/src/main/java/org/eolang/opeo/ast/Label.java
@@ -1,0 +1,34 @@
+package org.eolang.opeo.ast;
+
+import java.util.Collections;
+import java.util.List;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+public final class Label implements AstNode {
+
+    private final AstNode identifier;
+
+    public Label(final AstNode identifier) {
+        this.identifier = identifier;
+    }
+
+    @Override
+    public String print() {
+        return String.format(": %s", this.identifier.print());
+    }
+
+    @Override
+    public Iterable<Directive> toXmir() {
+        return new Directives()
+            .add("o")
+            .attr("base", "label")
+            .append(this.identifier.toXmir())
+            .up();
+    }
+
+    @Override
+    public List<AstNode> opcodes() {
+        return Collections.singletonList(this);
+    }
+}

--- a/src/main/java/org/eolang/opeo/ast/Literal.java
+++ b/src/main/java/org/eolang/opeo/ast/Literal.java
@@ -23,8 +23,10 @@
  */
 package org.eolang.opeo.ast;
 
+import java.util.Collections;
 import java.util.List;
 import org.eolang.jeo.representation.directives.DirectivesData;
+import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
 
 /**
@@ -53,7 +55,13 @@ public final class Literal implements AstNode {
 
     @Override
     public List<Opcode> opcodes() {
-        throw new UnsupportedOperationException("Not implemented yet");
+        if (this.object instanceof Integer) {
+            return Collections.singletonList(
+                Literal.opcode((Integer) this.object)
+            );
+        } else {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
     }
 
     @Override
@@ -65,5 +73,38 @@ public final class Literal implements AstNode {
             result = this.object.toString();
         }
         return result;
+    }
+
+    /**
+     * Convert integer into an opcode.
+     * @param value Integer value.
+     * @return Opcode.
+     */
+    private static Opcode opcode(final int value) {
+        final Opcode res;
+        switch (value) {
+            case 0:
+                res = new Opcode(Opcodes.ICONST_0);
+                break;
+            case 1:
+                res = new Opcode(Opcodes.ICONST_1);
+                break;
+            case 2:
+                res = new Opcode(Opcodes.ICONST_2);
+                break;
+            case 3:
+                res = new Opcode(Opcodes.ICONST_3);
+                break;
+            case 4:
+                res = new Opcode(Opcodes.ICONST_4);
+                break;
+            case 5:
+                res = new Opcode(Opcodes.ICONST_5);
+                break;
+            default:
+                res = new Opcode(Opcodes.BIPUSH, value);
+                break;
+        }
+        return res;
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Literal.java
+++ b/src/main/java/org/eolang/opeo/ast/Literal.java
@@ -55,13 +55,15 @@ public final class Literal implements AstNode {
 
     @Override
     public List<AstNode> opcodes() {
+        final List<AstNode> result;
         if (this.object instanceof Integer) {
-            return Collections.singletonList(Literal.opcode((Integer) this.object));
+            result = Collections.singletonList(Literal.opcode((Integer) this.object));
         } else if (this.object instanceof String) {
-            return Collections.singletonList(Literal.opcode((String) this.object));
+            result = Collections.singletonList(Literal.opcode((String) this.object));
         } else {
             throw new UnsupportedOperationException("Not implemented yet");
         }
+        return result;
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/ast/Literal.java
+++ b/src/main/java/org/eolang/opeo/ast/Literal.java
@@ -54,11 +54,11 @@ public final class Literal implements AstNode {
     }
 
     @Override
-    public List<Opcode> opcodes() {
+    public List<AstNode> opcodes() {
         if (this.object instanceof Integer) {
-            return Collections.singletonList(
-                Literal.opcode((Integer) this.object)
-            );
+            return Collections.singletonList(Literal.opcode((Integer) this.object));
+        } else if (this.object instanceof String) {
+            return Collections.singletonList(Literal.opcode((String) this.object));
         } else {
             throw new UnsupportedOperationException("Not implemented yet");
         }
@@ -73,6 +73,15 @@ public final class Literal implements AstNode {
             result = this.object.toString();
         }
         return result;
+    }
+
+    /**
+     * Convert string into an opcode.
+     * @param value String value.
+     * @return Opcode.
+     */
+    private static Opcode opcode(final String value) {
+        return new Opcode(Opcodes.LDC, value);
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/Literal.java
+++ b/src/main/java/org/eolang/opeo/ast/Literal.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.opeo.ast;
 
+import java.util.List;
 import org.eolang.jeo.representation.directives.DirectivesData;
 import org.xembly.Directive;
 
@@ -48,6 +49,11 @@ public final class Literal implements AstNode {
     @Override
     public Iterable<Directive> toXmir() {
         return new DirectivesData(this.object);
+    }
+
+    @Override
+    public List<Opcode> opcodes() {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/ast/Mul.java
+++ b/src/main/java/org/eolang/opeo/ast/Mul.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.opeo.ast;
 
+import java.util.List;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -64,5 +65,10 @@ public final class Mul implements AstNode {
             .append(this.left.toXmir())
             .append(this.right.toXmir())
             .up();
+    }
+
+    @Override
+    public List<Opcode> opcodes() {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Mul.java
+++ b/src/main/java/org/eolang/opeo/ast/Mul.java
@@ -68,7 +68,7 @@ public final class Mul implements AstNode {
     }
 
     @Override
-    public List<Opcode> opcodes() {
+    public List<AstNode> opcodes() {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Opcode.java
+++ b/src/main/java/org/eolang/opeo/ast/Opcode.java
@@ -106,4 +106,9 @@ public final class Opcode implements AstNode {
     public Iterable<Directive> toXmir() {
         return new DirectivesInstruction(this.bytecode, this.counting, this.operands.toArray());
     }
+
+    @Override
+    public List<Opcode> opcodes() {
+        return List.of(this);
+    }
 }

--- a/src/main/java/org/eolang/opeo/ast/Opcode.java
+++ b/src/main/java/org/eolang/opeo/ast/Opcode.java
@@ -121,7 +121,12 @@ public final class Opcode implements AstNode {
     /**
      * Disable opcodes counting.
      * It is useful for tests.
+     * @todo #65:30min Remove public static method 'disableCounting()' from Opcode.
+     *  Currently it is used in tests. We should find another
+     *  way to disable opcodes counting in tests. When we find
+     *  the way to do it, we should remove this method.
      */
+    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
     public static void disableCounting() {
         Opcode.COUNTING.set(false);
     }

--- a/src/main/java/org/eolang/opeo/ast/Opcode.java
+++ b/src/main/java/org/eolang/opeo/ast/Opcode.java
@@ -26,9 +26,12 @@ package org.eolang.opeo.ast;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.eolang.jeo.representation.directives.DirectivesInstruction;
+import org.eolang.jeo.representation.directives.DirectivesOperand;
 import org.eolang.parser.XMIR;
 import org.xembly.Directive;
+import org.xembly.Directives;
 import org.xembly.Transformers;
 import org.xembly.Xembler;
 
@@ -37,6 +40,11 @@ import org.xembly.Xembler;
  * @since 0.1
  */
 public final class Opcode implements AstNode {
+
+    /**
+     * Opcodes counting.
+     */
+    private static final AtomicBoolean COUNTING = new AtomicBoolean(true);
 
     /**
      * Opcode.
@@ -82,7 +90,7 @@ public final class Opcode implements AstNode {
      * @param operands Opcode operands
      */
     public Opcode(final int opcode, final List<Object> operands) {
-        this(opcode, operands, true);
+        this(opcode, operands, Opcode.COUNTING.get());
     }
 
     /**
@@ -108,7 +116,15 @@ public final class Opcode implements AstNode {
     }
 
     @Override
-    public List<Opcode> opcodes() {
+    public List<AstNode> opcodes() {
         return List.of(this);
+    }
+
+    /**
+     * Disable opcodes counting.
+     * It is useful for tests.
+     */
+    public static void disableCounting() {
+        Opcode.COUNTING.set(false);
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Opcode.java
+++ b/src/main/java/org/eolang/opeo/ast/Opcode.java
@@ -28,10 +28,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.eolang.jeo.representation.directives.DirectivesInstruction;
-import org.eolang.jeo.representation.directives.DirectivesOperand;
 import org.eolang.parser.XMIR;
 import org.xembly.Directive;
-import org.xembly.Directives;
 import org.xembly.Transformers;
 import org.xembly.Xembler;
 

--- a/src/main/java/org/eolang/opeo/ast/OpcodeName.java
+++ b/src/main/java/org/eolang/opeo/ast/OpcodeName.java
@@ -1,0 +1,119 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Opcode name.
+ * The name of bytecode instruction. The name combined with unique number in order to
+ * avoid name collisions.
+ * @since 0.1.0
+ * @todo #65:30min Code duplication with jeo-maven-plugin.
+ *  This class is a copy of org.eolang.jeo.representation.directives.OpcodeName.
+ *  It should be moved to jeo-maven-plugin and used from there.
+ */
+public final class OpcodeName {
+
+    /**
+     * Opcode names.
+     */
+    private static final Map<Integer, String> NAMES = OpcodeName.init();
+
+    /**
+     * Default counter.
+     */
+    private static final AtomicInteger DEFAULT = new AtomicInteger(0);
+
+    /**
+     * Bytecode operation code.
+     */
+    private final int opcode;
+
+    /**
+     * Opcode counter.
+     */
+    private final AtomicInteger counter;
+
+    /**
+     * Constructor.
+     * @param opcode Bytecode operation code.
+     */
+    public OpcodeName(final int opcode) {
+        this(opcode, OpcodeName.DEFAULT);
+    }
+
+    /**
+     * Constructor.
+     * @param opcode Bytecode operation code.
+     * @param counter Opcode counter.
+     */
+    OpcodeName(final int opcode, final AtomicInteger counter) {
+        this.opcode = opcode;
+        this.counter = counter;
+    }
+
+    /**
+     * Get simplified opcode name without counter.
+     * @return Simplified opcode name.
+     */
+    public String simplified() {
+        return OpcodeName.NAMES.getOrDefault(this.opcode, "UNKNOWN");
+    }
+
+    /**
+     * Get string representation of a bytecode.
+     * @return String representation of a bytecode.
+     */
+    String asString() {
+        final String opc = OpcodeName.NAMES.getOrDefault(this.opcode, "UNKNOWN");
+        return String.format("%s-%X", opc, this.counter.incrementAndGet());
+    }
+
+    /**
+     * Initialize opcode names.
+     * @return Opcode names.
+     */
+    private static Map<Integer, String> init() {
+        try {
+            final Map<Integer, String> res = new HashMap<>();
+            for (final Field field : Opcodes.class.getFields()) {
+                if (field.getType() == int.class) {
+                    res.put(field.getInt(Opcodes.class), field.getName());
+                }
+            }
+            return res;
+        } catch (final IllegalAccessException exception) {
+            throw new IllegalStateException(
+                String.format("Can't retrieve opcode names from '%s'", Opcodes.class),
+                exception
+            );
+        }
+    }
+}
+

--- a/src/main/java/org/eolang/opeo/ast/Reference.java
+++ b/src/main/java/org/eolang/opeo/ast/Reference.java
@@ -73,7 +73,7 @@ public final class Reference implements AstNode {
     }
 
     @Override
-    public List<Opcode> opcodes() {
+    public List<AstNode> opcodes() {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Reference.java
+++ b/src/main/java/org/eolang/opeo/ast/Reference.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.opeo.ast;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.xembly.Directive;
 
@@ -69,5 +70,10 @@ public final class Reference implements AstNode {
     @Override
     public Iterable<Directive> toXmir() {
         return this.ref.get().toXmir();
+    }
+
+    @Override
+    public List<Opcode> opcodes() {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Root.java
+++ b/src/main/java/org/eolang/opeo/ast/Root.java
@@ -26,6 +26,7 @@ package org.eolang.opeo.ast;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 import org.xembly.Directive;
 import org.xembly.Directives;
@@ -74,6 +75,11 @@ public final class Root implements AstNode {
             result = directives;
         }
         return result;
+    }
+
+    @Override
+    public List<Opcode> opcodes() {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/Root.java
+++ b/src/main/java/org/eolang/opeo/ast/Root.java
@@ -78,7 +78,7 @@ public final class Root implements AstNode {
     }
 
     @Override
-    public List<Opcode> opcodes() {
+    public List<AstNode> opcodes() {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 

--- a/src/main/java/org/eolang/opeo/ast/StoreLocal.java
+++ b/src/main/java/org/eolang/opeo/ast/StoreLocal.java
@@ -72,7 +72,7 @@ public final class StoreLocal implements AstNode {
     }
 
     @Override
-    public List<Opcode> opcodes() {
+    public List<AstNode> opcodes() {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/StoreLocal.java
+++ b/src/main/java/org/eolang/opeo/ast/StoreLocal.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.opeo.ast;
 
+import java.util.List;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -68,5 +69,10 @@ public final class StoreLocal implements AstNode {
             .append(this.variable.toXmir())
             .append(this.value.toXmir())
             .up();
+    }
+
+    @Override
+    public List<Opcode> opcodes() {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Super.java
+++ b/src/main/java/org/eolang/opeo/ast/Super.java
@@ -84,7 +84,7 @@ public final class Super implements AstNode {
     }
 
     @Override
-    public List<Opcode> opcodes() {
+    public List<AstNode> opcodes() {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 

--- a/src/main/java/org/eolang/opeo/ast/Super.java
+++ b/src/main/java/org/eolang/opeo/ast/Super.java
@@ -83,6 +83,11 @@ public final class Super implements AstNode {
         return directives.up();
     }
 
+    @Override
+    public List<Opcode> opcodes() {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
     /**
      * Print arguments.
      * @return Arguments.

--- a/src/main/java/org/eolang/opeo/ast/Super.java
+++ b/src/main/java/org/eolang/opeo/ast/Super.java
@@ -23,9 +23,11 @@
  */
 package org.eolang.opeo.ast;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -85,7 +87,16 @@ public final class Super implements AstNode {
 
     @Override
     public List<AstNode> opcodes() {
-        throw new UnsupportedOperationException("Not implemented yet");
+        final List<AstNode> res = new ArrayList<>(1);
+        res.addAll(this.instance.opcodes());
+        this.arguments.stream().map(AstNode::opcodes).forEach(res::addAll);
+        //@checkstyle MethodBodyCommentsCheck (10 lines)
+        // @todo #65:90min Pass correct arguments to invokespecial instruction.
+        //  Currently we just pass default arguments to invokespecial instruction.
+        //  We need to pass correct arguments to invokespecial instruction.
+        //  But in order to implement this we need to save this arguments somewhere before.
+        res.add(new Opcode(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V"));
+        return res;
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/This.java
+++ b/src/main/java/org/eolang/opeo/ast/This.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.opeo.ast;
 
+import java.util.List;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -42,6 +43,11 @@ public final class This implements AstNode {
     @Override
     public Iterable<Directive> toXmir() {
         return new Directives().add("o").attr("base", "$").up();
+    }
+
+    @Override
+    public List<Opcode> opcodes() {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
 }

--- a/src/main/java/org/eolang/opeo/ast/This.java
+++ b/src/main/java/org/eolang/opeo/ast/This.java
@@ -23,7 +23,9 @@
  */
 package org.eolang.opeo.ast;
 
+import java.util.Collections;
 import java.util.List;
+import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -47,7 +49,7 @@ public final class This implements AstNode {
 
     @Override
     public List<AstNode> opcodes() {
-        throw new UnsupportedOperationException("Not implemented yet");
+        return Collections.singletonList(new Opcode(Opcodes.ALOAD, 0));
     }
 
 }

--- a/src/main/java/org/eolang/opeo/ast/This.java
+++ b/src/main/java/org/eolang/opeo/ast/This.java
@@ -46,7 +46,7 @@ public final class This implements AstNode {
     }
 
     @Override
-    public List<Opcode> opcodes() {
+    public List<AstNode> opcodes() {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 

--- a/src/main/java/org/eolang/opeo/ast/Variable.java
+++ b/src/main/java/org/eolang/opeo/ast/Variable.java
@@ -80,7 +80,7 @@ public final class Variable implements AstNode {
     }
 
     @Override
-    public List<Opcode> opcodes() {
+    public List<AstNode> opcodes() {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Variable.java
+++ b/src/main/java/org/eolang/opeo/ast/Variable.java
@@ -25,6 +25,7 @@ package org.eolang.opeo.ast;
 
 import java.util.List;
 import lombok.ToString;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.xembly.Directive;
 import org.xembly.Directives;
@@ -81,6 +82,9 @@ public final class Variable implements AstNode {
 
     @Override
     public List<AstNode> opcodes() {
+        if (this.type.equals(Type.INT_TYPE)) {
+            return List.of(new Opcode(Opcodes.ILOAD, this.identifier));
+        }
         throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Variable.java
+++ b/src/main/java/org/eolang/opeo/ast/Variable.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.opeo.ast;
 
+import java.util.List;
 import lombok.ToString;
 import org.objectweb.asm.Type;
 import org.xembly.Directive;
@@ -76,5 +77,10 @@ public final class Variable implements AstNode {
             .add("o")
             .attr("base", String.format("local%d", this.identifier))
             .up();
+    }
+
+    @Override
+    public List<Opcode> opcodes() {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/WriteField.java
+++ b/src/main/java/org/eolang/opeo/ast/WriteField.java
@@ -68,7 +68,7 @@ public final class WriteField implements AstNode {
     }
 
     @Override
-    public List<Opcode> opcodes() {
+    public List<AstNode> opcodes() {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/WriteField.java
+++ b/src/main/java/org/eolang/opeo/ast/WriteField.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.opeo.ast;
 
+import java.util.List;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -64,5 +65,10 @@ public final class WriteField implements AstNode {
             .append(this.target.toXmir())
             .append(this.value.toXmir())
             .up();
+    }
+
+    @Override
+    public List<Opcode> opcodes() {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
+++ b/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
@@ -89,13 +89,6 @@ public final class OpeoNodes {
      * @return List of opcodes
      */
     private static List<XmlNode> opcodes(final XmlNode node) {
-        final List<XmlNode> result;
-        //@checkstyle MethodBodyCommentsCheck (10 lines)
-        // @todo #37:90min Parse AST from high-level XMIR.
-        //  Currently we apply naive algorithm to convert some parts of high-level representation
-        //  to bytecode instructions.
-        //  We should generate AST first and then compile it to bytecode instructions.
-        //  Don't forget to add unit tests.
         return OpeoNodes.node(node).opcodes()
             .stream()
             .map(Opcode::toXmir)
@@ -105,6 +98,16 @@ public final class OpeoNodes {
             .collect(Collectors.toList());
     }
 
+    /**
+     * Convert XmlNode to AstNode.
+     * @param node XmlNode
+     * @return Ast node
+     * @todo #65:90min Add more nodes to the parser.
+     *  Currently we only support addition and integer literals.
+     *  We need to add support for multiplication and many other nodes.
+     *  You can check all the required nodes in the {@link org.eolang.opeo.ast} package.
+     *  To check all correct transformation you can modify 'benchmark' integration test.
+     */
     private static AstNode node(final XmlNode node) {
         if (node.hasAttribute("base", ".plus")) {
             final List<XmlNode> inner = node.children().collect(Collectors.toList());

--- a/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
+++ b/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
@@ -36,6 +36,8 @@ import org.eolang.opeo.ast.Literal;
 import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.ast.Super;
 import org.eolang.opeo.ast.This;
+import org.eolang.opeo.ast.Variable;
+import org.objectweb.asm.Type;
 import org.xembly.Xembler;
 
 /**
@@ -141,6 +143,12 @@ public final class OpeoNodes {
             result = new Super(instance, arguments);
         } else if (node.hasAttribute("base", "$")) {
             result = new This();
+        } else if (node.hasAttribute("base", "local0")) {
+            //@checkstyle MethodBodyCommentsCheck (10 lines)
+            // @todo #65:90min Handle local variables.
+            //  Currently we just treat all the variables as local variable with index 0
+            //  and type int. We need to handle local variables correctly.
+            result = new Variable(Type.INT_TYPE, 0);
         } else {
             throw new IllegalArgumentException(
                 String.format("Can't recognize node: %n%s%n", node)

--- a/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
+++ b/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
@@ -32,6 +32,7 @@ import org.eolang.jeo.representation.xmir.XmlInstruction;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.ast.Add;
 import org.eolang.opeo.ast.AstNode;
+import org.eolang.opeo.ast.Label;
 import org.eolang.opeo.ast.Literal;
 import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.jeo.JeoInstruction;
@@ -91,7 +92,7 @@ public final class OpeoNodes {
     private static List<XmlNode> opcodes(final XmlNode node) {
         return OpeoNodes.node(node).opcodes()
             .stream()
-            .map(Opcode::toXmir)
+            .map(AstNode::toXmir)
             .map(Xembler::new)
             .map(Xembler::xmlQuietly)
             .map(XmlNode::new)
@@ -117,8 +118,13 @@ public final class OpeoNodes {
         } else if (node.hasAttribute("base", "opcode")) {
             final XmlInstruction instruction = new XmlInstruction(node.node());
             return new Opcode(instruction.opcode(), instruction.operands());
+        } else if (node.hasAttribute("base", "label")) {
+            final List<XmlNode> inner = node.children().collect(Collectors.toList());
+            return new Label(OpeoNodes.node(inner.get(0)));
         } else if (node.hasAttribute("base", "int")) {
             return new Literal(new HexString(node.text()).decodeAsInt());
+        } else if (node.hasAttribute("base", "string")) {
+            return new Literal(new HexString(node.text()).decode());
         } else {
             throw new IllegalArgumentException(
                 String.format("Can't recognize node: %n%s%n", node)

--- a/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
+++ b/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
@@ -24,6 +24,7 @@
 package org.eolang.opeo.compilation;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.eolang.jeo.representation.xmir.XmlInstruction;
@@ -33,6 +34,8 @@ import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.Label;
 import org.eolang.opeo.ast.Literal;
 import org.eolang.opeo.ast.Opcode;
+import org.eolang.opeo.ast.Super;
+import org.eolang.opeo.ast.This;
 import org.xembly.Xembler;
 
 /**
@@ -123,6 +126,21 @@ public final class OpeoNodes {
             result = new Literal(new HexString(node.text()).decodeAsInt());
         } else if (node.hasAttribute("base", "string")) {
             result = new Literal(new HexString(node.text()).decode());
+        } else if (node.hasAttribute("base", ".super")) {
+            final List<XmlNode> inner = node.children().collect(Collectors.toList());
+            final AstNode instance = OpeoNodes.node(inner.get(0));
+            final List<AstNode> arguments;
+            if (inner.size() > 1) {
+                arguments = inner.subList(1, inner.size())
+                    .stream()
+                    .map(OpeoNodes::node)
+                    .collect(Collectors.toList());
+            } else {
+                arguments = Collections.emptyList();
+            }
+            result = new Super(instance, arguments);
+        } else if (node.hasAttribute("base", "$")) {
+            result = new This();
         } else {
             throw new IllegalArgumentException(
                 String.format("Can't recognize node: %n%s%n", node)

--- a/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
+++ b/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
@@ -24,10 +24,8 @@
 package org.eolang.opeo.compilation;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.eolang.jeo.representation.xmir.XmlInstruction;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.ast.Add;
@@ -35,14 +33,13 @@ import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.Label;
 import org.eolang.opeo.ast.Literal;
 import org.eolang.opeo.ast.Opcode;
-import org.eolang.opeo.jeo.JeoInstruction;
-import org.objectweb.asm.Opcodes;
 import org.xembly.Xembler;
 
 /**
  * High-level representation of Opeo nodes.
  * @since 0.1
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class OpeoNodes {
 
     /**
@@ -110,25 +107,27 @@ public final class OpeoNodes {
      *  To check all correct transformation you can modify 'benchmark' integration test.
      */
     private static AstNode node(final XmlNode node) {
+        final AstNode result;
         if (node.hasAttribute("base", ".plus")) {
             final List<XmlNode> inner = node.children().collect(Collectors.toList());
             final AstNode left = OpeoNodes.node(inner.get(0));
             final AstNode right = OpeoNodes.node(inner.get(1));
-            return new Add(left, right);
+            result = new Add(left, right);
         } else if (node.hasAttribute("base", "opcode")) {
             final XmlInstruction instruction = new XmlInstruction(node.node());
-            return new Opcode(instruction.opcode(), instruction.operands());
+            result = new Opcode(instruction.opcode(), instruction.operands());
         } else if (node.hasAttribute("base", "label")) {
             final List<XmlNode> inner = node.children().collect(Collectors.toList());
-            return new Label(OpeoNodes.node(inner.get(0)));
+            result = new Label(OpeoNodes.node(inner.get(0)));
         } else if (node.hasAttribute("base", "int")) {
-            return new Literal(new HexString(node.text()).decodeAsInt());
+            result = new Literal(new HexString(node.text()).decodeAsInt());
         } else if (node.hasAttribute("base", "string")) {
-            return new Literal(new HexString(node.text()).decode());
+            result = new Literal(new HexString(node.text()).decode());
         } else {
             throw new IllegalArgumentException(
                 String.format("Can't recognize node: %n%s%n", node)
             );
         }
+        return result;
     }
 }

--- a/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
+++ b/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
@@ -110,6 +110,10 @@ public final class OpeoNodes {
         return result;
     }
 
+
+
+
+
     /**
      * Convert integer into an opcode.
      * @param value Integer value.

--- a/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
+++ b/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
@@ -28,9 +28,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.eolang.jeo.representation.xmir.XmlInstruction;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.ast.Add;
 import org.eolang.opeo.ast.AstNode;
+import org.eolang.opeo.ast.Literal;
 import org.eolang.opeo.ast.Opcode;
+import org.eolang.opeo.jeo.JeoInstruction;
 import org.objectweb.asm.Opcodes;
 import org.xembly.Xembler;
 
@@ -92,58 +96,30 @@ public final class OpeoNodes {
         //  to bytecode instructions.
         //  We should generate AST first and then compile it to bytecode instructions.
         //  Don't forget to add unit tests.
-        if (node.hasAttribute("base", ".plus")) {
-            final List<XmlNode> inner = node.children().collect(Collectors.toList());
-            result = Stream.of(
-                OpeoNodes.opcode(new HexString(inner.get(0).text()).decodeAsInt()),
-                OpeoNodes.opcode(new HexString(inner.get(1).text()).decodeAsInt()),
-                new Opcode(Opcodes.IADD)
-                )
-                .map(Opcode::toXmir)
-                .map(Xembler::new)
-                .map(Xembler::xmlQuietly)
-                .map(XmlNode::new)
-                .collect(Collectors.toList());
-        } else {
-            result = Collections.singletonList(node);
-        }
-        return result;
+        return OpeoNodes.node(node).opcodes()
+            .stream()
+            .map(Opcode::toXmir)
+            .map(Xembler::new)
+            .map(Xembler::xmlQuietly)
+            .map(XmlNode::new)
+            .collect(Collectors.toList());
     }
 
-
-
-
-
-    /**
-     * Convert integer into an opcode.
-     * @param value Integer value.
-     * @return Opcode.
-     */
-    private static Opcode opcode(final int value) {
-        final Opcode res;
-        switch (value) {
-            case 0:
-                res = new Opcode(Opcodes.ICONST_0);
-                break;
-            case 1:
-                res = new Opcode(Opcodes.ICONST_1);
-                break;
-            case 2:
-                res = new Opcode(Opcodes.ICONST_2);
-                break;
-            case 3:
-                res = new Opcode(Opcodes.ICONST_3);
-                break;
-            case 4:
-                res = new Opcode(Opcodes.ICONST_4);
-                break;
-            case 5:
-                res = new Opcode(Opcodes.ICONST_5);
-                break;
-            default:
-                res = new Opcode(Opcodes.BIPUSH, value);
-                break;
+    private static AstNode node(final XmlNode node) {
+        if (node.hasAttribute("base", ".plus")) {
+            final List<XmlNode> inner = node.children().collect(Collectors.toList());
+            final AstNode left = OpeoNodes.node(inner.get(0));
+            final AstNode right = OpeoNodes.node(inner.get(1));
+            return new Add(left, right);
+        } else if (node.hasAttribute("base", "opcode")) {
+            final XmlInstruction instruction = new XmlInstruction(node.node());
+            return new Opcode(instruction.opcode(), instruction.operands());
+        } else if (node.hasAttribute("base", "int")) {
+            return new Literal(new HexString(node.text()).decodeAsInt());
+        } else {
+            throw new IllegalArgumentException(
+                String.format("Can't recognize node: %n%s%n", node)
+            );
         }
-        return res;
     }
 }

--- a/src/main/java/org/eolang/opeo/compilation/OpeoTree.java
+++ b/src/main/java/org/eolang/opeo/compilation/OpeoTree.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.opeo.compilation.ast;
+package org.eolang.opeo.compilation;
 
 /**
  * AST tree of the free EO program.

--- a/src/main/java/org/eolang/opeo/compilation/ast/OpeoTree.java
+++ b/src/main/java/org/eolang/opeo/compilation/ast/OpeoTree.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.compilation.ast;
+
+/**
+ * AST tree of the free EO program.
+ * @since 0.1
+ */
+public final class OpeoTree {
+}

--- a/src/test/java/org/eolang/opeo/compilation/CompilerTest.java
+++ b/src/test/java/org/eolang/opeo/compilation/CompilerTest.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.io.ResourceOf;
+import org.eolang.opeo.ast.Opcode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.io.FileMatchers;
@@ -61,6 +62,7 @@ final class CompilerTest {
 
     @Test
     void compilesSingleHighLevelXmir(@TempDir final Path temp) throws Exception {
+        Opcode.disableCounting();
         final Path input = temp.resolve("opeo-xmir").resolve("Bar.xmir");
         Files.createDirectories(input.getParent());
         final byte[] before = new BytesOf(new ResourceOf("xmir/Bar.xmir")).asBytes();

--- a/src/test/java/org/eolang/opeo/compilation/JeoCompilerTest.java
+++ b/src/test/java/org/eolang/opeo/compilation/JeoCompilerTest.java
@@ -27,8 +27,10 @@ import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.text.TextOf;
+import org.eolang.opeo.ast.Opcode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,9 +41,11 @@ final class JeoCompilerTest {
 
     @Test
     void compilesSuccessfully() throws Exception {
+        Opcode.disableCounting();
         final XML expected = new XMLDocument(
             new TextOf(new ResourceOf("xmir/Bar.xmir")).asString()
         );
+        assertEquals(expected, new JeoCompiler(expected).compile());
         MatcherAssert.assertThat(
             "The compiled program is not equal to the expected one, but should since we provided already compiled program",
             new JeoCompiler(expected).compile(),

--- a/src/test/java/org/eolang/opeo/compilation/JeoCompilerTest.java
+++ b/src/test/java/org/eolang/opeo/compilation/JeoCompilerTest.java
@@ -30,7 +30,6 @@ import org.cactoos.text.TextOf;
 import org.eolang.opeo.ast.Opcode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -45,7 +44,6 @@ final class JeoCompilerTest {
         final XML expected = new XMLDocument(
             new TextOf(new ResourceOf("xmir/Bar.xmir")).asString()
         );
-        assertEquals(expected, new JeoCompiler(expected).compile());
         MatcherAssert.assertThat(
             "The compiled program is not equal to the expected one, but should since we provided already compiled program",
             new JeoCompiler(expected).compile(),

--- a/src/test/java/org/eolang/opeo/compilation/OpeoNodesTest.java
+++ b/src/test/java/org/eolang/opeo/compilation/OpeoNodesTest.java
@@ -23,13 +23,21 @@
  */
 package org.eolang.opeo.compilation;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.ast.Add;
 import org.eolang.opeo.ast.Literal;
 import org.eolang.opeo.ast.Opcode;
+import org.hamcrest.Description;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 
@@ -45,17 +53,16 @@ final class OpeoNodesTest {
             new Opcode(Opcodes.ICONST_0, false), new Opcode(Opcodes.POP, false)
         ).toJeoNodes();
         MatcherAssert.assertThat(
-            "We expect the first node to be ICONST_0",
-            nodes.get(0).toString(),
-            Matchers.equalTo(
-                "<o base=\"opcode\" name=\"ICONST_0\">\n   <o base=\"int\" data=\"bytes\">00 00 00 00 00 00 00 03</o>\n</o>\n"
-            )
+            "We expect to retrieve 2 opcodes, but got something else instead: %n%s%n",
+            nodes,
+            Matchers.hasSize(2)
         );
         MatcherAssert.assertThat(
-            "We expect the second node to be POP",
-            nodes.get(1).toString(),
-            Matchers.equalTo(
-                "<o base=\"opcode\" name=\"POP\">\n   <o base=\"int\" data=\"bytes\">00 00 00 00 00 00 00 57</o>\n</o>\n"
+            "We expect to have specific opcodes in right order as is",
+            nodes,
+            new HasInstructions(
+                Opcodes.ICONST_0,
+                Opcodes.POP
             )
         );
     }
@@ -74,19 +81,148 @@ final class OpeoNodesTest {
             Matchers.hasSize(3)
         );
         MatcherAssert.assertThat(
-            "We expect the first node to be ICONST_1",
-            nodes.get(0).attribute("name").get(),
-            Matchers.containsString("ICONST_1")
+            "We expect to have specific opcodes in right order",
+            nodes,
+            new HasInstructions(
+                Opcodes.ICONST_1,
+                Opcodes.ICONST_2,
+                Opcodes.IADD
+            )
         );
+    }
+
+    @Test
+    void convertsDeepAddition() {
+        final List<XmlNode> nodes = new OpeoNodes(
+            new Add(
+                new Add(
+                    new Literal(1),
+                    new Literal(2)
+                ),
+                new Add(
+                    new Literal(3),
+                    new Literal(4)
+                )
+            )
+        ).toJeoNodes();
         MatcherAssert.assertThat(
-            "We expect the second node to be ICONST_2",
-            nodes.get(1).attribute("name").get(),
-            Matchers.containsString("ICONST_2")
+            nodes,
+            new HasInstructions()
         );
-        MatcherAssert.assertThat(
-            "We expect the third node to be IADD",
-            nodes.get(2).attribute("name").get(),
-            Matchers.containsString("IADD")
-        );
+    }
+
+    /**
+     * Matcher for {@link List} of {@link XmlNode} to have specific instructions.
+     * @since 0.1
+     */
+    private static class HasInstructions extends TypeSafeMatcher<List<XmlNode>> {
+
+        /**
+         * Expected opcodes.
+         */
+        private final List<Integer> opcodes;
+
+        /**
+         * Bag of collected warnings.
+         */
+        private final List<String> warnings;
+
+        /**
+         * Constructor.
+         * @param opcodes Expected opcodes.
+         */
+        private HasInstructions(int... opcodes) {
+            this(IntStream.of(opcodes).boxed().collect(Collectors.toList()));
+        }
+
+        /**
+         * Constructor.
+         * @param opcodes Expected opcodes.
+         */
+        private HasInstructions(final List<Integer> opcodes) {
+            this.opcodes = opcodes;
+            this.warnings = new ArrayList<>(0);
+        }
+
+        @Override
+        protected boolean matchesSafely(final List<XmlNode> item) {
+            final int size = item.size();
+            for (int index = 0; index < size; ++index) {
+                final XmlNode node = item.get(index);
+                final Optional<String> obase = node.attribute("base");
+                if (obase.isPresent()) {
+                    final String base = obase.get();
+                    if (base.equals("opcode")) {
+                        final Optional<String> oname = node.attribute("name");
+                        if (oname.isPresent()) {
+                            final String expected = HasInstructions.name(this.opcodes.get(index));
+                            if (!oname.get().contains(expected)) {
+                                this.warnings.add(
+                                    String.format(
+                                        "Expected to have opcode with name %s at index %d, but got %s instead",
+                                        expected,
+                                        index,
+                                        oname.get()
+                                    )
+                                );
+                                return false;
+                            }
+                        } else {
+                            this.warnings.add(
+                                String.format(
+                                    "Expected to have opcode name at index %d, but got nothing instead",
+                                    index
+                                )
+                            );
+                            return false;
+                        }
+                    } else {
+                        this.warnings.add(
+                            String.format(
+                                "Expected to have opcode at index %d, but got %s instead",
+                                index,
+                                base
+                            )
+                        );
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        private static String name(final int opcode) {
+            final Field[] fields = Arrays.stream(Opcodes.class.getFields())
+                .filter(field -> !field.getName().startsWith("T_"))
+                .filter(field -> !field.getName().startsWith("H_"))
+                .filter(field -> !field.getName().startsWith("F_"))
+                .filter(field -> !field.getName().startsWith("ACC"))
+                .filter(field -> !field.getName().startsWith("ASM"))
+                .toArray(Field[]::new);
+            for (final Field field : fields) {
+                if (field.getType() == int.class) {
+                    try {
+                        if (opcode == field.getInt(Opcodes.class)) {
+                            return field.getName();
+                        }
+                    } catch (final IllegalAccessException exception) {
+                        throw new RuntimeException(exception);
+                    }
+                }
+            }
+            throw new IllegalStateException(String.format("Unknown opcode: %d", opcode));
+        }
+
+        @Override
+        public void describeTo(final Description description) {
+            description.appendText(
+                String.format(
+                    "Expected to have %d opcodes, but got %d instead. %n%s%n",
+                    this.opcodes.size(),
+                    this.warnings.size(),
+                    String.join("\n", this.warnings)
+                )
+            );
+        }
     }
 }

--- a/src/test/java/org/eolang/opeo/compilation/OpeoNodesTest.java
+++ b/src/test/java/org/eolang/opeo/compilation/OpeoNodesTest.java
@@ -93,23 +93,21 @@ final class OpeoNodesTest {
     }
 
     @Test
-    @Disabled("Not implemented yet")
     void convertsDeepAddition() {
-        final List<XmlNode> nodes = new OpeoNodes(
-            new Add(
-                new Add(
-                    new Literal(1),
-                    new Literal(2)
-                ),
-                new Add(
-                    new Literal(3),
-                    new Literal(4)
-                )
-            )
-        ).toJeoNodes();
         MatcherAssert.assertThat(
             "We expect to retrieve 7 opcodes, but got something else instead",
-            nodes,
+            new OpeoNodes(
+                new Add(
+                    new Add(
+                        new Literal(1),
+                        new Literal(2)
+                    ),
+                    new Add(
+                        new Literal(3),
+                        new Literal(4)
+                    )
+                )
+            ).toJeoNodes(),
             new HasInstructions(
                 Opcodes.ICONST_1,
                 Opcodes.ICONST_2,

--- a/src/test/java/org/eolang/opeo/compilation/OpeoNodesTest.java
+++ b/src/test/java/org/eolang/opeo/compilation/OpeoNodesTest.java
@@ -108,8 +108,17 @@ final class OpeoNodesTest {
             )
         ).toJeoNodes();
         MatcherAssert.assertThat(
+            "We expect to retrieve 7 opcodes, but got something else instead",
             nodes,
-            new HasInstructions()
+            new HasInstructions(
+                Opcodes.ICONST_1,
+                Opcodes.ICONST_2,
+                Opcodes.IADD,
+                Opcodes.ICONST_3,
+                Opcodes.ICONST_4,
+                Opcodes.IADD,
+                Opcodes.IADD
+            )
         );
     }
 

--- a/src/test/java/org/eolang/opeo/compilation/OpeoNodesTest.java
+++ b/src/test/java/org/eolang/opeo/compilation/OpeoNodesTest.java
@@ -34,6 +34,7 @@ import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.ast.Add;
 import org.eolang.opeo.ast.Literal;
 import org.eolang.opeo.ast.Opcode;
+import org.eolang.opeo.ast.OpcodeName;
 import org.hamcrest.Description;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -212,7 +213,7 @@ final class OpeoNodesTest {
             final boolean result;
             final Optional<String> oname = node.attribute("name");
             if (oname.isPresent()) {
-                final String expected = HasInstructions.name(this.opcodes.get(index));
+                final String expected = new OpcodeName(this.opcodes.get(index)).simplified();
                 final String name = oname.get();
                 if (name.contains(expected)) {
                     result = true;
@@ -237,44 +238,6 @@ final class OpeoNodesTest {
                 result = false;
             }
             return result;
-        }
-
-        /**
-         * Get opcode name by opcode.
-         * @param opcode Opcode.
-         * @return Opcode name.
-         */
-        private static String name(final int opcode) {
-            return Arrays.stream(Opcodes.class.getFields())
-                .filter(field -> field.getType() == int.class)
-                .filter(field -> !field.getName().startsWith("T_"))
-                .filter(field -> !field.getName().startsWith("H_"))
-                .filter(field -> !field.getName().startsWith("F_"))
-                .filter(field -> !field.getName().startsWith("ACC"))
-                .filter(field -> !field.getName().startsWith("ASM"))
-                .filter(field -> HasInstructions.sameOpcode(field, opcode))
-                .map(Field::getName)
-                .findFirst()
-                .orElseThrow(
-                    () -> new IllegalStateException(String.format("Unknown opcode: %d", opcode))
-                );
-        }
-
-        /**
-         * Check if field has the same opcode.
-         * @param field Field.
-         * @param opcode Opcode.
-         * @return True if field has the same opcode.
-         */
-        private static boolean sameOpcode(final Field field, final int opcode) {
-            try {
-                return opcode == field.getInt(Opcodes.class);
-            } catch (final IllegalAccessException exception) {
-                throw new IllegalStateException(
-                    String.format("Cannot access opcode %d in field %s", opcode, field),
-                    exception
-                );
-            }
         }
     }
 }

--- a/src/test/java/org/eolang/opeo/compilation/OpeoNodesTest.java
+++ b/src/test/java/org/eolang/opeo/compilation/OpeoNodesTest.java
@@ -38,6 +38,7 @@ import org.hamcrest.Description;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 
@@ -92,6 +93,7 @@ final class OpeoNodesTest {
     }
 
     @Test
+    @Disabled("Not implemented yet")
     void convertsDeepAddition() {
         final List<XmlNode> nodes = new OpeoNodes(
             new Add(
@@ -146,49 +148,58 @@ final class OpeoNodesTest {
 
         @Override
         protected boolean matchesSafely(final List<XmlNode> item) {
+            boolean result = true;
             final int size = item.size();
             for (int index = 0; index < size; ++index) {
-                final XmlNode node = item.get(index);
-                final Optional<String> obase = node.attribute("base");
-                if (obase.isPresent()) {
-                    final String base = obase.get();
-                    if (base.equals("opcode")) {
-                        final Optional<String> oname = node.attribute("name");
-                        if (oname.isPresent()) {
-                            final String expected = HasInstructions.name(this.opcodes.get(index));
-                            if (!oname.get().contains(expected)) {
-                                this.warnings.add(
-                                    String.format(
-                                        "Expected to have opcode with name %s at index %d, but got %s instead",
-                                        expected,
-                                        index,
-                                        oname.get()
-                                    )
-                                );
-                                return false;
-                            }
-                        } else {
+                if (!this.matches(item.get(index), index)) {
+                    result = false;
+                    break;
+                }
+            }
+            return result;
+        }
+
+        private boolean matches(final XmlNode node, final int index) {
+            boolean result = true;
+            final Optional<String> obase = node.attribute("base");
+            if (obase.isPresent()) {
+                final String base = obase.get();
+                if (base.equals("opcode")) {
+                    final Optional<String> oname = node.attribute("name");
+                    if (oname.isPresent()) {
+                        final String expected = HasInstructions.name(this.opcodes.get(index));
+                        if (!oname.get().contains(expected)) {
                             this.warnings.add(
                                 String.format(
-                                    "Expected to have opcode name at index %d, but got nothing instead",
-                                    index
+                                    "Expected to have opcode with name %s at index %d, but got %s instead",
+                                    expected,
+                                    index,
+                                    oname.get()
                                 )
                             );
-                            return false;
+                            result = false;
                         }
                     } else {
                         this.warnings.add(
                             String.format(
-                                "Expected to have opcode at index %d, but got %s instead",
-                                index,
-                                base
+                                "Expected to have opcode name at index %d, but got nothing instead",
+                                index
                             )
                         );
-                        return false;
+                        result = false;
                     }
+                } else {
+                    this.warnings.add(
+                        String.format(
+                            "Expected to have opcode at index %d, but got %s instead",
+                            index,
+                            base
+                        )
+                    );
+                    result = false;
                 }
             }
-            return true;
+            return result;
         }
 
         /**

--- a/src/test/java/org/eolang/opeo/compilation/OpeoNodesTest.java
+++ b/src/test/java/org/eolang/opeo/compilation/OpeoNodesTest.java
@@ -23,9 +23,7 @@
  */
 package org.eolang.opeo.compilation;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -39,7 +37,6 @@ import org.hamcrest.Description;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 

--- a/src/test/resources/xmir/Bar.xmir
+++ b/src/test/resources/xmir/Bar.xmir
@@ -41,17 +41,17 @@
                   <o base="label">
                      <o base="string" data="bytes">38 63 33 33 31 33 39 37 2D 32 35 39 35 2D 34 66 35 64 2D 38 65 62 30 2D 33 62 30 63 34 62 35 34 36 35 66 32</o>
                   </o>
-                  <o base="opcode" name="ALOAD-51">
+                  <o base="opcode" name="ALOAD">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
                      <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
                   </o>
-                  <o base="opcode" name="INVOKESPECIAL-52">
+                  <o base="opcode" name="INVOKESPECIAL">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 B7</o>
                      <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
                      <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
                      <o base="string" data="bytes">28 29 56</o>
                   </o>
-                  <o base="opcode" name="RETURN-53">
+                  <o base="opcode" name="RETURN">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 B1</o>
                   </o>
                   <o base="label">
@@ -59,7 +59,6 @@
                   </o>
                </o>
             </o>
-            <o base="tuple" name="trycatchblocks"/>
          </o>
          <o abstract="" name="j$foo">
             <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 01</o>
@@ -72,11 +71,11 @@
                   <o base="label">
                      <o base="string" data="bytes">62 39 63 64 62 64 63 65 2D 38 35 38 65 2D 34 30 36 32 2D 61 38 39 30 2D 62 32 65 34 30 62 34 36 31 36 61 37</o>
                   </o>
-                  <o base="opcode" name="ILOAD-54">
+                  <o base="opcode" name="ILOAD">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 15</o>
                      <o base="int" data="bytes">00 00 00 00 00 00 00 01</o>
                   </o>
-                  <o base="opcode" name="IFLE-55">
+                  <o base="opcode" name="IFLE">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 9E</o>
                      <o base="label">
                         <o base="string" data="bytes">36 62 34 36 66 61 36 32 2D 32 66 30 65 2D 34 38 34 30 2D 39 34 62 32 2D 66 65 32 64 31 36 35 65 33 35 30 32</o>
@@ -85,19 +84,19 @@
                   <o base="label">
                      <o base="string" data="bytes">30 61 30 33 30 39 37 66 2D 30 66 66 65 2D 34 61 38 63 2D 39 64 34 34 2D 64 31 39 39 33 32 61 35 65 35 35 30</o>
                   </o>
-                  <o base="opcode" name="ICONST_1-56">
+                  <o base="opcode" name="ICONST_1">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 04</o>
                   </o>
-                  <o base="opcode" name="IRETURN-57">
+                  <o base="opcode" name="IRETURN">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 AC</o>
                   </o>
                   <o base="label">
                      <o base="string" data="bytes">36 62 34 36 66 61 36 32 2D 32 66 30 65 2D 34 38 34 30 2D 39 34 62 32 2D 66 65 32 64 31 36 35 65 33 35 30 32</o>
                   </o>
-                  <o base="opcode" name="ICONST_2-58">
+                  <o base="opcode" name="ICONST_2">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 05</o>
                   </o>
-                  <o base="opcode" name="IRETURN-59">
+                  <o base="opcode" name="IRETURN">
                      <o base="int" data="bytes">00 00 00 00 00 00 00 AC</o>
                   </o>
                   <o base="label">


### PR DESCRIPTION
In this PR I tried to decompile simple EO constructs related to 'benchmark' example.

Here we decompile high-level code generated by `opeo-maven-plugin` and transform it to low-level code acceptable by `jeo-maven-plugin`.

Closes: #65

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the `opcodes()` method to various classes in the codebase. 

### Detailed summary
- Added the `opcodes()` method to the `AstNode` interface.
- Implemented the `opcodes()` method in multiple classes, throwing an `UnsupportedOperationException` for now.
- Added the `opcodes()` method to the `Literal` class, returning a list of opcodes based on the object type.
- Added the `disableCounting()` method to the `Opcode` class to disable opcodes counting for tests.
- Added the `opcodes()` method to the `Opcode` class, returning a list containing the opcode itself.

> The following files were skipped due to too many changes: `src/main/java/org/eolang/opeo/ast/Literal.java`, `src/main/java/org/eolang/opeo/ast/Label.java`, `src/test/resources/xmir/Bar.xmir`, `src/main/java/org/eolang/opeo/ast/OpcodeName.java`, `src/main/java/org/eolang/opeo/compilation/OpeoNodes.java`, `src/test/java/org/eolang/opeo/compilation/OpeoNodesTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->