### PR TITLE
feat(#103): add `sourcesDir` and `outputDir` for CompileMojo

### DIFF
--- a/src/it/decompile-compile/pom.xml
+++ b/src/it/decompile-compile/pom.xml
@@ -51,10 +51,29 @@ SOFTWARE.
             </goals>
           </execution>
           <execution>
+            <id>opeo-decompile-to-other-dir</id>
+            <goals>
+              <goal>decompile</goal>
+            </goals>
+            <configuration>
+              <outputDir>${project.build.directory}/generated-sources/opeo-xmir-second-try</outputDir>
+            </configuration>
+          </execution>
+          <execution>
             <id>opeo-compile</id>
             <goals>
               <goal>compile</goal>
             </goals>
+          </execution>
+          <execution>
+            <id>opeo-compile-from-other-dir</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <sourceDir>${project.build.directory}/generated-sources/opeo-xmir-second-try</sourceDir>
+              <outputDir>${project.build.directory}/generated-sources/jeo-xmir-second-try</outputDir>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/it/decompile-compile/verify.groovy
+++ b/src/it/decompile-compile/verify.groovy
@@ -33,6 +33,11 @@ assert log.contains("Compiling EO sources from")
 assert log.contains("Saving new compiled EO sources to")
 assert log.contains("Compiled")
 assert log.contains("Compiled 1 sources")
+// Check compiled files.
+assert new File(basedir, 'target/generated-sources/jeo-xmir').exists()
+assert new File(basedir, 'target/generated-sources/jeo-xmir-second-try').exists()
+assert new File(basedir, 'target/generated-sources/opeo-xmir').exists()
+assert new File(basedir, 'target/generated-sources/opeo-xmir-second-try').exists()
 // Check success.
 assert log.contains("BUILD SUCCESS")
 

--- a/src/main/java/org/eolang/opeo/CompileMojo.java
+++ b/src/main/java/org/eolang/opeo/CompileMojo.java
@@ -41,26 +41,36 @@ import org.eolang.opeo.compilation.Compiler;
 public final class CompileMojo extends AbstractMojo {
 
     /**
-     * Project default target directory.
-     * @since 0.1.0
+     * Source directory.
+     * Where to take opeo xmir from.
+     *
+     * @since 0.2.0
+     * @checkstyle MemberNameCheck (6 lines)
      */
-    @Parameter(defaultValue = "${project.build.directory}/generated-sources")
-    private File generated;
+    @Parameter(
+        property = "opeo.compile.sourcesDir",
+        defaultValue = "${project.build.directory}/generated-sources/opeo-xmir"
+    )
+    private File sourcesDir;
 
     /**
-     * Output directory.
-     * The default value is 'xmir'.
-     * @since 0.1.0
-     * @checkstyle MemberNameCheck (3 lines)
+     * Target directory.
+     * Where to save jeo representations to.
+     *
+     * @since 0.2.0
+     * @checkstyle MemberNameCheck (6 lines)
      */
-    @Parameter(defaultValue = "xmir")
-    private String outputDirectory;
+    @Parameter(
+        property = "opeo.compile.outputDir",
+        defaultValue = "${project.build.directory}/generated-sources/jeo-xmir"
+    )
+    private File outputDir;
 
     @Override
     public void execute() {
         new Compiler(
-            this.generated.toPath().resolve("opeo-xmir"),
-            this.generated.toPath().resolve(this.outputDirectory)
+            this.sourcesDir.toPath(),
+            this.outputDir.toPath()
         ).compile();
     }
 }

--- a/src/main/java/org/eolang/opeo/decompilation/Decompiler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/Decompiler.java
@@ -26,7 +26,6 @@ package org.eolang.opeo.decompilation;
 import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/org/eolang/opeo/decompilation/Decompiler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/Decompiler.java
@@ -60,14 +60,6 @@ public final class Decompiler {
      * Constructor.
      * @param generated The default Maven 'generated-sources' directory.
      */
-    public Decompiler(final File generated) {
-        this(generated.toPath());
-    }
-
-    /**
-     * Constructor.
-     * @param generated The default Maven 'generated-sources' directory.
-     */
     public Decompiler(final Path generated) {
         this(generated.resolve("xmir"), generated.resolve("opeo-xmir"));
     }


### PR DESCRIPTION
Add `sourcesDir` and `outputDir` for `CompileMojo`.

Closes: #103.
____
History:
- feat(#103): add sourcesDir and outputDir to CompileMojo
- feat(#103): add more checks for decompile-compile it
- feat(#103): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding new directories for generated sources and modifying the source and target directories for opeo-xmir and jeo-xmir.

### Detailed summary:
- Added new directories for generated sources: `target/generated-sources/jeo-xmir-second-try` and `target/generated-sources/opeo-xmir-second-try`
- Modified the source directory for opeo-xmir to `${project.build.directory}/generated-sources/opeo-xmir-second-try`
- Modified the target directory for jeo-xmir to `${project.build.directory}/generated-sources/jeo-xmir-second-try`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->