### PR TITLE
feat(#76): Compile 'Super' example

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/Invocation.java
+++ b/src/main/java/org/eolang/opeo/ast/Invocation.java
@@ -115,6 +115,10 @@ public final class Invocation implements AstNode {
 
     @Override
     public List<AstNode> opcodes() {
+        //@checkstyle MethodBodyCommentsCheck (10 lines)
+        // @todo #76:90min Implement and test invocation opcodes compilation.
+        //  Current implementation is dummy and is used only to pass integration tests.
+        //  We need to implement and test invocation opcodes compilation.
         final List<AstNode> res = new ArrayList<>(0);
         this.arguments.stream().map(AstNode::opcodes).forEach(res::addAll);
         res.add(new Opcode(Opcodes.INVOKEVIRTUAL, "V", this.method, "V()"));

--- a/src/main/java/org/eolang/opeo/ast/OpcodeNodes.java
+++ b/src/main/java/org/eolang/opeo/ast/OpcodeNodes.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.xembly.Xembler;
+
+/**
+ * Utility class that transforms {@link AstNode} to a list of XmlNode`s.
+ * See {@link org.eolang.jeo.representation.xmir.XmlNode}.
+ * @since 0.1
+ */
+public final class OpcodeNodes {
+
+    /**
+     * Ast node.
+     */
+    private final AstNode node;
+
+    /**
+     * Constructor.
+     * @param node Ast node.
+     */
+    public OpcodeNodes(final AstNode node) {
+        this.node = node;
+    }
+
+    /**
+     * Transform to a list of XmlNode`s.
+     * @return List of XmlNode`s.
+     */
+    public List<XmlNode> opcodes() {
+        return this.node.opcodes()
+            .stream()
+            .map(AstNode::toXmir)
+            .map(Xembler::new)
+            .map(Xembler::xmlQuietly)
+            .map(XmlNode::new)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/eolang/opeo/ast/Super.java
+++ b/src/main/java/org/eolang/opeo/ast/Super.java
@@ -80,6 +80,12 @@ public final class Super implements AstNode {
         this(instance, arguments, "()V");
     }
 
+    /**
+     * Constructor.
+     * @param instance Target instance
+     * @param arguments Super arguments
+     * @param descriptor Descriptor
+     */
     public Super(
         final AstNode instance,
         final List<AstNode> arguments,

--- a/src/main/java/org/eolang/opeo/ast/Super.java
+++ b/src/main/java/org/eolang/opeo/ast/Super.java
@@ -87,14 +87,9 @@ public final class Super implements AstNode {
 
     @Override
     public List<AstNode> opcodes() {
-        final List<AstNode> res = new ArrayList<>(1);
+        final List<AstNode> res = new ArrayList<>(2);
         res.addAll(this.instance.opcodes());
         this.arguments.stream().map(AstNode::opcodes).forEach(res::addAll);
-        //@checkstyle MethodBodyCommentsCheck (10 lines)
-        // @todo #65:90min Pass correct arguments to invokespecial instruction.
-        //  Currently we just pass default arguments to invokespecial instruction.
-        //  We need to pass correct arguments to invokespecial instruction.
-        //  But in order to implement this we need to save this arguments somewhere before.
         res.add(new Opcode(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V"));
         return res;
     }

--- a/src/main/java/org/eolang/opeo/ast/Super.java
+++ b/src/main/java/org/eolang/opeo/ast/Super.java
@@ -48,6 +48,11 @@ public final class Super implements AstNode {
     private final List<AstNode> arguments;
 
     /**
+     * Descriptor.
+     */
+    private final String descriptor;
+
+    /**
      * Constructor.
      * @param instance Super instance
      * @param arguments Super arguments
@@ -59,11 +64,30 @@ public final class Super implements AstNode {
     /**
      * Constructor.
      * @param instance Super instance
+     * @param descriptor Descriptor
+     * @param arguments Super arguments
+     */
+    public Super(final AstNode instance, final String descriptor, final AstNode... arguments) {
+        this(instance, Arrays.asList(arguments), descriptor);
+    }
+
+    /**
+     * Constructor.
+     * @param instance Super instance
      * @param arguments Super arguments
      */
     public Super(final AstNode instance, final List<AstNode> arguments) {
+        this(instance, arguments, "()V");
+    }
+
+    public Super(
+        final AstNode instance,
+        final List<AstNode> arguments,
+        final String descriptor
+    ) {
         this.instance = instance;
         this.arguments = arguments;
+        this.descriptor = descriptor;
     }
 
     @Override
@@ -90,7 +114,7 @@ public final class Super implements AstNode {
         final List<AstNode> res = new ArrayList<>(2);
         res.addAll(this.instance.opcodes());
         this.arguments.stream().map(AstNode::opcodes).forEach(res::addAll);
-        res.add(new Opcode(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V"));
+        res.add(new Opcode(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", this.descriptor));
         return res;
     }
 

--- a/src/main/java/org/eolang/opeo/ast/Super.java
+++ b/src/main/java/org/eolang/opeo/ast/Super.java
@@ -104,6 +104,7 @@ public final class Super implements AstNode {
         final Directives directives = new Directives();
         directives.add("o")
             .attr("base", ".super")
+            .attr("scope", this.descriptor)
             .append(this.instance.toXmir());
         this.arguments.stream().map(AstNode::toXmir).forEach(directives::append);
         return directives.up();

--- a/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
+++ b/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
@@ -168,7 +168,8 @@ public final class OpeoNodes {
                 node.attribute("scope")
                     .orElseThrow(
                         () -> new IllegalArgumentException(
-                            "Can't find descriptor for super invocation")
+                            "Can't find descriptor for super invocation"
+                        )
                     )
             );
         } else if ("$".equals(base)) {

--- a/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
+++ b/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
@@ -162,7 +162,15 @@ public final class OpeoNodes {
             } else {
                 arguments = Collections.emptyList();
             }
-            result = new Super(instance, arguments);
+            result = new Super(
+                instance,
+                arguments,
+                node.attribute("scope")
+                    .orElseThrow(
+                        () -> new IllegalArgumentException(
+                            "Can't find descriptor for super invocation")
+                    )
+            );
         } else if ("$".equals(base)) {
             result = new This();
         } else if (base.contains("local")) {

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
@@ -377,7 +377,6 @@ public final class DecompilerMachine {
     private class InvokespecialHandler implements InstructionHandler {
         @Override
         public void handle(final Instruction instruction) {
-            final String target = (String) instruction.operand(0);
             if (!instruction.operand(1).equals("<init>")) {
                 throw new UnsupportedOperationException(
                     String.format("Instruction %s is not supported yet", instruction)
@@ -387,6 +386,7 @@ public final class DecompilerMachine {
             final List<AstNode> args = DecompilerMachine.this.popArguments(
                 Type.getArgumentCount(descriptor)
             );
+            final String target = (String) instruction.operand(0);
             //@checkstyle MethodBodyCommentsCheck (10 lines)
             // @todo #76:90min Target might not be an Object.
             //  Here we just compare with object, but if the current class has a parent, the

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
@@ -383,8 +383,9 @@ public final class DecompilerMachine {
                     String.format("Instruction %s is not supported yet", instruction)
                 );
             }
+            final String descriptor = (String) instruction.operand(2);
             final List<AstNode> args = DecompilerMachine.this.popArguments(
-                Type.getArgumentCount((String) instruction.operand(2))
+                Type.getArgumentCount(descriptor)
             );
             //@checkstyle MethodBodyCommentsCheck (10 lines)
             // @todo #76:90min Target might not be an Object.
@@ -394,7 +395,7 @@ public final class DecompilerMachine {
             //  constructor of the 'Super' class somehow.
             if ("java/lang/Object".equals(target)) {
                 DecompilerMachine.this.stack.push(
-                    new Super(DecompilerMachine.this.stack.pop(), args)
+                    new Super(DecompilerMachine.this.stack.pop(), args, descriptor)
                 );
             } else {
                 ((Reference) DecompilerMachine.this.stack.pop())

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
@@ -377,27 +377,30 @@ public final class DecompilerMachine {
     private class InvokespecialHandler implements InstructionHandler {
         @Override
         public void handle(final Instruction instruction) {
+            final String target = (String) instruction.operand(0);
             if (!instruction.operand(1).equals("<init>")) {
                 throw new UnsupportedOperationException(
                     String.format("Instruction %s is not supported yet", instruction)
                 );
             }
-            if (instruction.operand(0).equals("java/lang/Object")) {
-                final List<AstNode> args = DecompilerMachine.this.popArguments(
-                    Type.getArgumentCount((String) instruction.operand(2))
-                );
+            final List<AstNode> args = DecompilerMachine.this.popArguments(
+                Type.getArgumentCount((String) instruction.operand(2))
+            );
+            //@checkstyle MethodBodyCommentsCheck (10 lines)
+            // @todo #76:90min Target might not be an Object.
+            //  Here we just compare with object, but if the current class has a parent, the
+            //  target might not be an Object. We should compare with the current class name
+            //  instead. Moreover, we have to pass the 'target' as an argument to the
+            //  constructor of the 'Super' class somehow.
+            if ("java/lang/Object".equals(target)) {
                 DecompilerMachine.this.stack.push(
                     new Super(DecompilerMachine.this.stack.pop(), args)
                 );
             } else {
-                final List<AstNode> args = DecompilerMachine.this.popArguments(
-                    Type.getArgumentCount((String) instruction.operand(2))
-                );
                 ((Reference) DecompilerMachine.this.stack.pop())
-                    .link(new Constructor((String) instruction.operand(0), args));
+                    .link(new Constructor(target, args));
             }
         }
-
     }
 
     /**

--- a/src/test/java/org/eolang/opeo/ast/SuperTest.java
+++ b/src/test/java/org/eolang/opeo/ast/SuperTest.java
@@ -24,10 +24,9 @@
 package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import java.util.List;
 import java.util.stream.Collectors;
-import org.eolang.opeo.compilation.HasInstructions;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/eolang/opeo/ast/SuperTest.java
+++ b/src/test/java/org/eolang/opeo/ast/SuperTest.java
@@ -80,9 +80,14 @@ class SuperTest {
                 .map(XmlNode::new)
                 .collect(Collectors.toList()),
             new HasInstructions(
-                Opcodes.ALOAD,
-                Opcodes.ICONST_1,
-                Opcodes.INVOKESPECIAL
+                new HasInstructions.Instruction(Opcodes.ALOAD, 0),
+                new HasInstructions.Instruction(Opcodes.ICONST_1),
+                new HasInstructions.Instruction(
+                    Opcodes.INVOKESPECIAL,
+                    "java/lang/Object",
+                    "<init>",
+                    "()V"
+                )
             )
         );
     }

--- a/src/test/java/org/eolang/opeo/ast/SuperTest.java
+++ b/src/test/java/org/eolang/opeo/ast/SuperTest.java
@@ -27,6 +27,7 @@ import com.jcabi.matchers.XhtmlMatchers;
 import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 import org.xembly.ImpossibleModificationException;
@@ -69,7 +70,7 @@ class SuperTest {
         MatcherAssert.assertThat(
             "Can't convert 'super' statement to opcodes with correct arguments",
             new OpcodeNodes(
-                new Super(new This(), new Literal(1))
+                new Super(new This(), "(I)V", new Literal(1))
             ).opcodes(),
             new HasInstructions(
                 new HasInstructions.Instruction(Opcodes.ALOAD, 0),
@@ -108,7 +109,7 @@ class SuperTest {
         MatcherAssert.assertThat(
             "Can't convert 'super' statement to opcodes with multiple arguments",
             new OpcodeNodes(
-                new Super(new This(), new Literal(1), new Literal(2))
+                new Super(new This(), "(II)V", new Literal(1), new Literal(2))
             ).opcodes(),
             new HasInstructions(
                 new HasInstructions.Instruction(Opcodes.ALOAD, 0),
@@ -125,6 +126,7 @@ class SuperTest {
     }
 
     @Test
+    @Disabled("Not implemented yet")
     void convertsToOpcodesWithParent() {
         MatcherAssert.assertThat(
             "Can't convert 'super' statement to opcodes with parent",

--- a/src/test/java/org/eolang/opeo/ast/SuperTest.java
+++ b/src/test/java/org/eolang/opeo/ast/SuperTest.java
@@ -24,8 +24,6 @@
 package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import java.util.stream.Collectors;
-import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -70,20 +68,74 @@ class SuperTest {
     void convertsToOpcodes() {
         MatcherAssert.assertThat(
             "Can't convert 'super' statement to opcodes with correct arguments",
-            new Super(new This(), new Literal(1))
-                .opcodes()
-                .stream()
-                .map(AstNode::toXmir)
-                .map(Xembler::new)
-                .map(Xembler::xmlQuietly)
-                .map(XmlNode::new)
-                .collect(Collectors.toList()),
+            new OpcodeNodes(
+                new Super(new This(), new Literal(1))
+            ).opcodes(),
             new HasInstructions(
                 new HasInstructions.Instruction(Opcodes.ALOAD, 0),
                 new HasInstructions.Instruction(Opcodes.ICONST_1),
                 new HasInstructions.Instruction(
                     Opcodes.INVOKESPECIAL,
                     "java/lang/Object",
+                    "<init>",
+                    "(I)V"
+                )
+            )
+        );
+    }
+
+    @Test
+    void convertsToOpcodesWithNoArguments() {
+        MatcherAssert.assertThat(
+            "Can't convert 'super' statement to opcodes with no arguments",
+            new OpcodeNodes(
+                new Super(new This())
+            ).opcodes(),
+            new HasInstructions(
+                new HasInstructions.Instruction(Opcodes.ALOAD, 0),
+                new HasInstructions.Instruction(
+                    Opcodes.INVOKESPECIAL,
+                    "java/lang/Object",
+                    "<init>",
+                    "()V"
+                )
+            )
+        );
+    }
+
+    @Test
+    void convertsToOpcodesWithMultipleArguments() {
+        MatcherAssert.assertThat(
+            "Can't convert 'super' statement to opcodes with multiple arguments",
+            new OpcodeNodes(
+                new Super(new This(), new Literal(1), new Literal(2))
+            ).opcodes(),
+            new HasInstructions(
+                new HasInstructions.Instruction(Opcodes.ALOAD, 0),
+                new HasInstructions.Instruction(Opcodes.ICONST_1),
+                new HasInstructions.Instruction(Opcodes.ICONST_2),
+                new HasInstructions.Instruction(
+                    Opcodes.INVOKESPECIAL,
+                    "java/lang/Object",
+                    "<init>",
+                    "(II)V"
+                )
+            )
+        );
+    }
+
+    @Test
+    void convertsToOpcodesWithParent() {
+        MatcherAssert.assertThat(
+            "Can't convert 'super' statement to opcodes with parent",
+            new OpcodeNodes(
+                new Super(new This())
+            ).opcodes(),
+            new HasInstructions(
+                new HasInstructions.Instruction(Opcodes.ALOAD, 0),
+                new HasInstructions.Instruction(
+                    Opcodes.INVOKESPECIAL,
+                    "some/interesting/Parent",
                     "<init>",
                     "()V"
                 )

--- a/src/test/java/org/eolang/opeo/ast/SuperTest.java
+++ b/src/test/java/org/eolang/opeo/ast/SuperTest.java
@@ -24,9 +24,14 @@
 package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eolang.opeo.compilation.HasInstructions;
+import org.eolang.jeo.representation.xmir.XmlNode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
@@ -41,9 +46,7 @@ class SuperTest {
         MatcherAssert.assertThat(
             "Can't print 'super' statement, should be 'this.super \"hello, world!\"'",
             new Super(new This(), new Literal("hello, world!")).print(),
-            Matchers.equalTo(
-                "this.super \"hello, world!\""
-            )
+            Matchers.equalTo("this.super \"hello, world!\"")
         );
     }
 
@@ -60,6 +63,26 @@ class SuperTest {
                 "./o[@base='.super']",
                 "./o[@base='.super']/o[@base='$']",
                 "./o[@base='.super']/o[@base='int' and contains(text(), '1')]"
+            )
+        );
+    }
+
+    @Test
+    void convertsToOpcodes() {
+        MatcherAssert.assertThat(
+            "Can't convert 'super' statement to opcodes with correct arguments",
+            new Super(new This(), new Literal(1))
+                .opcodes()
+                .stream()
+                .map(AstNode::toXmir)
+                .map(Xembler::new)
+                .map(Xembler::xmlQuietly)
+                .map(XmlNode::new)
+                .collect(Collectors.toList()),
+            new HasInstructions(
+                Opcodes.ALOAD,
+                Opcodes.ICONST_1,
+                Opcodes.INVOKESPECIAL
             )
         );
     }

--- a/src/test/java/org/eolang/opeo/ast/SuperTest.java
+++ b/src/test/java/org/eolang/opeo/ast/SuperTest.java
@@ -59,9 +59,25 @@ class SuperTest {
             xmir,
             XhtmlMatchers.hasXPaths(
                 "./o[@base='.super']",
+                "./o[@base='.super' and @scope='()V']",
                 "./o[@base='.super']/o[@base='$']",
                 "./o[@base='.super']/o[@base='int' and contains(text(), '1')]"
             )
+        );
+    }
+
+    @Test
+    void convertsToXmirWithCustomDescriptor() throws ImpossibleModificationException {
+        final String xmir = new Xembler(
+            new Super(new This(), "(I)V", new Literal(10)).toXmir()
+        ).xml();
+        MatcherAssert.assertThat(
+            String.format(
+                "Can't convert 'super' statement to XMIR, result is wrong: %n%s%n",
+                xmir
+            ),
+            xmir,
+            XhtmlMatchers.hasXPaths("./o[@base='.super' and @scope='(I)V']")
         );
     }
 

--- a/src/test/java/org/eolang/opeo/compilation/HasInstructions.java
+++ b/src/test/java/org/eolang/opeo/compilation/HasInstructions.java
@@ -25,16 +25,12 @@ package org.eolang.opeo.compilation;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.eolang.jeo.representation.directives.DirectivesData;
 import org.eolang.jeo.representation.xmir.XmlNode;
-import org.eolang.opeo.Instruction;
 import org.eolang.opeo.ast.OpcodeName;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
@@ -150,10 +146,9 @@ public final class HasInstructions extends TypeSafeMatcher<List<XmlNode>> {
      * @return True if opcode operands are correct.
      */
     private boolean verifyOperands(final XmlNode node, final int index) {
+        boolean result = true;
         final Instruction instruction = this.instructions.get(index);
-        if (instruction.isEmpty()) {
-            return true;
-        } else {
+        if (!instruction.isEmpty()) {
             final List<XmlNode> operands = node.children().skip(1).collect(Collectors.toList());
             for (int operindex = 0; operindex < operands.size(); ++operindex) {
                 final XmlNode operand = operands.get(operindex);
@@ -171,11 +166,12 @@ public final class HasInstructions extends TypeSafeMatcher<List<XmlNode>> {
                             expected
                         )
                     );
-                    return false;
+                    result = false;
+                    break;
                 }
             }
-            return true;
         }
+        return result;
     }
 
     /**
@@ -215,29 +211,62 @@ public final class HasInstructions extends TypeSafeMatcher<List<XmlNode>> {
         return result;
     }
 
+    /**
+     * Instruction.
+     * @since 0.1
+     */
+    public static final class Instruction {
 
-    public static class Instruction {
+        /**
+         * Opcode.
+         */
         private final int opcode;
+
+        /**
+         * Instruction operands.
+         */
         private final List<Object> operands;
 
+        /**
+         * Constructor.
+         * @param opcode Opcode.
+         */
         public Instruction(final int opcode) {
             this(opcode, new ArrayList<>(0));
         }
 
+        /**
+         * Constructor.
+         * @param opcode Instruction opcode.
+         * @param operands Instruction operands.
+         */
         public Instruction(final int opcode, final Object... operands) {
             this(opcode, Arrays.asList(operands));
         }
 
-        public Instruction(final int opcode, final List<Object> operands) {
+        /**
+         * Constructor.
+         * @param opcode Instruction opcode.
+         * @param operands Instruction operands.
+         */
+        Instruction(final int opcode, final List<Object> operands) {
             this.opcode = opcode;
             this.operands = operands;
         }
 
+        /**
+         * Opcode name.
+         * @return Opcode name.
+         */
         public String name() {
             return new OpcodeName(this.opcode).simplified();
         }
 
-        public boolean isEmpty() {
+        /**
+         * Check if instruction is empty.
+         * @return True if instruction operands are empty.
+         */
+        boolean isEmpty() {
             return this.operands.isEmpty();
         }
     }


### PR DESCRIPTION
Compile 'super' instruction to opcodes.

Closes: #76
____
History:
- feat(#76): create working test for 'super' transformation to opcodes
- feat(#76): check operands in an opcode instruction
- feat(#76): fix all linter suggestions
- feat(#76): remove the puzzle for 76 issue
- feat(#76): add more test cases for Super ast node - convertation to opcodes
- feat(#76): add one more puzzle
- feat(#76): add descriptor to Super class
- feat(#76): verify correct scope usage to store descriptor
- feat(#76): parse scope descriptor from xmir
- feat(#76): fix linter mistakes
- feat(#76): add one more puzzle to implement invocation compilation


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the code diff in several files related to the `Super` class in the `opeo` package. The notable changes include:
- Adding a new constructor to the `Super` class with a descriptor parameter
- Updating the `Super` class to include the descriptor in the XMIR representation
- Implementing and testing the compilation of invocation opcodes in the `Invocation` class
- Adding a new utility class `OpcodeNodes` to transform `AstNode` to a list of `XmlNode`s

> The following files were skipped due to too many changes: `src/test/java/org/eolang/opeo/compilation/HasInstructions.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->