### PR TITLE
feat(#100): remove 'prints' method from AstNode 

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/Add.java
+++ b/src/main/java/org/eolang/opeo/ast/Add.java
@@ -72,11 +72,6 @@ public final class Add implements AstNode {
     }
 
     @Override
-    public String print() {
-        return String.format("(%s) + (%s)", this.left.print(), this.right.print());
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         return new Directives().add("o")
             .attr("base", ".plus")

--- a/src/main/java/org/eolang/opeo/ast/ArrayConstructor.java
+++ b/src/main/java/org/eolang/opeo/ast/ArrayConstructor.java
@@ -57,11 +57,6 @@ public final class ArrayConstructor implements AstNode {
     }
 
     @Override
-    public String print() {
-        throw new UnsupportedOperationException("Not implemented yet");
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         final Directives directives = new Directives();
         directives.add("o")

--- a/src/main/java/org/eolang/opeo/ast/AstNode.java
+++ b/src/main/java/org/eolang/opeo/ast/AstNode.java
@@ -23,13 +23,8 @@
  */
 package org.eolang.opeo.ast;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.xembly.Directive;
-import org.xembly.Directives;
 
 /**
  * Abstract syntax tree node.

--- a/src/main/java/org/eolang/opeo/ast/AstNode.java
+++ b/src/main/java/org/eolang/opeo/ast/AstNode.java
@@ -38,12 +38,6 @@ import org.xembly.Directives;
 public interface AstNode {
 
     /**
-     * Print ast node and all it's children.
-     * @return String output.
-     */
-    String print();
-
-    /**
      * Convert node to XMIR.
      * @return XMIR XML.
      */
@@ -54,58 +48,4 @@ public interface AstNode {
      * @return List of opcodes.
      */
     List<AstNode> opcodes();
-
-    /**
-     * Sequence of nodes.
-     * @since 0.1
-     */
-    final class Sequence implements AstNode {
-
-        /**
-         * Nodes.
-         */
-        private final List<AstNode> nodes;
-
-        /**
-         * Useful constructor.
-         * @param nodes Nodes
-         * @param another Additional nodes
-         */
-        public Sequence(final List<AstNode> nodes, final AstNode... another) {
-            this(
-                Stream.concat(nodes.stream(), Arrays.stream(another)).collect(Collectors.toList())
-            );
-        }
-
-        /**
-         * Constructor.
-         * @param nodes Nodes.
-         */
-        public Sequence(final List<AstNode> nodes) {
-            this.nodes = nodes;
-        }
-
-        @Override
-        public String print() {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-
-        @Override
-        public Iterable<Directive> toXmir() {
-            final Directives directives = new Directives();
-            for (final AstNode node : this.nodes) {
-                directives.append(node.toXmir());
-            }
-            return directives;
-        }
-
-        @Override
-        public List<AstNode> opcodes() {
-            final List<AstNode> res = new ArrayList<>(0);
-            for (final AstNode node : this.nodes) {
-                res.addAll(node.opcodes());
-            }
-            return res;
-        }
-    }
 }

--- a/src/main/java/org/eolang/opeo/ast/ClassField.java
+++ b/src/main/java/org/eolang/opeo/ast/ClassField.java
@@ -59,11 +59,6 @@ public final class ClassField implements AstNode {
     }
 
     @Override
-    public String print() {
-        throw new UnsupportedOperationException("Not implemented yet");
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         return new Directives()
             .add("o")

--- a/src/main/java/org/eolang/opeo/ast/Constructor.java
+++ b/src/main/java/org/eolang/opeo/ast/Constructor.java
@@ -26,7 +26,6 @@ package org.eolang.opeo.ast;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
 import org.xembly.Directives;

--- a/src/main/java/org/eolang/opeo/ast/Constructor.java
+++ b/src/main/java/org/eolang/opeo/ast/Constructor.java
@@ -104,15 +104,6 @@ public final class Constructor implements AstNode {
     }
 
     @Override
-    public String print() {
-        return String.format(
-            "%s.new%s",
-            this.type,
-            this.args()
-        );
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         final Directives directives = new Directives();
         directives.add("o")
@@ -138,22 +129,5 @@ public final class Constructor implements AstNode {
             )
         );
         return res;
-    }
-
-    /**
-     * Print arguments.
-     * @return Arguments string.
-     */
-    private String args() {
-        final String result;
-        if (this.arguments.isEmpty()) {
-            result = "";
-        } else {
-            result = this.arguments.stream()
-                .map(AstNode::print)
-                .map(s -> String.format("(%s)", s))
-                .collect(Collectors.joining(" ", " ", ""));
-        }
-        return result;
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/InstanceField.java
+++ b/src/main/java/org/eolang/opeo/ast/InstanceField.java
@@ -82,11 +82,6 @@ public final class InstanceField implements AstNode {
     }
 
     @Override
-    public String print() {
-        return String.format("%s.%s", this.source.print(), this.attributes.name());
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         return new Directives()
             .add("o")

--- a/src/main/java/org/eolang/opeo/ast/Invocation.java
+++ b/src/main/java/org/eolang/opeo/ast/Invocation.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import lombok.ToString;
 import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;

--- a/src/main/java/org/eolang/opeo/ast/Invocation.java
+++ b/src/main/java/org/eolang/opeo/ast/Invocation.java
@@ -131,16 +131,6 @@ public final class Invocation implements AstNode {
     }
 
     @Override
-    public String print() {
-        return String.format(
-            "(%s).%s%s",
-            this.source.print(),
-            this.attributes.name(),
-            this.args()
-        );
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         if (Objects.isNull(this.source)) {
             throw new IllegalArgumentException(
@@ -173,20 +163,5 @@ public final class Invocation implements AstNode {
             )
         );
         return res;
-    }
-
-    /**
-     * Print arguments.
-     * @return Arguments
-     */
-    private String args() {
-        final String result;
-        if (this.arguments.isEmpty()) {
-            result = "";
-        } else {
-            result = this.arguments.stream().map(AstNode::print)
-                .collect(Collectors.joining(" ", " ", ""));
-        }
-        return result;
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Label.java
+++ b/src/main/java/org/eolang/opeo/ast/Label.java
@@ -48,11 +48,6 @@ public final class Label implements AstNode {
     }
 
     @Override
-    public String print() {
-        return String.format(": %s", this.identifier.print());
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         return new Directives()
             .add("o")

--- a/src/main/java/org/eolang/opeo/ast/Literal.java
+++ b/src/main/java/org/eolang/opeo/ast/Literal.java
@@ -72,17 +72,6 @@ public final class Literal implements AstNode {
         return result;
     }
 
-    @Override
-    public String print() {
-        final String result;
-        if (this.object instanceof String) {
-            result = String.format("\"%s\"", this.object);
-        } else {
-            result = this.object.toString();
-        }
-        return result;
-    }
-
     /**
      * Convert string into an opcode.
      * @param value String value.

--- a/src/main/java/org/eolang/opeo/ast/Mul.java
+++ b/src/main/java/org/eolang/opeo/ast/Mul.java
@@ -55,11 +55,6 @@ public final class Mul implements AstNode {
     }
 
     @Override
-    public String print() {
-        return String.format("%s * %s", this.left.print(), this.right.print());
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         return new Directives().add("o")
             .attr("base", "times")

--- a/src/main/java/org/eolang/opeo/ast/Opcode.java
+++ b/src/main/java/org/eolang/opeo/ast/Opcode.java
@@ -101,11 +101,6 @@ public final class Opcode implements AstNode {
     }
 
     @Override
-    public String print() {
-        return "opcode";
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         return new DirectivesInstruction(this.bytecode, this.counting, this.operands.toArray());
     }

--- a/src/main/java/org/eolang/opeo/ast/Reference.java
+++ b/src/main/java/org/eolang/opeo/ast/Reference.java
@@ -71,11 +71,6 @@ public final class Reference implements AstNode {
     }
 
     @Override
-    public String print() {
-        return this.ref.get().print();
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         return this.ref.get().toXmir();
     }

--- a/src/main/java/org/eolang/opeo/ast/Root.java
+++ b/src/main/java/org/eolang/opeo/ast/Root.java
@@ -67,11 +67,6 @@ public final class Root implements AstNode {
     }
 
     @Override
-    public String print() {
-        return this.children.stream().map(AstNode::print).collect(Collectors.joining("\n"));
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         final Iterable<Directive> result;
         if (this.children.isEmpty()) {

--- a/src/main/java/org/eolang/opeo/ast/Root.java
+++ b/src/main/java/org/eolang/opeo/ast/Root.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.xembly.Directive;
 import org.xembly.Directives;
 

--- a/src/main/java/org/eolang/opeo/ast/StaticInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/StaticInvocation.java
@@ -94,11 +94,6 @@ public final class StaticInvocation implements AstNode {
     }
 
     @Override
-    public String print() {
-        throw new UnsupportedOperationException("Not implemented yet");
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         final Directives directives = new Directives();
         directives.add("o")

--- a/src/main/java/org/eolang/opeo/ast/StoreArray.java
+++ b/src/main/java/org/eolang/opeo/ast/StoreArray.java
@@ -67,11 +67,6 @@ public final class StoreArray implements AstNode {
     }
 
     @Override
-    public String print() {
-        throw new UnsupportedOperationException("Not implemented yet");
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         return new Directives().add("o")
             .attr("base", ".writearray")

--- a/src/main/java/org/eolang/opeo/ast/StoreLocal.java
+++ b/src/main/java/org/eolang/opeo/ast/StoreLocal.java
@@ -55,15 +55,6 @@ public final class StoreLocal implements AstNode {
     }
 
     @Override
-    public String print() {
-        return String.format(
-            "%s = %s",
-            this.variable.print(),
-            this.value.print()
-        );
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         return new Directives().add("o")
             .attr("base", ".write")

--- a/src/main/java/org/eolang/opeo/ast/Substraction.java
+++ b/src/main/java/org/eolang/opeo/ast/Substraction.java
@@ -58,26 +58,12 @@ public final class Substraction implements AstNode {
      * Constructor.
      * @param left Left operand.
      * @param right Right operand.
-     */
-    public Substraction(final AstNode left, final AstNode right) {
-        this(left, right, new Attributes().type("int"));
-    }
-
-    /**
-     * Constructor.
-     * @param left Left operand.
-     * @param right Right operand.
      * @param attributes Attributes.
      */
     public Substraction(final AstNode left, final AstNode right, final Attributes attributes) {
         this.left = left;
         this.right = right;
         this.attributes = attributes;
-    }
-
-    @Override
-    public String print() {
-        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/ast/Super.java
+++ b/src/main/java/org/eolang/opeo/ast/Super.java
@@ -97,15 +97,6 @@ public final class Super implements AstNode {
     }
 
     @Override
-    public String print() {
-        return String.format(
-            "%s.super%s",
-            this.instance.print(),
-            this.args()
-        );
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         final Directives directives = new Directives();
         directives.add("o")
@@ -123,22 +114,5 @@ public final class Super implements AstNode {
         this.arguments.stream().map(AstNode::opcodes).forEach(res::addAll);
         res.add(new Opcode(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", this.descriptor));
         return res;
-    }
-
-    /**
-     * Print arguments.
-     * @return Arguments.
-     */
-    private String args() {
-        final String result;
-        if (this.arguments.isEmpty()) {
-            result = "";
-        } else {
-            result = this.arguments
-                .stream()
-                .map(AstNode::print)
-                .collect(Collectors.joining(" ", " ", ""));
-        }
-        return result;
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Super.java
+++ b/src/main/java/org/eolang/opeo/ast/Super.java
@@ -26,7 +26,6 @@ package org.eolang.opeo.ast;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
 import org.xembly.Directives;

--- a/src/main/java/org/eolang/opeo/ast/This.java
+++ b/src/main/java/org/eolang/opeo/ast/This.java
@@ -38,11 +38,6 @@ import org.xembly.Directives;
 public final class This implements AstNode {
 
     @Override
-    public String print() {
-        return "this";
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         return new Directives().add("o").attr("base", "$").up();
     }

--- a/src/main/java/org/eolang/opeo/ast/Variable.java
+++ b/src/main/java/org/eolang/opeo/ast/Variable.java
@@ -98,17 +98,6 @@ public final class Variable implements AstNode {
         this.identifier = identifier;
     }
 
-    @ToString.Include
-    @Override
-    public String print() {
-        return String.format(
-            "%s%d%s",
-            Variable.PREFIX,
-            this.identifier,
-            Type.getType(this.attributes.descriptor()).getClassName()
-        );
-    }
-
     @Override
     public Iterable<Directive> toXmir() {
         return new Directives()

--- a/src/main/java/org/eolang/opeo/ast/WriteField.java
+++ b/src/main/java/org/eolang/opeo/ast/WriteField.java
@@ -76,11 +76,6 @@ public final class WriteField implements AstNode {
     }
 
     @Override
-    public String print() {
-        return String.format("%s = %s", this.target.print(), this.value.print());
-    }
-
-    @Override
     public Iterable<Directive> toXmir() {
         return new Directives().add("o")
             .attr("base", ".write")

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
@@ -159,7 +159,7 @@ public final class DecompilerMachine {
      * @param instructions Instructions to decompile.
      * @return Decompiled instructions.
      */
-    public Iterable<Directive> decompileToXmir(final Instruction... instructions) {
+    public Iterable<Directive> decompile(final Instruction... instructions) {
         Arrays.stream(instructions)
             .forEach(inst -> this.handler(inst.opcode()).handle(inst));
         return new Root(new ListOf<>(this.stack.descendingIterator())).toXmir();

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
@@ -166,17 +166,6 @@ public final class DecompilerMachine {
     }
 
     /**
-     * Decompile instructions.
-     * @param instructions Instructions to decompile.
-     * @return Decompiled code.
-     */
-    public String decompile(final Instruction... instructions) {
-        Arrays.stream(instructions)
-            .forEach(inst -> this.handler(inst.opcode()).handle(inst));
-        return new Root(new ListOf<>(this.stack.descendingIterator())).print();
-    }
-
-    /**
      * Do we add number to opcode name or not?
      * if true then we add number to opcode name:
      *  RETURN -> RETURN-1

--- a/src/main/java/org/eolang/opeo/jeo/JeoDecompiler.java
+++ b/src/main/java/org/eolang/opeo/jeo/JeoDecompiler.java
@@ -79,7 +79,7 @@ public final class JeoDecompiler {
                         new DecompilerMachine(
                             new LocalVariables(method.access()),
                             Map.of("counting", "false")
-                        ).decompileToXmir(new JeoInstructions(method).instructions()),
+                        ).decompile(new JeoInstructions(method).instructions()),
                         new Transformers.Node()
                     ).xmlQuietly()
                 ).children().collect(Collectors.toList()).toArray(XmlNode[]::new)

--- a/src/test/java/org/eolang/opeo/ast/InstanceFieldTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InstanceFieldTest.java
@@ -26,7 +26,6 @@ package org.eolang.opeo.ast;
 import com.jcabi.matchers.XhtmlMatchers;
 import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 import org.xembly.Directives;

--- a/src/test/java/org/eolang/opeo/ast/InstanceFieldTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InstanceFieldTest.java
@@ -40,15 +40,6 @@ import org.xembly.Xembler;
 class InstanceFieldTest {
 
     @Test
-    void printsField() {
-        MatcherAssert.assertThat(
-            "We can't print a field access, actual result is wrong",
-            new InstanceField(new This(), "bar").print(),
-            Matchers.equalTo("this.bar")
-        );
-    }
-
-    @Test
     void convertsToXmir() throws ImpossibleModificationException {
         final String actual = new Xembler(
             new Directives()

--- a/src/test/java/org/eolang/opeo/ast/MulTest.java
+++ b/src/test/java/org/eolang/opeo/ast/MulTest.java
@@ -37,18 +37,6 @@ import org.xembly.Xembler;
 class MulTest {
 
     @Test
-    void printsMultiplication() {
-        MatcherAssert.assertThat(
-            "Can't print multiplication of two literals",
-            new Mul(
-                new Literal(1),
-                new Literal(2)
-            ).print(),
-            Matchers.equalTo("1 * 2")
-        );
-    }
-
-    @Test
     void convertsToXmir() throws ImpossibleModificationException {
         final String xmir = new Xembler(
             new Mul(

--- a/src/test/java/org/eolang/opeo/ast/MulTest.java
+++ b/src/test/java/org/eolang/opeo/ast/MulTest.java
@@ -25,7 +25,6 @@ package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;

--- a/src/test/java/org/eolang/opeo/ast/OpcodeTest.java
+++ b/src/test/java/org/eolang/opeo/ast/OpcodeTest.java
@@ -26,7 +26,6 @@ package org.eolang.opeo.ast;
 import com.jcabi.matchers.XhtmlMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 import org.xembly.Transformers;
@@ -35,12 +34,6 @@ import org.xembly.Xembler;
 /**
  * Test case for {@link Opcode}.
  * @since 0.1
- * @todo #95:90min Enable the 'prints 'test below and fix it.
- *  Currently the test {@link OpcodeTest#prints} is disabled because it fails.
- *  You can find the reason of the failure in the issue #2801.
- *  Link: <a href="https://github.com/objectionary/eo/issues/2801">#2801</a>.
- *  Also in the project we have several more tests with the same problem.
- *  You can find them by the '2801' in the project.
  */
 class OpcodeTest {
 
@@ -58,20 +51,6 @@ class OpcodeTest {
             Matchers.allOf(
                 XhtmlMatchers.hasXPath("./o[@base='opcode']/o[@base='int']"),
                 XhtmlMatchers.hasXPath("./o[@base='opcode']/o[@base='string']")
-            )
-        );
-    }
-
-    @Test
-    @Disabled("https://github.com/objectionary/eo/issues/2801")
-    void prints() {
-        MatcherAssert.assertThat(
-            "We expect the following string to be printed: 'opcode > LDC-1\n  18\n  \"bye\"'",
-            new Opcode(Opcodes.LDC, "bye").print(),
-            Matchers.allOf(
-                Matchers.containsString("opcode > LDC"),
-                Matchers.containsString("18"),
-                Matchers.containsString("bye")
             )
         );
     }

--- a/src/test/java/org/eolang/opeo/ast/StoreLocalTest.java
+++ b/src/test/java/org/eolang/opeo/ast/StoreLocalTest.java
@@ -25,7 +25,6 @@ package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Type;
 import org.xembly.ImpossibleModificationException;

--- a/src/test/java/org/eolang/opeo/ast/StoreLocalTest.java
+++ b/src/test/java/org/eolang/opeo/ast/StoreLocalTest.java
@@ -39,15 +39,6 @@ import org.xembly.Xembler;
 class StoreLocalTest {
 
     @Test
-    void printsCorrectly() {
-        MatcherAssert.assertThat(
-            "We expect the printed assignment to be correct",
-            new StoreLocal(new Variable(Type.INT_TYPE, 1), new Literal(1)).print(),
-            Matchers.equalTo("local1int = 1")
-        );
-    }
-
-    @Test
     void convertsToXmirCorrectly() throws ImpossibleModificationException {
         final String xml = new Xembler(
             new StoreLocal(

--- a/src/test/java/org/eolang/opeo/ast/SuperTest.java
+++ b/src/test/java/org/eolang/opeo/ast/SuperTest.java
@@ -26,7 +26,6 @@ package org.eolang.opeo.ast;
 import com.jcabi.matchers.XhtmlMatchers;
 import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
@@ -38,15 +37,6 @@ import org.xembly.Xembler;
  * @since 0.1
  */
 class SuperTest {
-
-    @Test
-    void printsSuper() {
-        MatcherAssert.assertThat(
-            "Can't print 'super' statement, should be 'this.super \"hello, world!\"'",
-            new Super(new This(), new Literal("hello, world!")).print(),
-            Matchers.equalTo("this.super \"hello, world!\"")
-        );
-    }
 
     @Test
     void convertsToXmir() throws ImpossibleModificationException {

--- a/src/test/java/org/eolang/opeo/ast/VariableTest.java
+++ b/src/test/java/org/eolang/opeo/ast/VariableTest.java
@@ -46,21 +46,6 @@ import org.xembly.Xembler;
 class VariableTest {
 
     @Test
-    void prints() {
-        final String actual = new Variable(Type.INT_TYPE, 0).print();
-        final String expected = "local0int";
-        MatcherAssert.assertThat(
-            String.format(
-                "We expect the printed variable to be equal to '%s', but it wasn't, current value is '%s'",
-                expected,
-                actual
-            ),
-            actual,
-            Matchers.equalTo(expected)
-        );
-    }
-
-    @Test
     void convertsToXmir() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "We expect the xmir variable to be equal to <o base='local1'/>, but it wasn't",

--- a/src/test/java/org/eolang/opeo/ast/WriteFieldTest.java
+++ b/src/test/java/org/eolang/opeo/ast/WriteFieldTest.java
@@ -39,18 +39,6 @@ import org.xembly.Xembler;
 class WriteFieldTest {
 
     @Test
-    void prints() {
-        MatcherAssert.assertThat(
-            "Can't print 'write field' statement, should be 'this.a = 2' assignment",
-            new WriteField(
-                new InstanceField(new This(), "a"),
-                new Literal(2)
-            ).print(),
-            Matchers.equalTo("this.a = 2")
-        );
-    }
-
-    @Test
     void convertsToXmir() throws ImpossibleModificationException {
         final String xmir = new Xembler(
             new WriteField(

--- a/src/test/java/org/eolang/opeo/ast/WriteFieldTest.java
+++ b/src/test/java/org/eolang/opeo/ast/WriteFieldTest.java
@@ -26,7 +26,6 @@ package org.eolang.opeo.ast;
 import com.jcabi.matchers.XhtmlMatchers;
 import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 import org.xembly.ImpossibleModificationException;

--- a/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
@@ -66,7 +66,7 @@ final class DecompilerMachineTest {
     @Test
     void decompilesSimpleInstanceCall() {
         Assertions.assertDoesNotThrow(
-            () -> new DecompilerMachine().decompileToXmir(
+            () -> new DecompilerMachine().decompile(
                 new OpcodeInstruction(Opcodes.NEW, "A"),
                 new OpcodeInstruction(Opcodes.DUP),
                 new OpcodeInstruction(Opcodes.INVOKESPECIAL, "A", "<init>", "()V"),
@@ -87,7 +87,7 @@ final class DecompilerMachineTest {
     @Test
     void decompilesInstanceCallWithArguments() {
         Assertions.assertDoesNotThrow(
-            () -> new DecompilerMachine().decompileToXmir(
+            () -> new DecompilerMachine().decompile(
                 new OpcodeInstruction(Opcodes.NEW, "A"),
                 new OpcodeInstruction(Opcodes.DUP),
                 new OpcodeInstruction(Opcodes.BIPUSH, 28),
@@ -110,7 +110,7 @@ final class DecompilerMachineTest {
     @Test
     void decompilesNestedInstanceCallWithArguments() {
         Assertions.assertDoesNotThrow(
-            () -> new DecompilerMachine().decompileToXmir(
+            () -> new DecompilerMachine().decompile(
                 new OpcodeInstruction(Opcodes.ALOAD, 0),
                 new OpcodeInstruction(Opcodes.ALOAD, 0),
                 new OpcodeInstruction(Opcodes.INVOKEVIRTUAL, "App", "bar", "()I"),
@@ -133,7 +133,7 @@ final class DecompilerMachineTest {
     @Test
     void decompilesFieldAccess() {
         Assertions.assertDoesNotThrow(
-            () -> new DecompilerMachine().decompileToXmir(
+            () -> new DecompilerMachine().decompile(
                 new OpcodeInstruction(Opcodes.ALOAD, 0),
                 new OpcodeInstruction(Opcodes.GETFIELD, "App", "a", "I"),
                 new OpcodeInstruction(Opcodes.ALOAD, 0),
@@ -155,7 +155,7 @@ final class DecompilerMachineTest {
     @Test
     void decompilesFieldAccessAndMethodInvocation() {
         Assertions.assertDoesNotThrow(
-            () -> new DecompilerMachine().decompileToXmir(
+            () -> new DecompilerMachine().decompile(
                 new OpcodeInstruction(Opcodes.ALOAD, 0),
                 new OpcodeInstruction(Opcodes.GETFIELD, "App", "a", "Ljava/lang/Integer;"),
                 new OpcodeInstruction(Opcodes.INVOKEVIRTUAL, "App", "intValue", "()I"),
@@ -186,7 +186,7 @@ final class DecompilerMachineTest {
         final Label label = labels.label(uid);
         Assertions.assertDoesNotThrow(
             () -> {
-                new DecompilerMachine().decompileToXmir(
+                new DecompilerMachine().decompile(
                     new OpcodeInstruction(Opcodes.ALOAD, 0),
                     new OpcodeInstruction(Opcodes.GETFIELD, "org/eolang/other/A", "d", "I"),
                     new OpcodeInstruction(Opcodes.IFGT, label),
@@ -219,7 +219,7 @@ final class DecompilerMachineTest {
             () ->
                 new Xembler(
                     new DecompilerMachine()
-                        .decompileToXmir(
+                        .decompile(
                             new OpcodeInstruction(Opcodes.LLOAD, 4),
                             new OpcodeInstruction(Opcodes.ALOAD, 1),
                             new OpcodeInstruction(Opcodes.INVOKEVIRTUAL, "App", "run", "()I"),
@@ -239,7 +239,7 @@ final class DecompilerMachineTest {
             "Can't decompile array creation",
             new Xembler(
                 new DecompilerMachine()
-                    .decompileToXmir(
+                    .decompile(
                         new OpcodeInstruction(Opcodes.ICONST_2),
                         new OpcodeInstruction(Opcodes.ICONST_3),
                         new OpcodeInstruction(Opcodes.IADD),
@@ -266,7 +266,7 @@ final class DecompilerMachineTest {
             "Can't decompile array insertion",
             new Xembler(
                 new DecompilerMachine()
-                    .decompileToXmir(
+                    .decompile(
                         new OpcodeInstruction(Opcodes.ICONST_2),
                         new OpcodeInstruction(Opcodes.ANEWARRAY, type),
                         new OpcodeInstruction(Opcodes.DUP),
@@ -296,7 +296,7 @@ final class DecompilerMachineTest {
             "Can't decompile vararg invocation",
             new Xembler(
                 new DecompilerMachine(Map.of("counting", "false"))
-                    .decompileToXmir(
+                    .decompile(
                         new OpcodeInstruction(
                             Opcodes.GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;"
                         ),

--- a/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
@@ -65,17 +65,14 @@ final class DecompilerMachineTest {
      */
     @Test
     void decompilesSimpleInstanceCall() {
-        MatcherAssert.assertThat(
-            "Can't decompile method call instructions for 'new A().bar();'",
-            new DecompilerMachine().decompileToXmir(
+        Assertions.assertDoesNotThrow(
+            () -> new DecompilerMachine().decompileToXmir(
                 new OpcodeInstruction(Opcodes.NEW, "A"),
                 new OpcodeInstruction(Opcodes.DUP),
                 new OpcodeInstruction(Opcodes.INVOKESPECIAL, "A", "<init>", "()V"),
                 new OpcodeInstruction(Opcodes.INVOKEVIRTUAL, "A", "bar", "()V")
             ),
-            Matchers.equalTo(
-                "(A.new).bar"
-            )
+            "Can't decompile method call instructions for 'new A().bar();'"
         );
     }
 
@@ -89,9 +86,8 @@ final class DecompilerMachineTest {
      */
     @Test
     void decompilesInstanceCallWithArguments() {
-        MatcherAssert.assertThat(
-            "Can't decompile method call instructions for 'new A(28).bar(29);'",
-            new DecompilerMachine().decompileToXmir(
+        Assertions.assertDoesNotThrow(
+            () -> new DecompilerMachine().decompileToXmir(
                 new OpcodeInstruction(Opcodes.NEW, "A"),
                 new OpcodeInstruction(Opcodes.DUP),
                 new OpcodeInstruction(Opcodes.BIPUSH, 28),
@@ -99,45 +95,7 @@ final class DecompilerMachineTest {
                 new OpcodeInstruction(Opcodes.BIPUSH, 29),
                 new OpcodeInstruction(Opcodes.INVOKEVIRTUAL, "A", "bar", "(I)V")
             ),
-            Matchers.equalTo(
-                "(A.new (28)).bar 29"
-            )
-        );
-    }
-
-    /**
-     * Test decompilation of instance call instructions with arguments.
-     * <p>
-     *     {@code
-     *       new StringBuilder('a').append('b');
-     *     }
-     * </p>
-     */
-    @Test
-    void decompilesStringBuilder() {
-        MatcherAssert.assertThat(
-            "Can't decompile StringBuilder instructions for 'new StringBuilder('a').append('b');",
-            new DecompilerMachine().decompileToXmir(
-                new OpcodeInstruction(Opcodes.NEW, "java/lang/StringBuilder"),
-                new OpcodeInstruction(Opcodes.DUP),
-                new OpcodeInstruction(Opcodes.LDC, "a"),
-                new OpcodeInstruction(
-                    Opcodes.INVOKESPECIAL,
-                    "java/lang/StringBuilder",
-                    "<init>",
-                    "(Ljava/lang/String;)V"
-                ),
-                new OpcodeInstruction(Opcodes.LDC, "b"),
-                new OpcodeInstruction(
-                    Opcodes.INVOKEVIRTUAL,
-                    "java/lang/StringBuilder",
-                    "append",
-                    "(Ljava/lang/String;)Ljava/lang/StringBuilder"
-                )
-            ),
-            Matchers.equalTo(
-                "(java/lang/StringBuilder.new (\"a\")).append \"b\""
-            )
+            "Can't decompile method call instructions for 'new A(28).bar(29);'"
         );
     }
 
@@ -151,9 +109,8 @@ final class DecompilerMachineTest {
      */
     @Test
     void decompilesNestedInstanceCallWithArguments() {
-        MatcherAssert.assertThat(
-            "Can't decompile method call instructions for 'foo(bar()) + 3;'",
-            new DecompilerMachine().decompileToXmir(
+        Assertions.assertDoesNotThrow(
+            () -> new DecompilerMachine().decompileToXmir(
                 new OpcodeInstruction(Opcodes.ALOAD, 0),
                 new OpcodeInstruction(Opcodes.ALOAD, 0),
                 new OpcodeInstruction(Opcodes.INVOKEVIRTUAL, "App", "bar", "()I"),
@@ -161,9 +118,7 @@ final class DecompilerMachineTest {
                 new OpcodeInstruction(Opcodes.ICONST_3),
                 new OpcodeInstruction(Opcodes.IADD)
             ),
-            Matchers.equalTo(
-                "((this).foo (this).bar) + (3)"
-            )
+            "Can't decompile method call instructions for 'foo(bar()) + 3;'"
         );
     }
 
@@ -177,18 +132,15 @@ final class DecompilerMachineTest {
      */
     @Test
     void decompilesFieldAccess() {
-        MatcherAssert.assertThat(
-            "Can't decompile field access instructions for 'this.a + this.b;'",
-            new DecompilerMachine().decompileToXmir(
+        Assertions.assertDoesNotThrow(
+            () -> new DecompilerMachine().decompileToXmir(
                 new OpcodeInstruction(Opcodes.ALOAD, 0),
                 new OpcodeInstruction(Opcodes.GETFIELD, "App", "a", "I"),
                 new OpcodeInstruction(Opcodes.ALOAD, 0),
                 new OpcodeInstruction(Opcodes.GETFIELD, "App", "b", "I"),
                 new OpcodeInstruction(Opcodes.IADD)
             ),
-            Matchers.equalTo(
-                "(this.a) + (this.b)"
-            )
+            "Can't decompile field access instructions for 'this.a + this.b;'"
         );
     }
 
@@ -202,18 +154,15 @@ final class DecompilerMachineTest {
      */
     @Test
     void decompilesFieldAccessAndMethodInvocation() {
-        MatcherAssert.assertThat(
-            "Can't decompile field access and method invocation instructions for 'this.a.intValue() + 1;'",
-            new DecompilerMachine().decompileToXmir(
+        Assertions.assertDoesNotThrow(
+            () -> new DecompilerMachine().decompileToXmir(
                 new OpcodeInstruction(Opcodes.ALOAD, 0),
                 new OpcodeInstruction(Opcodes.GETFIELD, "App", "a", "Ljava/lang/Integer;"),
                 new OpcodeInstruction(Opcodes.INVOKEVIRTUAL, "App", "intValue", "()I"),
                 new OpcodeInstruction(Opcodes.ICONST_1),
                 new OpcodeInstruction(Opcodes.IADD)
             ),
-            Matchers.equalTo(
-                "((this.a).intValue) + (1)"
-            )
+            "Can't decompile field access and method invocation instructions for 'this.a.intValue() + 1;'"
         );
     }
 


### PR DESCRIPTION
Remove 'prints' method from `AstNode` since we don't use it anymore.

Closes: #100.
____
History:
- feat(#100): remove old decompilation to pseudo-code
- feat(#100): simplify most of the unit tests
- feat(#100): optimize imports


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the `print()` method from several classes and updating the code to use the `toXmir()` method instead. 

### Detailed summary
- Removed `print()` method from `Reference`, `Label`, `ClassField`, `StoreArray`, `Mul`, `Add`, `Opcode`, `InstanceField`, `WriteField`, `This`, `StoreLocal`, `ArrayConstructor`, `StaticInvocation`, `Variable`, `Literal`, `Substraction`, `Invocation`, and `Constructor` classes.
- Updated code to use the `toXmir()` method instead of `print()` method in the above classes.

> The following files were skipped due to too many changes: `src/main/java/org/eolang/opeo/ast/Constructor.java`, `src/main/java/org/eolang/opeo/ast/Super.java`, `src/test/java/org/eolang/opeo/ast/OpcodeTest.java`, `src/main/java/org/eolang/opeo/ast/AstNode.java`, `src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->