### PR TITLE
feat(#78): compile local variables loading

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/Variable.java
+++ b/src/main/java/org/eolang/opeo/ast/Variable.java
@@ -89,10 +89,27 @@ public final class Variable implements AstNode {
 
     @Override
     public List<AstNode> opcodes() {
+        final List<AstNode> result;
         if (this.type.equals(Type.INT_TYPE)) {
-            return List.of(new Opcode(Opcodes.ILOAD, this.identifier));
+            result = List.of(new Opcode(Opcodes.ILOAD, this.identifier));
+        } else if (this.type.equals(Type.DOUBLE_TYPE)) {
+            result = List.of(new Opcode(Opcodes.DLOAD, this.identifier));
+        } else if (this.type.equals(Type.LONG_TYPE)) {
+            result = List.of(new Opcode(Opcodes.LLOAD, this.identifier));
+        } else if (this.type.equals(Type.FLOAT_TYPE)) {
+            result = List.of(new Opcode(Opcodes.FLOAD, this.identifier));
+        } else if (this.type.equals(Type.BOOLEAN_TYPE)) {
+            result = List.of(new Opcode(Opcodes.ILOAD, this.identifier));
+        } else if (this.type.equals(Type.CHAR_TYPE)) {
+            result = List.of(new Opcode(Opcodes.ILOAD, this.identifier));
+        } else if (this.type.equals(Type.BYTE_TYPE)) {
+            result = List.of(new Opcode(Opcodes.ILOAD, this.identifier));
+        } else if (this.type.equals(Type.SHORT_TYPE)) {
+            result = List.of(new Opcode(Opcodes.ILOAD, this.identifier));
+        } else {
+            result = List.of(new Opcode(Opcodes.ALOAD, this.identifier));
         }
-        throw new UnsupportedOperationException("Not implemented yet");
+        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/Variable.java
+++ b/src/main/java/org/eolang/opeo/ast/Variable.java
@@ -24,7 +24,9 @@
 package org.eolang.opeo.ast;
 
 import java.util.List;
+import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eolang.jeo.representation.xmir.XmlNode;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.xembly.Directive;
@@ -35,7 +37,14 @@ import org.xembly.Directives;
  * @since 0.1
  */
 @ToString
+@EqualsAndHashCode
 public final class Variable implements AstNode {
+
+    /**
+     * The prefix of the variable.
+     */
+    private static final String PREFIX = "local";
+
     /**
      * The type of the variable.
      */
@@ -45,6 +54,10 @@ public final class Variable implements AstNode {
      * The identifier of the variable.
      */
     private final int identifier;
+
+    public Variable(final XmlNode node) {
+        this(Variable.type(node), Variable.identifier(node));
+    }
 
     /**
      * Constructor.
@@ -62,14 +75,14 @@ public final class Variable implements AstNode {
     @ToString.Include
     @Override
     public String print() {
-        return String.format("local%d%s", this.identifier, this.type.getClassName());
+        return String.format("%s%d%s", Variable.PREFIX, this.identifier, this.type.getClassName());
     }
 
     @Override
     public Iterable<Directive> toXmir() {
         return new Directives()
             .add("o")
-            .attr("base", String.format("local%d", this.identifier))
+            .attr("base", String.format("%s%d", Variable.PREFIX, this.identifier))
             .attr("scope", this.type.getDescriptor())
             .up();
     }
@@ -80,5 +93,41 @@ public final class Variable implements AstNode {
             return List.of(new Opcode(Opcodes.ILOAD, this.identifier));
         }
         throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * Get the identifier of the variable.
+     * @param node The XML node that represents variable.
+     * @return The identifier.
+     */
+    private static int identifier(final XmlNode node) {
+        return Integer.parseInt(
+            node.attribute("base").orElseThrow(
+                () -> new IllegalArgumentException(
+                    String.format(
+                        "Can't recognize variable node: %n%s%nWe expected to find 'base' attribute",
+                        node
+                    )
+                )
+            ).substring(Variable.PREFIX.length())
+        );
+    }
+
+    /**
+     * Get the type of the variable.
+     * @param node The XML node that represents variable.
+     * @return The type.
+     */
+    private static Type type(final XmlNode node) {
+        return Type.getType(node.attribute("scope")
+            .orElseThrow(
+                () -> new IllegalArgumentException(
+                    String.format(
+                        "Can't recognize variable node: %n%s%nWe expected to find 'scope' attribute",
+                        node
+                    )
+                )
+            )
+        );
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Variable.java
+++ b/src/main/java/org/eolang/opeo/ast/Variable.java
@@ -55,8 +55,12 @@ public final class Variable implements AstNode {
      */
     private final int identifier;
 
+    /**
+     * Constructor.
+     * @param node The XML node that represents variable.
+     */
     public Variable(final XmlNode node) {
-        this(Variable.type(node), Variable.identifier(node));
+        this(Variable.vtype(node), Variable.videntifier(node));
     }
 
     /**
@@ -117,7 +121,7 @@ public final class Variable implements AstNode {
      * @param node The XML node that represents variable.
      * @return The identifier.
      */
-    private static int identifier(final XmlNode node) {
+    private static int videntifier(final XmlNode node) {
         return Integer.parseInt(
             node.attribute("base").orElseThrow(
                 () -> new IllegalArgumentException(
@@ -135,7 +139,7 @@ public final class Variable implements AstNode {
      * @param node The XML node that represents variable.
      * @return The type.
      */
-    private static Type type(final XmlNode node) {
+    private static Type vtype(final XmlNode node) {
         return Type.getType(node.attribute("scope")
             .orElseThrow(
                 () -> new IllegalArgumentException(

--- a/src/test/java/org/eolang/opeo/ast/VariableTest.java
+++ b/src/test/java/org/eolang/opeo/ast/VariableTest.java
@@ -137,6 +137,7 @@ class VariableTest {
      * Don't remove this method, it's used by {@link #transformsToBytecodeInstructions(Type, int)}}.
      * @return Arguments.
      */
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static Stream<Arguments> loads() {
         return Stream.of(
             Arguments.of(Type.INT_TYPE, Opcodes.ILOAD),

--- a/src/test/java/org/eolang/opeo/ast/VariableTest.java
+++ b/src/test/java/org/eolang/opeo/ast/VariableTest.java
@@ -24,14 +24,17 @@
 package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
@@ -93,6 +96,20 @@ class VariableTest {
         );
     }
 
+    @ParameterizedTest(name = "[{index}] {0} => {1}")
+    @MethodSource("loads")
+    void transformsToBytecodeInstructions(final Type type, final int expected) {
+        MatcherAssert.assertThat(
+            "Can't correctly transform variable to bytecode instructions. It should be exactly 1 instruction",
+            new Variable(type, 0).opcodes().stream().map(AstNode::toXmir)
+                .map(Xembler::new)
+                .map(Xembler::xmlQuietly)
+                .map(XmlNode::new)
+                .collect(Collectors.toList()),
+            new HasInstructions(expected)
+        );
+    }
+
     /**
      * Types arguments.
      * Don't remove this method, it's used by {@link #convertsType(Type, String)}.
@@ -112,6 +129,26 @@ class VariableTest {
             Arguments.of(Type.SHORT_TYPE, "S"),
             Arguments.of(Type.VOID_TYPE, "V"),
             Arguments.of(Type.getType("Ljava/lang/String;"), "Ljava/lang/String;")
+        );
+    }
+
+    /**
+     * Arguments for {@link #transformsToBytecodeInstructions(Type, int)} ()}.
+     * Don't remove this method, it's used by {@link #transformsToBytecodeInstructions(Type, int)}}.
+     * @return Arguments.
+     */
+    private static Stream<Arguments> loads() {
+        return Stream.of(
+            Arguments.of(Type.INT_TYPE, Opcodes.ILOAD),
+            Arguments.of(Type.BOOLEAN_TYPE, Opcodes.ILOAD),
+            Arguments.of(Type.BYTE_TYPE, Opcodes.ILOAD),
+            Arguments.of(Type.CHAR_TYPE, Opcodes.ILOAD),
+            Arguments.of(Type.DOUBLE_TYPE, Opcodes.DLOAD),
+            Arguments.of(Type.FLOAT_TYPE, Opcodes.FLOAD),
+            Arguments.of(Type.LONG_TYPE, Opcodes.LLOAD),
+            Arguments.of(Type.SHORT_TYPE, Opcodes.ILOAD),
+            Arguments.of(Type.VOID_TYPE, Opcodes.ALOAD),
+            Arguments.of(Type.getType("Ljava/lang/String;"), Opcodes.ALOAD)
         );
     }
 }

--- a/src/test/java/org/eolang/opeo/ast/VariableTest.java
+++ b/src/test/java/org/eolang/opeo/ast/VariableTest.java
@@ -25,6 +25,7 @@ package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
 import java.util.stream.Stream;
+import org.eolang.jeo.representation.xmir.XmlNode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -79,6 +80,16 @@ class VariableTest {
             ),
             xml,
             XhtmlMatchers.hasXPath(String.format("./o[@scope='%s']", expected))
+        );
+    }
+
+    @Test
+    void createsVariableFromXmir() throws ImpossibleModificationException {
+        final Variable original = new Variable(Type.FLOAT_TYPE, 2);
+        MatcherAssert.assertThat(
+            "Can't correctly create variable from XMIR. We expect the variable to be equal to the original, but it wasn't",
+            new Variable(new XmlNode(new Xembler(original.toXmir()).xml())),
+            Matchers.equalTo(original)
         );
     }
 

--- a/src/test/java/org/eolang/opeo/compilation/HasInstructions.java
+++ b/src/test/java/org/eolang/opeo/compilation/HasInstructions.java
@@ -1,0 +1,131 @@
+package org.eolang.opeo.compilation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.ast.OpcodeName;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Matcher for {@link List} of {@link XmlNode} to have specific instructions.
+ * @since 0.1
+ */
+public final class HasInstructions extends TypeSafeMatcher<List<XmlNode>> {
+
+    /**
+     * Expected opcodes.
+     */
+    private final List<Integer> opcodes;
+
+    /**
+     * Bag of collected warnings.
+     */
+    private final List<String> warnings;
+
+    /**
+     * Constructor.
+     * @param opcodes Expected opcodes.
+     */
+    public HasInstructions(final int... opcodes) {
+        this(IntStream.of(opcodes).boxed().collect(Collectors.toList()));
+    }
+
+    /**
+     * Constructor.
+     * @param opcodes Expected opcodes.
+     */
+    private HasInstructions(final List<Integer> opcodes) {
+        this.opcodes = opcodes;
+        this.warnings = new ArrayList<>(0);
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendText(
+            String.format(
+                "Expected to have %d opcodes, but got %d instead. %n%s%n",
+                this.opcodes.size(),
+                this.warnings.size(),
+                String.join("\n", this.warnings)
+            )
+        );
+    }
+
+    @Override
+    public boolean matchesSafely(final List<XmlNode> item) {
+        boolean result = true;
+        final int size = item.size();
+        for (int index = 0; index < size; ++index) {
+            if (!this.matches(item.get(index), index)) {
+                result = false;
+                break;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Check if node matches expected opcode.
+     * @param node Node.
+     * @param index Index.
+     * @return True if node matches expected opcode.
+     */
+    private boolean matches(final XmlNode node, final int index) {
+        final boolean result;
+        final String base = node.attribute("base").orElseThrow();
+        if (base.equals("opcode")) {
+            result = this.verifyName(node, index);
+        } else {
+            this.warnings.add(
+                String.format(
+                    "Expected to have opcode at index %d, but got %s instead",
+                    index,
+                    base
+                )
+            );
+            result = false;
+        }
+        return result;
+    }
+
+    /**
+     * Verify opcode name.
+     * @param node Node.
+     * @param index Index.
+     * @return True if opcode name is correct.
+     */
+    private boolean verifyName(final XmlNode node, final int index) {
+        final boolean result;
+        final Optional<String> oname = node.attribute("name");
+        if (oname.isPresent()) {
+            final String expected = new OpcodeName(this.opcodes.get(index)).simplified();
+            final String name = oname.get();
+            if (name.contains(expected)) {
+                result = true;
+            } else {
+                this.warnings.add(
+                    String.format(
+                        "Expected to have opcode with name %s at index %d, but got %s instead",
+                        expected,
+                        index,
+                        name
+                    )
+                );
+                result = false;
+            }
+        } else {
+            this.warnings.add(
+                String.format(
+                    "Expected to have opcode name at index %d, but got nothing instead",
+                    index
+                )
+            );
+            result = false;
+        }
+        return result;
+    }
+}

--- a/src/test/java/org/eolang/opeo/compilation/HasInstructions.java
+++ b/src/test/java/org/eolang/opeo/compilation/HasInstructions.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.opeo.compilation;
 
 import java.util.ArrayList;

--- a/src/test/java/org/eolang/opeo/compilation/HasInstructions.java
+++ b/src/test/java/org/eolang/opeo/compilation/HasInstructions.java
@@ -37,6 +37,7 @@ import org.hamcrest.TypeSafeMatcher;
  * Matcher for {@link List} of {@link XmlNode} to have specific instructions.
  * @since 0.1
  */
+@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleCorrectTestName"})
 public final class HasInstructions extends TypeSafeMatcher<List<XmlNode>> {
 
     /**

--- a/src/test/java/org/eolang/opeo/compilation/OpeoNodesTest.java
+++ b/src/test/java/org/eolang/opeo/compilation/OpeoNodesTest.java
@@ -23,20 +23,13 @@
  */
 package org.eolang.opeo.compilation;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.ast.Add;
 import org.eolang.opeo.ast.Literal;
 import org.eolang.opeo.ast.Opcode;
-import org.eolang.opeo.ast.OpcodeName;
-import org.hamcrest.Description;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.hamcrest.TypeSafeMatcher;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 
@@ -118,123 +111,4 @@ final class OpeoNodesTest {
         );
     }
 
-    /**
-     * Matcher for {@link List} of {@link XmlNode} to have specific instructions.
-     * @since 0.1
-     */
-    private static final class HasInstructions extends TypeSafeMatcher<List<XmlNode>> {
-
-        /**
-         * Expected opcodes.
-         */
-        private final List<Integer> opcodes;
-
-        /**
-         * Bag of collected warnings.
-         */
-        private final List<String> warnings;
-
-        /**
-         * Constructor.
-         * @param opcodes Expected opcodes.
-         */
-        private HasInstructions(final int... opcodes) {
-            this(IntStream.of(opcodes).boxed().collect(Collectors.toList()));
-        }
-
-        /**
-         * Constructor.
-         * @param opcodes Expected opcodes.
-         */
-        private HasInstructions(final List<Integer> opcodes) {
-            this.opcodes = opcodes;
-            this.warnings = new ArrayList<>(0);
-        }
-
-        @Override
-        public void describeTo(final Description description) {
-            description.appendText(
-                String.format(
-                    "Expected to have %d opcodes, but got %d instead. %n%s%n",
-                    this.opcodes.size(),
-                    this.warnings.size(),
-                    String.join("\n", this.warnings)
-                )
-            );
-        }
-
-        @Override
-        public boolean matchesSafely(final List<XmlNode> item) {
-            boolean result = true;
-            final int size = item.size();
-            for (int index = 0; index < size; ++index) {
-                if (!this.matches(item.get(index), index)) {
-                    result = false;
-                    break;
-                }
-            }
-            return result;
-        }
-
-        /**
-         * Check if node matches expected opcode.
-         * @param node Node.
-         * @param index Index.
-         * @return True if node matches expected opcode.
-         */
-        private boolean matches(final XmlNode node, final int index) {
-            final boolean result;
-            final String base = node.attribute("base").orElseThrow();
-            if (base.equals("opcode")) {
-                result = this.verifyName(node, index);
-            } else {
-                this.warnings.add(
-                    String.format(
-                        "Expected to have opcode at index %d, but got %s instead",
-                        index,
-                        base
-                    )
-                );
-                result = false;
-            }
-            return result;
-        }
-
-        /**
-         * Verify opcode name.
-         * @param node Node.
-         * @param index Index.
-         * @return True if opcode name is correct.
-         */
-        private boolean verifyName(final XmlNode node, final int index) {
-            final boolean result;
-            final Optional<String> oname = node.attribute("name");
-            if (oname.isPresent()) {
-                final String expected = new OpcodeName(this.opcodes.get(index)).simplified();
-                final String name = oname.get();
-                if (name.contains(expected)) {
-                    result = true;
-                } else {
-                    this.warnings.add(
-                        String.format(
-                            "Expected to have opcode with name %s at index %d, but got %s instead",
-                            expected,
-                            index,
-                            name
-                        )
-                    );
-                    result = false;
-                }
-            } else {
-                this.warnings.add(
-                    String.format(
-                        "Expected to have opcode name at index %d, but got nothing instead",
-                        index
-                    )
-                );
-                result = false;
-            }
-            return result;
-        }
-    }
 }


### PR DESCRIPTION
Transform `Variable` to a set of bytecode instructions. 

Closes: #78.
_____
History:
- feat(#78): create variable from raw XMIR
- feat(#78): handle local variable as a single endpoint
- feat(#78): load variables with all possible types
- feat(#78): add unit tests
- feat(#78): fix all linter suggestions
- feat(#78): fix all jtcop suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding functionality to create a Variable object from XMIR and transforming it to bytecode instructions.

### Detailed summary
- Added `createsVariableFromXmir` test in `VariableTest.java`
- Added `transformsToBytecodeInstructions` test in `VariableTest.java`
- Added `Variable` constructor that takes an XML node
- Added `videntifier` and `vtype` methods in `Variable.java`
- Added `HasInstructions` class in `HasInstructions.java`

> The following files were skipped due to too many changes: `src/test/java/org/eolang/opeo/compilation/HasInstructions.java`, `src/main/java/org/eolang/opeo/compilation/OpeoNodes.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->