### PR TITLE
feat(#136): Handle AASTORE Bytecode Instruction Correctly

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/Reference.java
+++ b/src/main/java/org/eolang/opeo/ast/Reference.java
@@ -62,6 +62,10 @@ public final class Reference implements AstNode {
         this.ref.set(node);
     }
 
+    public AstNode object() {
+        return this.ref.get();
+    }
+
     @Override
     public String print() {
         return this.ref.get().print();

--- a/src/main/java/org/eolang/opeo/ast/Reference.java
+++ b/src/main/java/org/eolang/opeo/ast/Reference.java
@@ -62,6 +62,10 @@ public final class Reference implements AstNode {
         this.ref.set(node);
     }
 
+    /**
+     * Get the object.
+     * @return Object.
+     */
     public AstNode object() {
         return this.ref.get();
     }

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
@@ -299,18 +299,7 @@ public final class DecompilerMachine {
             final AstNode value = DecompilerMachine.this.stack.pop();
             final AstNode index = DecompilerMachine.this.stack.pop();
             final Reference array = (Reference) DecompilerMachine.this.stack.pop();
-            //@checkstyle MethodBodyCommentsCheck (10 lines)
-            // @todo #132:90min Handle array links carefully.
-            //  Currently we added an ad-hoc solution to handle array links. We should
-            //  refactor this code to handle array links in a more elegant way.
-            //  Moreover, the approach with removing the array reference from the stack is not
-            //  safe and maybe even wrong.
-//            if (DecompilerMachine.this.stack.peek() == array) {
-//                DecompilerMachine.this.stack.pop();
-//            }
             array.link(new StoreArray(array.object(), index, value));
-//            DecompilerMachine.this.stack.push(out);
-//            DecompilerMachine.this.output.push(out);
         }
     }
 
@@ -326,7 +315,6 @@ public final class DecompilerMachine {
             final Reference reference = new Reference();
             reference.link(new ArrayConstructor(size, type));
             DecompilerMachine.this.stack.push(reference);
-//            DecompilerMachine.this.output.push(reference);
         }
 
     }
@@ -399,7 +387,6 @@ public final class DecompilerMachine {
                 .descriptor((String) instruction.operand(2));
             final WriteField write = new WriteField(target, value, attributes);
             DecompilerMachine.this.stack.push(write);
-//            DecompilerMachine.this.output.push(write);
         }
 
     }
@@ -425,7 +412,6 @@ public final class DecompilerMachine {
 
         @Override
         public void handle(final Instruction ignore) {
-//            DecompilerMachine.this.stack.pop();
         }
 
     }
@@ -500,10 +486,9 @@ public final class DecompilerMachine {
             );
             Collections.reverse(args);
             final AstNode source = DecompilerMachine.this.stack.pop();
-            final Invocation invocation = new Invocation(
+            DecompilerMachine.this.stack.push(new Invocation(
                 source, new Attributes().name(method).descriptor(descriptor).owner(owner), args
-            );
-            DecompilerMachine.this.stack.push(invocation);
+            ));
         }
 
     }

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
@@ -63,6 +63,7 @@ import org.xembly.Directive;
 /**
  * Decompiler machine.
  * @since 0.1
+ * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
 public final class DecompilerMachine {
 
@@ -70,8 +71,6 @@ public final class DecompilerMachine {
      * Output Stack.
      */
     private final Deque<AstNode> stack;
-
-    private final Deque<AstNode> output;
 
     /**
      * Local variables.
@@ -290,6 +289,9 @@ public final class DecompilerMachine {
 
     /**
      * Label instruction handler.
+     * Store a reference in an array
+     * Opcodes: aastore
+     * Stack [before]->[after]: "arrayref, index, value →"
      * @since 0.1
      */
     private class StoreToArrayHandler implements InstructionHandler {
@@ -412,6 +414,7 @@ public final class DecompilerMachine {
 
         @Override
         public void handle(final Instruction ignore) {
+            // We do nothing here to keep the stack contains previous computations.
         }
 
     }
@@ -486,11 +489,14 @@ public final class DecompilerMachine {
             );
             Collections.reverse(args);
             final AstNode source = DecompilerMachine.this.stack.pop();
-            DecompilerMachine.this.stack.push(new Invocation(
-                source, new Attributes().name(method).descriptor(descriptor).owner(owner), args
-            ));
+            DecompilerMachine.this.stack.push(
+                new Invocation(
+                    source,
+                    new Attributes().name(method).descriptor(descriptor).owner(owner),
+                    args
+                )
+            );
         }
-
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
@@ -64,6 +64,10 @@ import org.xembly.Directive;
  * Decompiler machine.
  * @since 0.1
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
+ * @todo #136:90min Refactor DecompilerMachine to simplify the code.
+ *  The class is too complex and has too many responsibilities. It should be
+ *  refactored to have a single responsibility. The class should be split into
+ *  smaller classes, each with a single responsibility.
  */
 public final class DecompilerMachine {
 

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.opeo.decompilation;
 
-import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
@@ -63,11 +62,11 @@ import org.xembly.Directive;
 /**
  * Decompiler machine.
  * @since 0.1
- * @checkstyle ClassFanOutComplexityCheck (500 lines)
  * @todo #136:90min Refactor DecompilerMachine to simplify the code.
  *  The class is too complex and has too many responsibilities. It should be
  *  refactored to have a single responsibility. The class should be split into
  *  smaller classes, each with a single responsibility.
+ * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
 public final class DecompilerMachine {
 
@@ -113,7 +112,6 @@ public final class DecompilerMachine {
      */
     public DecompilerMachine(final LocalVariables locals, final Map<String, String> arguments) {
         this.stack = new LinkedList<>();
-        this.output = new ArrayDeque<>(0);
         this.locals = locals;
         this.arguments = arguments;
         this.handlers = new MapOf<>(

--- a/src/main/java/org/eolang/opeo/decompilation/LocalVariables.java
+++ b/src/main/java/org/eolang/opeo/decompilation/LocalVariables.java
@@ -62,7 +62,7 @@ public final class LocalVariables {
      * @param load Load or store.
      * @return Variable.
      */
-    public AstNode variable(final int index, final Type type, final boolean load) {
+    public AstNode  variable(final int index, final Type type, final boolean load) {
         final AstNode result;
         if (index == 0 && (this.modifiers & Opcodes.ACC_STATIC) == 0) {
             result = new This();

--- a/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
@@ -424,6 +424,7 @@ final class DecompilerMachineTest {
                     .decompileToXmir(
                         new OpcodeInstruction(Opcodes.ICONST_2),
                         new OpcodeInstruction(Opcodes.ANEWARRAY, type),
+                        new OpcodeInstruction(Opcodes.DUP),
                         new OpcodeInstruction(Opcodes.ICONST_0),
                         new OpcodeInstruction(Opcodes.ALOAD, 0),
                         new OpcodeInstruction(Opcodes.AASTORE)


### PR DESCRIPTION
Handle AASTORE instruction correctly. Now we handle stack correctly.

Closes: #136.
____
History:
- feat(#136): use array references
- feat(#136): remove the puzzle for 136 issue
- feat(#136): fix all qulice suggestions
- feat(#136): add one more puzzle
- feat(#136): fix compilation errors


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added a new method `object()` to the `Reference` class that returns the object.
- Added a new instruction `DUP` to the `DecompilerMachineTest` class.
- Modified the `variable()` method in the `LocalVariables` class to fix a typo in the return type.
- Added a new comment in the `DecompilerMachine` class to refactor and simplify the code.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->