### PR TITLE
feat(#89): Implement compilation of 'InstanceField' AST node to opcodes

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/Attributes.java
+++ b/src/main/java/org/eolang/opeo/ast/Attributes.java
@@ -34,6 +34,7 @@ import org.cactoos.map.MapEntry;
  * This class is useful when we need to preserve the information about types of AST nodes.
  * @since 0.1
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class Attributes {
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/Attributes.java
+++ b/src/main/java/org/eolang/opeo/ast/Attributes.java
@@ -165,15 +165,21 @@ public final class Attributes {
      * @return Map
      */
     private static Map<String, String> fromEntries(final String... entries) {
+        final Map<String, String> result;
         final int length = entries.length;
-        if (length % 2 != 0) {
-            throw new IllegalArgumentException("Entries must be even");
+        if (length == 0) {
+            result = new LinkedHashMap<>(0);
+        } else {
+            if (length % 2 != 0) {
+                throw new IllegalArgumentException("Entries must be even");
+            }
+            final Map<String, String> res = new LinkedHashMap<>(0);
+            for (int idx = 0; idx < length; idx += 2) {
+                res.put(entries[idx], entries[idx + 1]);
+            }
+            result = res;
         }
-        final Map<String, String> res = new LinkedHashMap<>(0);
-        for (int idx = 0; idx < length; idx += 2) {
-            res.put(entries[idx], entries[idx + 1]);
-        }
-        return res;
+        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/Attributes.java
+++ b/src/main/java/org/eolang/opeo/ast/Attributes.java
@@ -188,8 +188,32 @@ public final class Attributes {
      * @return Map
      */
     private static Map<String, String> parse(final String raw) {
-        return Arrays.stream(raw.split("\\|")).map(entry -> entry.split("="))
-            .map(entry -> new MapEntry<>(entry[0], entry[1]))
-            .collect(Collectors.toMap(MapEntry::getKey, MapEntry::getValue));
+        try {
+            return Arrays.stream(raw.split("\\|")).map(entry -> entry.split("="))
+                .peek(Attributes::entrySize)
+                .map(entry -> new MapEntry<>(entry[0], entry[1]))
+                .collect(Collectors.toMap(MapEntry::getKey, MapEntry::getValue));
+        } catch (final IllegalArgumentException exception) {
+            throw new IllegalArgumentException(
+                String.format("Can't parse attributes '%s'", raw),
+                exception
+            );
+        }
+    }
+
+    /**
+     * Check entry size.
+     * @param entry Entry to check
+     */
+    private static void entrySize(final String... entry) {
+        if (entry.length != 2) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Entry must have two parts, but it has %d: %s",
+                    entry.length,
+                    Arrays.toString(entry)
+                )
+            );
+        }
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Attributes.java
+++ b/src/main/java/org/eolang/opeo/ast/Attributes.java
@@ -1,0 +1,71 @@
+package org.eolang.opeo.ast;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.cactoos.map.MapEntry;
+
+public final class Attributes {
+
+    private final LinkedHashMap<String, String> all;
+
+    public Attributes(final String raw) {
+        this(Attributes.parse(raw));
+    }
+
+    public Attributes(final String... entries) {
+        this(Attributes.fromEntries(entries));
+    }
+
+    public Attributes(final Map<String, String> all) {
+        this.all = new LinkedHashMap<>(all);
+    }
+
+    @Override
+    public String toString() {
+        return this.all.entrySet().stream()
+            .map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue()))
+            .collect(Collectors.joining("|"));
+    }
+
+    public String descriptor() {
+        return this.find("descriptor");
+    }
+
+    public String type() {
+        return this.find("type");
+    }
+
+    public String owner() {
+        return this.find("owner");
+    }
+
+    private String find(final String key) {
+        if (this.all.containsKey(key)) {
+            return this.all.get(key);
+        } else {
+            throw new IllegalArgumentException(
+                String.format("'%s' is not defined: %s", key, this));
+        }
+    }
+
+    private static Map<String, String> fromEntries(final String[] entries) {
+        final int length = entries.length;
+        if (length % 2 != 0) {
+            throw new IllegalArgumentException("Entries must be even");
+        }
+        final Map<String, String> res = new LinkedHashMap<>(0);
+        for (int idx = 0; idx < length; idx += 2) {
+            res.put(entries[idx], entries[idx + 1]);
+        }
+        return res;
+    }
+
+    private static Map<String, String> parse(final String raw) {
+        return Arrays.stream(raw.split("\\|")).map(entry -> entry.split("="))
+            .map(entry -> new MapEntry<>(entry[0], entry[1]))
+            .collect(Collectors.toMap(MapEntry::getKey, MapEntry::getValue));
+    }
+
+}

--- a/src/main/java/org/eolang/opeo/ast/Attributes.java
+++ b/src/main/java/org/eolang/opeo/ast/Attributes.java
@@ -127,6 +127,24 @@ public final class Attributes {
     }
 
     /**
+     * Get name attribute.
+     * @return Name value.
+     */
+    public String name() {
+        return this.find("name");
+    }
+
+    /**
+     * Set name attribute.
+     * @param name Name
+     * @return This object
+     */
+    public Attributes name(final String name) {
+        this.all.put("name", name);
+        return this;
+    }
+
+    /**
      * Find attribute.
      * @param key Attribute key
      * @return Attribute value

--- a/src/main/java/org/eolang/opeo/ast/Attributes.java
+++ b/src/main/java/org/eolang/opeo/ast/Attributes.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.opeo.ast;
 
 import java.util.Arrays;
@@ -6,20 +29,40 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.cactoos.map.MapEntry;
 
+/**
+ * Type attributes of AST nodes.
+ * This class is useful when we need to preserve the information about types of AST nodes.
+ * @since 0.1
+ */
 public final class Attributes {
 
-    private final LinkedHashMap<String, String> all;
+    /**
+     * All attributes.
+     */
+    private final Map<String, String> all;
 
+    /**
+     * Constructor.
+     * @param raw Raw attributes
+     */
     public Attributes(final String raw) {
         this(Attributes.parse(raw));
     }
 
+    /**
+     * Constructor.
+     * @param entries Attribute entry pairs.
+     */
     public Attributes(final String... entries) {
         this(Attributes.fromEntries(entries));
     }
 
+    /**
+     * Constructor.
+     * @param all All attributes.
+     */
     public Attributes(final Map<String, String> all) {
-        this.all = new LinkedHashMap<>(all);
+        this.all = all;
     }
 
     @Override
@@ -29,28 +72,81 @@ public final class Attributes {
             .collect(Collectors.joining("|"));
     }
 
+    /**
+     * Get descriptor attribute.
+     * @return Descriptor value.
+     */
     public String descriptor() {
         return this.find("descriptor");
     }
 
+    /**
+     * Set descriptor attribute.
+     * @param descriptor Descriptor
+     * @return This object
+     */
+    public Attributes descriptor(final String descriptor) {
+        this.all.put("descriptor", descriptor);
+        return this;
+    }
+
+    /**
+     * Get type attribute.
+     * @return Type value.
+     */
     public String type() {
         return this.find("type");
     }
 
+    /**
+     * Set type attribute.
+     * @param type Type
+     * @return This object
+     */
+    public Attributes type(final String type) {
+        this.all.put("type", type);
+        return this;
+    }
+
+    /**
+     * Get owner attribute.
+     * @return Owner value.
+     */
     public String owner() {
         return this.find("owner");
     }
 
+    /**
+     * Set owner attribute.
+     * @param owner Owner
+     * @return This object
+     */
+    public Attributes owner(final String owner) {
+        this.all.put("owner", owner);
+        return this;
+    }
+
+    /**
+     * Find attribute.
+     * @param key Attribute key
+     * @return Attribute value
+     */
     private String find(final String key) {
         if (this.all.containsKey(key)) {
             return this.all.get(key);
         } else {
             throw new IllegalArgumentException(
-                String.format("'%s' is not defined: %s", key, this));
+                String.format("'%s' is not defined: %s", key, this)
+            );
         }
     }
 
-    private static Map<String, String> fromEntries(final String[] entries) {
+    /**
+     * Convert entries to map.
+     * @param entries Entries
+     * @return Map
+     */
+    private static Map<String, String> fromEntries(final String... entries) {
         final int length = entries.length;
         if (length % 2 != 0) {
             throw new IllegalArgumentException("Entries must be even");
@@ -62,10 +158,14 @@ public final class Attributes {
         return res;
     }
 
+    /**
+     * Parse raw attributes.
+     * @param raw Raw attributes
+     * @return Map
+     */
     private static Map<String, String> parse(final String raw) {
         return Arrays.stream(raw.split("\\|")).map(entry -> entry.split("="))
             .map(entry -> new MapEntry<>(entry[0], entry[1]))
             .collect(Collectors.toMap(MapEntry::getKey, MapEntry::getValue));
     }
-
 }

--- a/src/main/java/org/eolang/opeo/ast/InstanceField.java
+++ b/src/main/java/org/eolang/opeo/ast/InstanceField.java
@@ -46,13 +46,36 @@ public final class InstanceField implements AstNode {
     private final String name;
 
     /**
+     * Field descriptor.
+     */
+    private final String descriptor;
+
+    /**
      * Constructor.
      * @param source Object reference from which the field is accessed
      * @param name Field name
      */
-    public InstanceField(final AstNode source, final String name) {
+    public InstanceField(
+        final AstNode source,
+        final String name
+    ) {
+        this(source, name, "I");
+    }
+
+    /**
+     * Constructor.
+     * @param source Object reference from which the field is accessed
+     * @param name Field name
+     * @param descriptor Field descriptor
+     */
+    public InstanceField(
+        final AstNode source,
+        final String name,
+        final String descriptor
+    ) {
         this.source = source;
         this.name = name;
+        this.descriptor = descriptor.replace("field|", "");
     }
 
     @Override
@@ -65,21 +88,16 @@ public final class InstanceField implements AstNode {
         return new Directives()
             .add("o")
             .attr("base", String.format(".%s", this.name))
-            .attr("scope", "field")
+            .attr("scope", String.format("field|%s", this.descriptor))
             .append(this.source.toXmir())
             .up();
     }
 
     @Override
     public List<AstNode> opcodes() {
-        //@checkstyle MethodBodyCommentsCheck (10 lines)
-        // @todo #86:90min Implement "GETFIELD" opcode compilation from 'InstanceField'.
-        //  The opcode should be compiled from the 'InstanceField' node correctly.
-        //  Right now we put dummy owner and descriptor.
-        //  Don't forget to remove this comment after the implementation is done and add new tests.
         final List<AstNode> res = new ArrayList<>(0);
         res.addAll(this.source.opcodes());
-        res.add(new Opcode(Opcodes.GETFIELD, "???owner???", this.name, "???descriptor???"));
+        res.add(new Opcode(Opcodes.GETFIELD, "???owner???", this.name, this.descriptor));
         return res;
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/InstanceField.java
+++ b/src/main/java/org/eolang/opeo/ast/InstanceField.java
@@ -41,14 +41,9 @@ public final class InstanceField implements AstNode {
     private final AstNode source;
 
     /**
-     * Field name.
+     * Field attributes.
      */
-    private final String name;
-
-    /**
-     * Field descriptor.
-     */
-    private final String descriptor;
+    private final Attributes attributes;
 
     /**
      * Constructor.
@@ -73,22 +68,46 @@ public final class InstanceField implements AstNode {
         final String name,
         final String descriptor
     ) {
+        this(source, new Attributes().name(name).type("field").descriptor(descriptor));
+    }
+
+    /**
+     * Constructor.
+     * @param source Object reference from which the field is accessed
+     * @param name Field name
+     * @param descriptor Field descriptor
+     * @param owner Field owner
+     */
+    public InstanceField(
+        final AstNode source,
+        final String name,
+        final String descriptor,
+        final String owner
+    ) {
+        this(source, new Attributes().name(name).type("field").descriptor(descriptor).owner(owner));
+    }
+
+    /**
+     * Constructor.
+     * @param source Object reference from which the field is accessed
+     * @param attributes Field attributes
+     */
+    public InstanceField(final AstNode source, final Attributes attributes) {
         this.source = source;
-        this.name = name;
-        this.descriptor = descriptor.replace("field|", "");
+        this.attributes = attributes;
     }
 
     @Override
     public String print() {
-        return String.format("%s.%s", this.source.print(), this.name);
+        return String.format("%s.%s", this.source.print(), this.attributes.name());
     }
 
     @Override
     public Iterable<Directive> toXmir() {
         return new Directives()
             .add("o")
-            .attr("base", String.format(".%s", this.name))
-            .attr("scope", String.format("field|%s", this.descriptor))
+            .attr("base", String.format(".%s", this.attributes.name()))
+            .attr("scope", String.format(this.attributes.descriptor()))
             .append(this.source.toXmir())
             .up();
     }
@@ -97,7 +116,14 @@ public final class InstanceField implements AstNode {
     public List<AstNode> opcodes() {
         final List<AstNode> res = new ArrayList<>(0);
         res.addAll(this.source.opcodes());
-        res.add(new Opcode(Opcodes.GETFIELD, "???owner???", this.name, this.descriptor));
+        res.add(
+            new Opcode(
+                Opcodes.GETFIELD,
+                this.attributes.owner(),
+                this.attributes.name(),
+                this.attributes.descriptor()
+            )
+        );
         return res;
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/InstanceField.java
+++ b/src/main/java/org/eolang/opeo/ast/InstanceField.java
@@ -74,22 +74,6 @@ public final class InstanceField implements AstNode {
     /**
      * Constructor.
      * @param source Object reference from which the field is accessed
-     * @param name Field name
-     * @param descriptor Field descriptor
-     * @param owner Field owner
-     */
-    public InstanceField(
-        final AstNode source,
-        final String name,
-        final String descriptor,
-        final String owner
-    ) {
-        this(source, new Attributes().name(name).type("field").descriptor(descriptor).owner(owner));
-    }
-
-    /**
-     * Constructor.
-     * @param source Object reference from which the field is accessed
      * @param attributes Field attributes
      */
     public InstanceField(final AstNode source, final Attributes attributes) {
@@ -107,7 +91,7 @@ public final class InstanceField implements AstNode {
         return new Directives()
             .add("o")
             .attr("base", String.format(".%s", this.attributes.name()))
-            .attr("scope", String.format(this.attributes.descriptor()))
+            .attr("scope", this.attributes)
             .append(this.source.toXmir())
             .up();
     }

--- a/src/main/java/org/eolang/opeo/ast/Invocation.java
+++ b/src/main/java/org/eolang/opeo/ast/Invocation.java
@@ -72,23 +72,6 @@ public final class Invocation implements AstNode {
     /**
      * Constructor.
      * @param source Source or target on which the invocation is performed
-     * @param method Method name
-     * @param descriptor Method descriptor
-     * @param args Arguments
-     * @checkstyle ParameterNumberCheck (5 lines)
-     */
-    public Invocation(
-        final AstNode source,
-        final String method,
-        final String descriptor,
-        final AstNode... args
-    ) {
-        this(source, method, Arrays.asList(args), descriptor);
-    }
-
-    /**
-     * Constructor.
-     * @param source Source or target on which the invocation is performed
      * @param attributes Method attributes
      * @param args Arguments
      */

--- a/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
+++ b/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
@@ -221,17 +221,18 @@ public final class OpeoNodes {
                 }
                 result = new Invocation(
                     target,
-                    base.substring(1),
-                    arguments,
-                    node.attribute("scope")
-                        .orElseThrow(
-                            () -> new IllegalArgumentException(
-                                String.format(
-                                    "Can't find descriptor for invocation of '%s'",
-                                    base
+                    new Attributes(
+                        node.attribute("scope")
+                            .orElseThrow(
+                                () -> new IllegalArgumentException(
+                                    String.format(
+                                        "Can't find descriptor for invocation of '%s'",
+                                        base
+                                    )
                                 )
                             )
-                        )
+                    ),
+                    arguments
                 );
             }
         } else {

--- a/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
+++ b/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
@@ -31,6 +31,7 @@ import org.eolang.jeo.representation.xmir.XmlInstruction;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.ast.Add;
 import org.eolang.opeo.ast.AstNode;
+import org.eolang.opeo.ast.Attributes;
 import org.eolang.opeo.ast.Constructor;
 import org.eolang.opeo.ast.InstanceField;
 import org.eolang.opeo.ast.Invocation;
@@ -204,7 +205,7 @@ public final class OpeoNodes {
                 final List<XmlNode> inner = node.children().collect(Collectors.toList());
                 final AstNode target = OpeoNodes.node(inner.get(0));
                 result = new InstanceField(
-                    target, base.substring(1), node.attribute("scope").orElseThrow()
+                    target, new Attributes(node.attribute("scope").orElseThrow())
                 );
             } else {
                 final List<XmlNode> inner = node.children().collect(Collectors.toList());

--- a/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
+++ b/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
@@ -200,10 +200,12 @@ public final class OpeoNodes {
             }
             result = new Constructor(type, arguments);
         } else if (!base.isEmpty() && base.charAt(0) == '.') {
-            if (node.hasAttribute("scope", "field")) {
+            if (base.contains("field|")) {
                 final List<XmlNode> inner = node.children().collect(Collectors.toList());
                 final AstNode target = OpeoNodes.node(inner.get(0));
-                result = new InstanceField(target, base.substring(1));
+                result = new InstanceField(
+                    target, base.substring(1), node.attribute("scope").orElseThrow()
+                );
             } else {
                 final List<XmlNode> inner = node.children().collect(Collectors.toList());
                 final AstNode target = OpeoNodes.node(inner.get(0));

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
@@ -286,10 +286,13 @@ public final class DecompilerMachine {
 
         @Override
         public void handle(final Instruction instruction) {
+            final String owner = (String) instruction.operand(0);
+            final String name = (String) instruction.operand(1);
+            final String descriptor = (String) instruction.operand(2);
             DecompilerMachine.this.stack.push(
                 new InstanceField(
                     DecompilerMachine.this.stack.pop(),
-                    (String) instruction.operand(1)
+                    new Attributes().name(name).descriptor(descriptor).owner(owner)
                 )
             );
         }

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
@@ -35,6 +35,7 @@ import org.cactoos.map.MapOf;
 import org.eolang.opeo.Instruction;
 import org.eolang.opeo.ast.Add;
 import org.eolang.opeo.ast.AstNode;
+import org.eolang.opeo.ast.Attributes;
 import org.eolang.opeo.ast.Constructor;
 import org.eolang.opeo.ast.InstanceField;
 import org.eolang.opeo.ast.Invocation;
@@ -411,6 +412,7 @@ public final class DecompilerMachine {
     private class InvokevirtualHandler implements InstructionHandler {
         @Override
         public void handle(final Instruction instruction) {
+            final String owner = (String) instruction.operand(0);
             final String method = (String) instruction.operand(1);
             final String descriptor = (String) instruction.operand(2);
             final List<AstNode> args = DecompilerMachine.this.popArguments(
@@ -418,7 +420,9 @@ public final class DecompilerMachine {
             );
             final AstNode source = DecompilerMachine.this.stack.pop();
             DecompilerMachine.this.stack.push(
-                new Invocation(source, method, args)
+                new Invocation(
+                    source, new Attributes().name(method).descriptor(descriptor).owner(owner), args
+                )
             );
         }
 

--- a/src/test/java/org/eolang/opeo/ast/AttributesTest.java
+++ b/src/test/java/org/eolang/opeo/ast/AttributesTest.java
@@ -1,0 +1,47 @@
+package org.eolang.opeo.ast;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class AttributesTest {
+
+    @ParameterizedTest(name = "Converts \"{1}\" attributes to a single string \"{0}\"")
+    @CsvSource({
+        "scope=foo, 'scope,foo,'",
+        "descriptor=I|type=field|owner=Lorg/eolang/opeo/ast/Invocation;, 'descriptor,I,type,field,owner,Lorg/eolang/opeo/ast/Invocation;'",
+        "descriptor=()V|type=method|owner=Lorg/eolang/opeo/ast/Invocation;, 'descriptor,()V,type,method,owner,Lorg/eolang/opeo/ast/Invocation;'",
+    })
+    void convertsToString(final String expected, final String attributes) {
+        MatcherAssert.assertThat(
+            "Can't convert to string",
+            new Attributes(attributes.replace("'", "").split(",")).toString(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    void parsesRawString() {
+        final Attributes actual = new Attributes(
+            "descriptor=I|type=field|owner=Lorg/eolang/opeo/ast/Invocation;");
+        MatcherAssert.assertThat(
+            "Can't parse descriptor from raw string",
+            actual.descriptor(),
+            Matchers.equalTo("I")
+        );
+        MatcherAssert.assertThat(
+            "Can't parse type from raw string",
+            actual.type(),
+            Matchers.equalTo("field")
+        );
+        MatcherAssert.assertThat(
+            "Can't parse owner from raw string",
+            actual.owner(),
+            Matchers.equalTo("Lorg/eolang/opeo/ast/Invocation;")
+        );
+    }
+
+
+}

--- a/src/test/java/org/eolang/opeo/ast/AttributesTest.java
+++ b/src/test/java/org/eolang/opeo/ast/AttributesTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.opeo.ast;
 
 import org.hamcrest.MatcherAssert;
@@ -6,13 +29,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-class AttributesTest {
+/**
+ * Test case for {@link Attributes}.
+ * @since 0.1
+ */
+final class AttributesTest {
 
     @ParameterizedTest(name = "Converts \"{1}\" attributes to a single string \"{0}\"")
     @CsvSource({
         "scope=foo, 'scope,foo,'",
         "descriptor=I|type=field|owner=Lorg/eolang/opeo/ast/Invocation;, 'descriptor,I,type,field,owner,Lorg/eolang/opeo/ast/Invocation;'",
-        "descriptor=()V|type=method|owner=Lorg/eolang/opeo/ast/Invocation;, 'descriptor,()V,type,method,owner,Lorg/eolang/opeo/ast/Invocation;'",
+        "descriptor=()V|type=method|owner=Lorg/eolang/opeo/ast/Invocation;, 'descriptor,()V,type,method,owner,Lorg/eolang/opeo/ast/Invocation;'"
     })
     void convertsToString(final String expected, final String attributes) {
         MatcherAssert.assertThat(
@@ -25,7 +52,8 @@ class AttributesTest {
     @Test
     void parsesRawString() {
         final Attributes actual = new Attributes(
-            "descriptor=I|type=field|owner=Lorg/eolang/opeo/ast/Invocation;");
+            "descriptor=I|type=field|owner=Lorg/eolang/opeo/ast/Invocation;"
+        );
         MatcherAssert.assertThat(
             "Can't parse descriptor from raw string",
             actual.descriptor(),
@@ -42,6 +70,4 @@ class AttributesTest {
             Matchers.equalTo("Lorg/eolang/opeo/ast/Invocation;")
         );
     }
-
-
 }

--- a/src/test/java/org/eolang/opeo/ast/InstanceFieldTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InstanceFieldTest.java
@@ -73,12 +73,20 @@ class InstanceFieldTest {
 
     @Test
     void transformsToOpcodes() {
+        final String descriptor = "S";
+        final String owner = "java/lang/Object";
+        final String name = "bar";
         MatcherAssert.assertThat(
             "Can't transform to opcodes",
-            new OpcodeNodes(new InstanceField(new This(), "bar", "S")).opcodes(),
+            new OpcodeNodes(
+                new InstanceField(
+                    new This(),
+                    new Attributes("name", name, "descriptor", descriptor, "owner", owner)
+                )
+            ).opcodes(),
             new HasInstructions(
                 new HasInstructions.Instruction(Opcodes.ALOAD, 0),
-                new HasInstructions.Instruction(Opcodes.GETFIELD, "???owner???", "bar", "S")
+                new HasInstructions.Instruction(Opcodes.GETFIELD, owner, name, descriptor)
             )
         );
     }

--- a/src/test/java/org/eolang/opeo/ast/InstanceFieldTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InstanceFieldTest.java
@@ -24,9 +24,11 @@
 package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
 import org.xembly.Directives;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
@@ -65,6 +67,18 @@ class InstanceFieldTest {
                 "./o[@name='method']",
                 "./o[@name='method']/o[@base='.bar']",
                 "./o[@name='method']/o[@base='.bar']/o[@base='$']"
+            )
+        );
+    }
+
+    @Test
+    void transformsToOpcodes() {
+        MatcherAssert.assertThat(
+            "Can't transform to opcodes",
+            new OpcodeNodes(new InstanceField(new This(), "bar")).opcodes(),
+            new HasInstructions(
+                new HasInstructions.Instruction(Opcodes.ALOAD, 0),
+                new HasInstructions.Instruction(Opcodes.GETFIELD, "","bar")
             )
         );
     }

--- a/src/test/java/org/eolang/opeo/ast/InstanceFieldTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InstanceFieldTest.java
@@ -75,10 +75,10 @@ class InstanceFieldTest {
     void transformsToOpcodes() {
         MatcherAssert.assertThat(
             "Can't transform to opcodes",
-            new OpcodeNodes(new InstanceField(new This(), "bar")).opcodes(),
+            new OpcodeNodes(new InstanceField(new This(), "bar", "S")).opcodes(),
             new HasInstructions(
                 new HasInstructions.Instruction(Opcodes.ALOAD, 0),
-                new HasInstructions.Instruction(Opcodes.GETFIELD, "","bar")
+                new HasInstructions.Instruction(Opcodes.GETFIELD, "???owner???", "bar", "S")
             )
         );
     }

--- a/src/test/java/org/eolang/opeo/ast/InvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InvocationTest.java
@@ -127,8 +127,7 @@ class InvocationTest {
             new OpcodeNodes(
                 new Invocation(
                     new Variable(Type.getType(String.class), 1),
-                    new Attributes().name(name).descriptor(descriptor).owner(
-                        owner)
+                    new Attributes().name(name).descriptor(descriptor).owner(owner)
                 )
             ).opcodes(),
             new HasInstructions(

--- a/src/test/java/org/eolang/opeo/ast/InvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InvocationTest.java
@@ -76,14 +76,15 @@ class InvocationTest {
             new Xembler(
                 new Invocation(
                     new This(),
-                    "bar",
-                    "(Ljava/lang/String;)Ljava/lang/String;",
+                    new Attributes().name("bar")
+                        .descriptor("(Ljava/lang/String;)Ljava/lang/String;")
+                        .owner("some/Owner"),
                     new Literal("baz")
                 ).toXmir(),
                 new Transformers.Node()
             ).xmlQuietly(),
             XhtmlMatchers.hasXPaths(
-                "/o[@base='.bar' and @scope='(Ljava/lang/String;)Ljava/lang/String;']"
+                "/o[@base='.bar' and contains(@scope,'(Ljava/lang/String;)Ljava/lang/String;')]"
             )
         );
     }
@@ -93,17 +94,22 @@ class InvocationTest {
         final String name = "bar";
         final String constant = "baz";
         final String descriptor = "(Ljava/lang/String;)Ljava/lang/String;";
+        final String owner = "some/instruction/Owner";
         MatcherAssert.assertThat(
             "Can't transform 'invocation' to correct opcodes",
             new OpcodeNodes(
-                new Invocation(new This(), name, descriptor, new Literal(constant))
+                new Invocation(
+                    new This(),
+                    new Attributes().descriptor(descriptor).name(name).owner(owner),
+                    new Literal(constant)
+                )
             ).opcodes(),
             new HasInstructions(
                 new HasInstructions.Instruction(Opcodes.ALOAD, 0),
                 new HasInstructions.Instruction(Opcodes.LDC, constant),
                 new HasInstructions.Instruction(
                     Opcodes.INVOKEVIRTUAL,
-                    "???owner???",
+                    owner,
                     name,
                     descriptor
                 )
@@ -115,16 +121,21 @@ class InvocationTest {
     void transformsToOpcodesWithoutArguments() {
         final String name = "toString";
         final String descriptor = "()Ljava/lang/String;";
+        final String owner = "random/Owner";
         MatcherAssert.assertThat(
             "Can't transform 'local1.toSting()' to correct opcodes",
             new OpcodeNodes(
-                new Invocation(new Variable(Type.getType(String.class), 1), name, descriptor)
+                new Invocation(
+                    new Variable(Type.getType(String.class), 1),
+                    new Attributes().name(name).descriptor(descriptor).owner(
+                        owner)
+                )
             ).opcodes(),
             new HasInstructions(
                 new HasInstructions.Instruction(Opcodes.ALOAD, 1),
                 new HasInstructions.Instruction(
                     Opcodes.INVOKEVIRTUAL,
-                    "???owner???",
+                    owner,
                     name,
                     descriptor
                 )


### PR DESCRIPTION
Implement compilation of InstanceField AST node to bytecode opcodes.

Closes: #89.
____
History:
- feat(#89): add unit test to check bytecode transformation
- feat(#89): save field scope
- feat(#89): add attributes
- feat(#89): fix all qulice suggestions
- feat(#89): add name to Attributes
- feat(#89): use attributes in instance field
- feat(#89): use Attributes in invokation
- feat(#89): use correct constructor of Invocation in DecompilerMachine
- feat(#89): save owner to instance field scope attribute
- feat(#89): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the code diff by introducing a new `Attributes` class to represent field and method attributes. 

### Detailed summary
- Added `Attributes` class to represent field and method attributes
- Refactored `InstanceField` and `Invocation` classes to use `Attributes`
- Updated relevant tests to use `Attributes`

> The following files were skipped due to too many changes: `src/main/java/org/eolang/opeo/ast/Invocation.java`, `src/main/java/org/eolang/opeo/ast/Attributes.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->