### PR TITLE
feat(#122): add substraction support

### DIFF
--- a/src/it/benchmark/pom.xml
+++ b/src/it/benchmark/pom.xml
@@ -31,7 +31,7 @@ SOFTWARE.
   <description>
     Integration test that checks entire benchmark suite together with the ineo-maven-plugin optimizations
     If you need to run only this test, use the following command:
-    "mvn clean install invoker:run -Dinvoker.test=optimization -DskipTests"
+    "mvn clean integration-test invoker:run -Dinvoker.test=benchmark -DskipTests"
     _____
     This integration test consists from the following steps (in order):
     1. jeo-maven-plugin:disassemble | phase:process-classes

--- a/src/it/benchmark/src/main/java/org/eolang/other/A.java
+++ b/src/it/benchmark/src/main/java/org/eolang/other/A.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.other;
+
+class A {
+    private int d;
+    A(int d) {
+        this.d = d;
+    }
+    public int get() {
+        if (d <= 0) {
+            return d;
+        }
+        return new A(d - 1).get();
+    }
+}

--- a/src/main/java/org/eolang/opeo/LabelInstruction.java
+++ b/src/main/java/org/eolang/opeo/LabelInstruction.java
@@ -1,0 +1,30 @@
+package org.eolang.opeo;
+
+import java.util.Collections;
+import java.util.List;
+import org.eolang.opeo.jeo.JeoLabel;
+import org.objectweb.asm.Label;
+
+public final class LabelInstruction implements Instruction {
+
+    private final Label label;
+
+    public LabelInstruction(final Label label) {
+        this.label = label;
+    }
+
+    @Override
+    public int opcode() {
+        return JeoLabel.LABEL_OPCODE;
+    }
+
+    @Override
+    public Object operand(final int index) {
+        return this.label;
+    }
+
+    @Override
+    public List<Object> operands() {
+        return Collections.singletonList(this.label);
+    }
+}

--- a/src/main/java/org/eolang/opeo/LabelInstruction.java
+++ b/src/main/java/org/eolang/opeo/LabelInstruction.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.opeo;
 
 import java.util.Collections;
@@ -6,10 +29,26 @@ import org.eolang.jeo.representation.xmir.AllLabels;
 import org.eolang.opeo.jeo.JeoLabel;
 import org.objectweb.asm.Label;
 
+/**
+ * Label instruction.
+ * @since 0.1
+ * @todo #122:90min Remove code duplication between LabelInstruction and JeoLabel.
+ *  LabelInstruction and JeoLabel are almost the same. We need to refactor them
+ *  and remove the code duplication. Don't forget to remove this puzzle after
+ *  refactoring. Alongside with the removing code duplication, we need to
+ *  add unit tests for LabelInstruction class.
+ */
 public final class LabelInstruction implements Instruction {
 
+    /**
+     * Label.
+     */
     private final Label label;
 
+    /**
+     * Constructor.
+     * @param label Label.
+     */
     public LabelInstruction(final Label label) {
         this.label = label;
     }
@@ -26,8 +65,6 @@ public final class LabelInstruction implements Instruction {
 
     @Override
     public List<Object> operands() {
-        return Collections.singletonList(
-            new AllLabels().uid(this.label)
-        );
+        return Collections.singletonList(new AllLabels().uid(this.label));
     }
 }

--- a/src/main/java/org/eolang/opeo/LabelInstruction.java
+++ b/src/main/java/org/eolang/opeo/LabelInstruction.java
@@ -2,6 +2,7 @@ package org.eolang.opeo;
 
 import java.util.Collections;
 import java.util.List;
+import org.eolang.jeo.representation.xmir.AllLabels;
 import org.eolang.opeo.jeo.JeoLabel;
 import org.objectweb.asm.Label;
 
@@ -20,11 +21,13 @@ public final class LabelInstruction implements Instruction {
 
     @Override
     public Object operand(final int index) {
-        return this.label;
+        return this.operands().get(index);
     }
 
     @Override
     public List<Object> operands() {
-        return Collections.singletonList(this.label);
+        return Collections.singletonList(
+            new AllLabels().uid(this.label)
+        );
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Substraction.java
+++ b/src/main/java/org/eolang/opeo/ast/Substraction.java
@@ -1,0 +1,41 @@
+package org.eolang.opeo.ast;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.objectweb.asm.Opcodes;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+public final class Substraction implements AstNode {
+
+    private final AstNode left;
+    private final AstNode right;
+
+    public Substraction(final AstNode left, final AstNode right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    @Override
+    public String print() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public Iterable<Directive> toXmir() {
+        return new Directives().add("o")
+            .attr("base", ".minus")
+            .append(this.left.toXmir())
+            .append(this.right.toXmir())
+            .up();
+    }
+
+    @Override
+    public List<AstNode> opcodes() {
+        final List<AstNode> res = new ArrayList<>(0);
+        res.addAll(this.left.opcodes());
+        res.addAll(this.right.opcodes());
+        res.add(new Opcode(Opcodes.IADD));
+        return res;
+    }
+}

--- a/src/main/java/org/eolang/opeo/ast/Substraction.java
+++ b/src/main/java/org/eolang/opeo/ast/Substraction.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.opeo.ast;
 
 import java.util.ArrayList;
@@ -16,9 +39,21 @@ import org.xembly.Directives;
  */
 public final class Substraction implements AstNode {
 
+    /**
+     * Left operand.
+     */
     private final AstNode left;
+
+    /**
+     * Right operand.
+     */
     private final AstNode right;
 
+    /**
+     * Constructor.
+     * @param left Left operand.
+     * @param right Right operand.
+     */
     public Substraction(final AstNode left, final AstNode right) {
         this.left = left;
         this.right = right;

--- a/src/main/java/org/eolang/opeo/ast/Substraction.java
+++ b/src/main/java/org/eolang/opeo/ast/Substraction.java
@@ -78,7 +78,7 @@ public final class Substraction implements AstNode {
         final List<AstNode> res = new ArrayList<>(0);
         res.addAll(this.left.opcodes());
         res.addAll(this.right.opcodes());
-        res.add(new Opcode(Opcodes.IADD));
+        res.add(new Opcode(Opcodes.ISUB));
         return res;
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Substraction.java
+++ b/src/main/java/org/eolang/opeo/ast/Substraction.java
@@ -6,6 +6,14 @@ import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
+/**
+ * Substraction output node.
+ * @since 0.1
+ * @todo #122:30min Add unit tests for Substraction class.
+ *  Add unit tests for Substraction class.
+ *  We have to test the both transformations: toXmir and opcodes.
+ *  Don't forget to remove this puzzle after adding the tests.
+ */
 public final class Substraction implements AstNode {
 
     private final AstNode left;

--- a/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
+++ b/src/main/java/org/eolang/opeo/compilation/OpeoNodes.java
@@ -39,6 +39,7 @@ import org.eolang.opeo.ast.Label;
 import org.eolang.opeo.ast.Literal;
 import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.ast.StoreLocal;
+import org.eolang.opeo.ast.Substraction;
 import org.eolang.opeo.ast.Super;
 import org.eolang.opeo.ast.This;
 import org.eolang.opeo.ast.Variable;
@@ -142,6 +143,11 @@ public final class OpeoNodes {
             final AstNode left = OpeoNodes.node(inner.get(0));
             final AstNode right = OpeoNodes.node(inner.get(1));
             result = new Add(left, right);
+        } else if (".minus".equals(base)) {
+            final List<XmlNode> inner = node.children().collect(Collectors.toList());
+            final AstNode left = OpeoNodes.node(inner.get(0));
+            final AstNode right = OpeoNodes.node(inner.get(1));
+            result = new Substraction(left, right);
         } else if ("opcode".equals(base)) {
             final XmlInstruction instruction = new XmlInstruction(node.node());
             result = new Opcode(instruction.opcode(), instruction.operands());

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
@@ -46,6 +46,7 @@ import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.ast.Reference;
 import org.eolang.opeo.ast.Root;
 import org.eolang.opeo.ast.StoreLocal;
+import org.eolang.opeo.ast.Substraction;
 import org.eolang.opeo.ast.Super;
 import org.eolang.opeo.ast.WriteField;
 import org.eolang.opeo.jeo.JeoLabel;
@@ -110,6 +111,7 @@ public final class DecompilerMachine {
             new MapEntry<>(Opcodes.ICONST_4, new IconstHandler()),
             new MapEntry<>(Opcodes.ICONST_5, new IconstHandler()),
             new MapEntry<>(Opcodes.IADD, new AddHandler()),
+            new MapEntry<>(Opcodes.ISUB, new SubstractionHandler()),
             new MapEntry<>(Opcodes.IMUL, new MulHandler()),
             new MapEntry<>(Opcodes.ILOAD, new LoadHandler(Type.INT_TYPE)),
             new MapEntry<>(Opcodes.LLOAD, new LoadHandler(Type.LONG_TYPE)),
@@ -480,6 +482,29 @@ public final class DecompilerMachine {
                 final AstNode right = DecompilerMachine.this.stack.pop();
                 final AstNode left = DecompilerMachine.this.stack.pop();
                 DecompilerMachine.this.stack.push(new Add(left, right));
+            } else {
+                DecompilerMachine.this.stack.push(
+                    new Opcode(
+                        instruction.opcode(),
+                        instruction.operands(),
+                        DecompilerMachine.this.counting()
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * Substraction instruction handler.
+     * @since 0.1
+     */
+    private class SubstractionHandler implements InstructionHandler {
+        @Override
+        public void handle(final Instruction instruction) {
+            if (instruction.opcode() == Opcodes.ISUB) {
+                final AstNode right = DecompilerMachine.this.stack.pop();
+                final AstNode left = DecompilerMachine.this.stack.pop();
+                DecompilerMachine.this.stack.push(new Substraction(left, right));
             } else {
                 DecompilerMachine.this.stack.push(
                     new Opcode(

--- a/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
@@ -28,8 +28,6 @@ import java.util.UUID;
 import org.eolang.jeo.representation.xmir.AllLabels;
 import org.eolang.opeo.LabelInstruction;
 import org.eolang.opeo.OpcodeInstruction;
-import org.eolang.opeo.compilation.OpeoNodes;
-import org.eolang.opeo.jeo.JeoLabel;
 import org.eolang.parser.xmir.Xmir;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -44,7 +42,7 @@ import org.xembly.Xembler;
  * Test case for {@link DecompilerMachine}.
  * @since 0.1
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 final class DecompilerMachineTest {
 
     /**
@@ -319,6 +317,7 @@ final class DecompilerMachineTest {
      *             return d;
      *         }
      *         return new A(d - 1).get();
+     *         }
      *     }
      * </p>
      */
@@ -344,9 +343,11 @@ final class DecompilerMachineTest {
                     new OpcodeInstruction(Opcodes.ICONST_1),
                     new OpcodeInstruction(Opcodes.ISUB),
                     new OpcodeInstruction(
-                        Opcodes.INVOKESPECIAL, "org/eolang/other/A", "<init>", "(I)V"),
+                        Opcodes.INVOKESPECIAL, "org/eolang/other/A", "<init>", "(I)V"
+                    ),
                     new OpcodeInstruction(
-                        Opcodes.INVOKEVIRTUAL, "org/eolang/other/A", "get", "()I"),
+                        Opcodes.INVOKEVIRTUAL, "org/eolang/other/A", "get", "()I"
+                    ),
                     new OpcodeInstruction(Opcodes.IRETURN)
                 );
             },


### PR DESCRIPTION
Add substraction support in order to be able handle bytecode that uses ISUB instruction.

Closes: #122.
____
History:
- feat(#122): reproduce the bug
- feat(#122): add unit unit test that reproduce the problem
- feat(#122): handle substraction
- feat(#122): fix label instruction
- feat(#122): parse substraction from XMIR
- feat(#122): fix all qulice suggestions

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Changed the command to run a specific integration test in the benchmark suite.
- Added a new class `Substraction` to handle subtraction operations in the OpeoNodes class.
- Added a new class `A` to demonstrate a simple method with an "if" clause.
- Added a new class `DecompilerMachineTest` to test the decompilation process.
- Added a new class `LabelInstruction` to handle label instructions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->