### PR TITLE
feat(#49): save type of variable to scope attribute

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/Variable.java
+++ b/src/main/java/org/eolang/opeo/ast/Variable.java
@@ -33,13 +33,6 @@ import org.xembly.Directives;
 /**
  * A variable.
  * @since 0.1
- * @todo #44:90min Use type of the variable.
- *  Currently, the type of the variable is not used.
- *  It should be used to generate the correct XMIR.
- *  For example, if the type is "int", then the XMIR
- *  should contain this information to be able to
- *  reconstruct the type of the variable during
- *  the compilation to bytecode.
  */
 @ToString
 public final class Variable implements AstNode {

--- a/src/main/java/org/eolang/opeo/ast/Variable.java
+++ b/src/main/java/org/eolang/opeo/ast/Variable.java
@@ -77,6 +77,7 @@ public final class Variable implements AstNode {
         return new Directives()
             .add("o")
             .attr("base", String.format("local%d", this.identifier))
+            .attr("scope", this.type.getDescriptor())
             .up();
     }
 

--- a/src/test/java/org/eolang/opeo/ast/VariableTest.java
+++ b/src/test/java/org/eolang/opeo/ast/VariableTest.java
@@ -84,8 +84,11 @@ class VariableTest {
 
     /**
      * Types arguments.
+     * Don't remove this method, it's used by {@link #convertsType(Type, String)}.
      * @return Arguments.
+     * @checkstyle UnusedPrivateMethod (10 lines)
      */
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static Stream<Arguments> typesArguments() {
         return Stream.of(
             Arguments.of(Type.INT_TYPE, "I"),

--- a/src/test/java/org/eolang/opeo/ast/VariableTest.java
+++ b/src/test/java/org/eolang/opeo/ast/VariableTest.java
@@ -24,9 +24,13 @@
 package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.objectweb.asm.Type;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
@@ -58,6 +62,42 @@ class VariableTest {
             "We expect the xmir variable to be equal to <o base='local1'/>, but it wasn't",
             new Xembler(new Variable(Type.INT_TYPE, 1).toXmir()).xml(),
             XhtmlMatchers.hasXPath("./o[@base='local1']")
+        );
+    }
+
+    @ParameterizedTest(name = "[{index}] {0} => {1}")
+    @MethodSource("typesArguments")
+    void convertsType(
+        final Type type, final String expected
+    ) throws ImpossibleModificationException {
+        final String xml = new Xembler(new Variable(type, 1).toXmir()).xml();
+        MatcherAssert.assertThat(
+            String.format(
+                "We expect the xmir variable type to be equal to <o base='local1' scope='%s'/>, but it wasn't, current value is '%s'",
+                expected,
+                xml
+            ),
+            xml,
+            XhtmlMatchers.hasXPath(String.format("./o[@scope='%s']", expected))
+        );
+    }
+
+    /**
+     * Types arguments.
+     * @return Arguments.
+     */
+    private static Stream<Arguments> typesArguments() {
+        return Stream.of(
+            Arguments.of(Type.INT_TYPE, "I"),
+            Arguments.of(Type.BOOLEAN_TYPE, "Z"),
+            Arguments.of(Type.BYTE_TYPE, "B"),
+            Arguments.of(Type.CHAR_TYPE, "C"),
+            Arguments.of(Type.DOUBLE_TYPE, "D"),
+            Arguments.of(Type.FLOAT_TYPE, "F"),
+            Arguments.of(Type.LONG_TYPE, "J"),
+            Arguments.of(Type.SHORT_TYPE, "S"),
+            Arguments.of(Type.VOID_TYPE, "V"),
+            Arguments.of(Type.getType("Ljava/lang/String;"), "Ljava/lang/String;")
         );
     }
 }


### PR DESCRIPTION
Save any variable type to scope attribute in order to be able to restore it from XMIR.

Closes: #49.
___
History:
- feat(#49): save variable type to scope
- feat(#49): remove the puzzle for #49 issue
- feat(#49): fix all linter suggestions
