### PR TITLE
feat(#87): Implement invokevirtual compilation

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/InstanceField.java
+++ b/src/main/java/org/eolang/opeo/ast/InstanceField.java
@@ -23,7 +23,9 @@
  */
 package org.eolang.opeo.ast;
 
+import java.util.ArrayList;
 import java.util.List;
+import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -63,12 +65,16 @@ public final class InstanceField implements AstNode {
         return new Directives()
             .add("o")
             .attr("base", String.format(".%s", this.name))
+            .attr("scope", "field")
             .append(this.source.toXmir())
             .up();
     }
 
     @Override
     public List<AstNode> opcodes() {
-        throw new UnsupportedOperationException("Not implemented yet");
+        final List<AstNode> res = new ArrayList<>(0);
+        res.addAll(this.source.opcodes());
+        res.add(new Opcode(Opcodes.GETFIELD, "???owner???", this.name, "???descriptor???"));
+        return res;
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/InstanceField.java
+++ b/src/main/java/org/eolang/opeo/ast/InstanceField.java
@@ -72,6 +72,11 @@ public final class InstanceField implements AstNode {
 
     @Override
     public List<AstNode> opcodes() {
+        //@checkstyle MethodBodyCommentsCheck (10 lines)
+        // @todo #86:90min Implement "GETFIELD" opcode compilation from 'InstanceField'.
+        //  The opcode should be compiled from the 'InstanceField' node correctly.
+        //  Right now we put dummy owner and descriptor.
+        //  Don't forget to remove this comment after the implementation is done and add new tests.
         final List<AstNode> res = new ArrayList<>(0);
         res.addAll(this.source.opcodes());
         res.add(new Opcode(Opcodes.GETFIELD, "???owner???", this.name, "???descriptor???"));

--- a/src/main/java/org/eolang/opeo/ast/Invocation.java
+++ b/src/main/java/org/eolang/opeo/ast/Invocation.java
@@ -56,6 +56,11 @@ public final class Invocation implements AstNode {
     private final List<AstNode> arguments;
 
     /**
+     * Descriptor.
+     */
+    private final String descriptor;
+
+    /**
      * Constructor.
      * @param source Source or target on which the invocation is performed
      * @param method Method name
@@ -73,6 +78,23 @@ public final class Invocation implements AstNode {
      * Constructor.
      * @param source Source or target on which the invocation is performed
      * @param method Method name
+     * @param descriptor Method descriptor
+     * @param args Arguments
+     */
+    public Invocation(
+        final AstNode source,
+        final String method,
+        final String descriptor,
+        final AstNode... args
+    ) {
+        this(source, method, Arrays.asList(args), descriptor);
+    }
+
+
+    /**
+     * Constructor.
+     * @param source Source or target on which the invocation is performed
+     * @param method Method name
      * @param arguments Arguments
      */
     public Invocation(
@@ -80,9 +102,26 @@ public final class Invocation implements AstNode {
         final String method,
         final List<AstNode> arguments
     ) {
+        this(source, method, arguments, "V()");
+    }
+
+    /**
+     * Constructor.
+     * @param source Source or target on which the invocation is performed
+     * @param method Method name
+     * @param arguments Arguments
+     * @param descriptor Descriptor
+     */
+    public Invocation(
+        final AstNode source,
+        final String method,
+        final List<AstNode> arguments,
+        final String descriptor
+    ) {
         this.source = source;
         this.method = method;
         this.arguments = arguments;
+        this.descriptor = descriptor;
     }
 
     @Override
@@ -108,6 +147,7 @@ public final class Invocation implements AstNode {
         final Directives directives = new Directives();
         directives.add("o")
             .attr("base", String.format(".%s", this.method))
+            .attr("scope", this.descriptor)
             .append(this.source.toXmir());
         this.arguments.stream().map(AstNode::toXmir).forEach(directives::append);
         return directives.up();
@@ -118,7 +158,7 @@ public final class Invocation implements AstNode {
         final List<AstNode> res = new ArrayList<>(0);
         res.addAll(this.source.opcodes());
         this.arguments.stream().map(AstNode::opcodes).forEach(res::addAll);
-        res.add(new Opcode(Opcodes.INVOKEVIRTUAL, "???owner???", this.method, "V()"));
+        res.add(new Opcode(Opcodes.INVOKEVIRTUAL, "???owner???", this.method, this.descriptor));
         return res;
     }
 

--- a/src/main/java/org/eolang/opeo/ast/Invocation.java
+++ b/src/main/java/org/eolang/opeo/ast/Invocation.java
@@ -115,11 +115,8 @@ public final class Invocation implements AstNode {
 
     @Override
     public List<AstNode> opcodes() {
-        //@checkstyle MethodBodyCommentsCheck (10 lines)
-        // @todo #76:90min Implement and test invocation opcodes compilation.
-        //  Current implementation is dummy and is used only to pass integration tests.
-        //  We need to implement and test invocation opcodes compilation.
         final List<AstNode> res = new ArrayList<>(0);
+        res.addAll(this.source.opcodes());
         this.arguments.stream().map(AstNode::opcodes).forEach(res::addAll);
         res.add(new Opcode(Opcodes.INVOKEVIRTUAL, "V", this.method, "V()"));
         return res;

--- a/src/main/java/org/eolang/opeo/ast/Invocation.java
+++ b/src/main/java/org/eolang/opeo/ast/Invocation.java
@@ -118,7 +118,7 @@ public final class Invocation implements AstNode {
         final List<AstNode> res = new ArrayList<>(0);
         res.addAll(this.source.opcodes());
         this.arguments.stream().map(AstNode::opcodes).forEach(res::addAll);
-        res.add(new Opcode(Opcodes.INVOKEVIRTUAL, "V", this.method, "V()"));
+        res.add(new Opcode(Opcodes.INVOKEVIRTUAL, "???owner???", this.method, "V()"));
         return res;
     }
 

--- a/src/main/java/org/eolang/opeo/ast/Invocation.java
+++ b/src/main/java/org/eolang/opeo/ast/Invocation.java
@@ -80,6 +80,7 @@ public final class Invocation implements AstNode {
      * @param method Method name
      * @param descriptor Method descriptor
      * @param args Arguments
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     public Invocation(
         final AstNode source,
@@ -89,7 +90,6 @@ public final class Invocation implements AstNode {
     ) {
         this(source, method, Arrays.asList(args), descriptor);
     }
-
 
     /**
      * Constructor.
@@ -111,6 +111,7 @@ public final class Invocation implements AstNode {
      * @param method Method name
      * @param arguments Arguments
      * @param descriptor Descriptor
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     public Invocation(
         final AstNode source,

--- a/src/main/java/org/eolang/opeo/ast/Literal.java
+++ b/src/main/java/org/eolang/opeo/ast/Literal.java
@@ -61,7 +61,13 @@ public final class Literal implements AstNode {
         } else if (this.object instanceof String) {
             result = Collections.singletonList(Literal.opcode((String) this.object));
         } else {
-            throw new UnsupportedOperationException("Not implemented yet");
+            throw new IllegalArgumentException(
+                String.format(
+                    "Unsupported literal type %s, value is %s",
+                    this.object.getClass().getName(),
+                    this.object
+                )
+            );
         }
         return result;
     }

--- a/src/main/java/org/eolang/opeo/ast/Reference.java
+++ b/src/main/java/org/eolang/opeo/ast/Reference.java
@@ -74,6 +74,6 @@ public final class Reference implements AstNode {
 
     @Override
     public List<AstNode> opcodes() {
-        throw new UnsupportedOperationException("Not implemented yet");
+        return this.ref.get().opcodes();
     }
 }

--- a/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
+++ b/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
@@ -210,7 +210,20 @@ public final class OpeoNodes {
             } else {
                 arguments = Collections.emptyList();
             }
-            result = new Invocation(target, base.substring(1), arguments);
+            result = new Invocation(
+                target,
+                base.substring(1),
+                arguments,
+                node.attribute("scope")
+                    .orElseThrow(
+                        () -> new IllegalArgumentException(
+                            String.format(
+                                "Can't find descriptor for invocation of '%s'",
+                                base
+                            )
+                        )
+                    )
+            );
         } else {
             throw new IllegalArgumentException(
                 String.format("Can't recognize node: %n%s%n", node)

--- a/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
+++ b/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
@@ -32,6 +32,7 @@ import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.ast.Add;
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.Constructor;
+import org.eolang.opeo.ast.InstanceField;
 import org.eolang.opeo.ast.Invocation;
 import org.eolang.opeo.ast.Label;
 import org.eolang.opeo.ast.Literal;
@@ -199,31 +200,37 @@ public final class OpeoNodes {
             }
             result = new Constructor(type, arguments);
         } else if (!base.isEmpty() && base.charAt(0) == '.') {
-            final List<XmlNode> inner = node.children().collect(Collectors.toList());
-            final AstNode target = OpeoNodes.node(inner.get(0));
-            final List<AstNode> arguments;
-            if (inner.size() > 1) {
-                arguments = inner.subList(1, inner.size())
-                    .stream()
-                    .map(OpeoNodes::node)
-                    .collect(Collectors.toList());
+            if (node.hasAttribute("scope", "field")) {
+                final List<XmlNode> inner = node.children().collect(Collectors.toList());
+                final AstNode target = OpeoNodes.node(inner.get(0));
+                result = new InstanceField(target, base.substring(1));
             } else {
-                arguments = Collections.emptyList();
-            }
-            result = new Invocation(
-                target,
-                base.substring(1),
-                arguments,
-                node.attribute("scope")
-                    .orElseThrow(
-                        () -> new IllegalArgumentException(
-                            String.format(
-                                "Can't find descriptor for invocation of '%s'",
-                                base
+                final List<XmlNode> inner = node.children().collect(Collectors.toList());
+                final AstNode target = OpeoNodes.node(inner.get(0));
+                final List<AstNode> arguments;
+                if (inner.size() > 1) {
+                    arguments = inner.subList(1, inner.size())
+                        .stream()
+                        .map(OpeoNodes::node)
+                        .collect(Collectors.toList());
+                } else {
+                    arguments = Collections.emptyList();
+                }
+                result = new Invocation(
+                    target,
+                    base.substring(1),
+                    arguments,
+                    node.attribute("scope")
+                        .orElseThrow(
+                            () -> new IllegalArgumentException(
+                                String.format(
+                                    "Can't find descriptor for invocation of '%s'",
+                                    base
+                                )
                             )
                         )
-                    )
-            );
+                );
+            }
         } else {
             throw new IllegalArgumentException(
                 String.format("Can't recognize node: %n%s%n", node)

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
@@ -530,6 +530,5 @@ public final class DecompilerMachine {
                     );
             }
         }
-
     }
 }

--- a/src/test/java/org/eolang/opeo/ast/InvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InvocationTest.java
@@ -24,8 +24,10 @@
 package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Transformers;
 import org.xembly.Xembler;
@@ -62,6 +64,26 @@ class InvocationTest {
             XhtmlMatchers.hasXPaths(
                 "/o[@base='.bar']/o[@base='.new']/o[@base='foo']",
                 "/o[@base='.bar']/o[@base='string' and @data='bytes' and text()='62 61 7A']"
+            )
+        );
+    }
+
+    @Test
+    void transformsToOpcodes() {
+        final String name = "bar";
+        final String constant = "baz";
+        MatcherAssert.assertThat(
+            "Can't transform 'invocation' to correct opcodes",
+            new OpcodeNodes(new Invocation(new This(), name, new Literal(constant))).opcodes(),
+            new HasInstructions(
+                new HasInstructions.Instruction(Opcodes.ALOAD, 0),
+                new HasInstructions.Instruction(Opcodes.LDC, constant),
+                new HasInstructions.Instruction(
+                    Opcodes.INVOKEVIRTUAL,
+                    "???owner???",
+                    name,
+                    "(Ljava/lang/String;)Ljava/lang/String;"
+                )
             )
         );
     }

--- a/src/test/java/org/eolang/opeo/ast/InvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InvocationTest.java
@@ -29,7 +29,6 @@ import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
-import org.xembly.Directive;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Transformers;
 import org.xembly.Xembler;

--- a/src/test/java/org/eolang/opeo/ast/InvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InvocationTest.java
@@ -28,6 +28,7 @@ import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Transformers;
 import org.xembly.Xembler;
@@ -83,6 +84,26 @@ class InvocationTest {
                     "???owner???",
                     name,
                     "(Ljava/lang/String;)Ljava/lang/String;"
+                )
+            )
+        );
+    }
+
+    @Test
+    void transformsToOpcodesWithoutArguments() {
+        final String name = "toString";
+        MatcherAssert.assertThat(
+            "Can't transform 'local1.toSting()' to correct opcodes",
+            new OpcodeNodes(
+                new Invocation(new Variable(Type.getType(String.class), 1), name)
+            ).opcodes(),
+            new HasInstructions(
+                new HasInstructions.Instruction(Opcodes.ALOAD, 1),
+                new HasInstructions.Instruction(
+                    Opcodes.INVOKEVIRTUAL,
+                    "???owner???",
+                    name,
+                    "()Ljava/lang/String;"
                 )
             )
         );

--- a/src/test/java/org/eolang/opeo/compilation/HasInstructions.java
+++ b/src/test/java/org/eolang/opeo/compilation/HasInstructions.java
@@ -160,10 +160,12 @@ public final class HasInstructions extends TypeSafeMatcher<List<XmlNode>> {
                 if (!operand.equals(expected)) {
                     this.warnings.add(
                         String.format(
-                            "Bytecode instruction at %d index should have opcode with operands %s but got %s instead",
+                            "Bytecode instruction at %d index should have opcode with operands %s but got %s instead, ('%s' != '%s')",
                             index,
                             operand,
-                            expected
+                            expected,
+                            new HexString(operand.text()).decode(),
+                            new HexString(expected.text()).decode()
                         )
                     );
                     result = false;


### PR DESCRIPTION
Implement compilation of Invocation AST node to INVOKEVIRTUAL command.

Closes: #86.
____
History:
- feat(#86): remove the puzzle for 86 issue
- feat(#86): add failing test
- feat(#86): add one more test
- feat(#86): check correct saving of descriptor to scope attribute
- feat(#86): read descriptor from XMIR during compilation
- feat(#86): parse fields
- feat(#86): add one more puzzle
- feat(#86): fix all linter mistakes


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing the compilation of invocation opcodes in the EO programming language. 

### Detailed summary
- Added `Invocation` constructor with descriptor parameter
- Modified `Invocation` toXmir method to include the descriptor in the scope attribute
- Modified `Invocation` opcodes method to generate correct opcodes for invocation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->