### PR TITLE
feat(#169): Implement All Literal Types

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/Literal.java
+++ b/src/main/java/org/eolang/opeo/ast/Literal.java
@@ -48,6 +48,14 @@ public final class Literal implements AstNode, Typed {
 
     /**
      * Constructor.
+     * Null literal.
+     */
+    public Literal() {
+        this(null, Type.VOID_TYPE);
+    }
+
+    /**
+     * Constructor.
      * @param value Char literal value.
      */
     public Literal(final char value) {
@@ -154,6 +162,8 @@ public final class Literal implements AstNode, Typed {
             res = new Opcode(Opcodes.LDC, this.value);
         } else if (this.type.equals(Type.getType(String.class))) {
             res = new Opcode(Opcodes.LDC, this.value);
+        } else if (this.type.equals(Type.VOID_TYPE)) {
+            res = new Opcode(Opcodes.ACONST_NULL);
         } else {
             throw new IllegalArgumentException(
                 String.format(
@@ -179,6 +189,9 @@ public final class Literal implements AstNode, Typed {
     private static Opcode opcode(final int value) {
         final Opcode res;
         switch (value) {
+            case -1:
+                res = new Opcode(Opcodes.ICONST_M1);
+                break;
             case 0:
                 res = new Opcode(Opcodes.ICONST_0);
                 break;

--- a/src/main/java/org/eolang/opeo/ast/Literal.java
+++ b/src/main/java/org/eolang/opeo/ast/Literal.java
@@ -44,77 +44,136 @@ public final class Literal implements AstNode, Typed {
     /**
      * Literal value.
      */
-    private final Object object;
+    private final Object value;
+
+    /**
+     * Literal type.
+     */
+    private final Type type;
 
     /**
      * Constructor.
-     * @param value Literal value
+     * @param value Char literal value.
+     */
+    public Literal(final char value) {
+        this(value, Type.CHAR_TYPE);
+    }
+
+    /**
+     * Constructor.
+     * @param value Boolean literal value.
+     */
+    public Literal(final boolean value) {
+        this(value, Type.BOOLEAN_TYPE);
+    }
+
+    /**
+     * Constructor.
+     * @param value Byte literal value.
+     */
+    public Literal(final byte value) {
+        this(value, Type.BYTE_TYPE);
+    }
+
+    /**
+     * Constructor.
+     * @param value Short literal value.
+     */
+    public Literal(final short value) {
+        this(value, Type.SHORT_TYPE);
+    }
+
+    /**
+     * Constructor.
+     * @param value Integer literal value.
+     */
+    public Literal(final int value) {
+        this(value, Type.INT_TYPE);
+    }
+
+    /**
+     * Constructor.
+     * @param value Long literal value.
+     */
+    public Literal(final long value) {
+        this(value, Type.LONG_TYPE);
+    }
+
+    /**
+     * Constructor.
+     * @param value Float literal value.
+     */
+    public Literal(final float value) {
+        this(value, Type.FLOAT_TYPE);
+    }
+
+    /**
+     * Constructor.
+     * @param value Double literal value.
+     */
+    public Literal(final double value) {
+        this(value, Type.DOUBLE_TYPE);
+    }
+
+    /**
+     * Constructor.
+     * @param value Literal value.
      */
     public Literal(final Object value) {
-        this.object = value;
+        this(value, Type.getType(value.getClass()));
+    }
+
+    /**
+     * Constructor.
+     * @param value Literal value.
+     * @param type Literal type.
+     */
+    public Literal(final Object value, final Type type) {
+        this.value = value;
+        this.type = type;
     }
 
     @Override
     public Iterable<Directive> toXmir() {
-        return new DirectivesData(this.object);
+        return new DirectivesData(this.value);
     }
 
     @Override
     public List<AstNode> opcodes() {
-        final List<AstNode> result;
-        if (this.object instanceof Integer) {
-            result = Collections.singletonList(Literal.opcode((Integer) this.object));
-        } else if (this.object instanceof Long) {
-            result = Collections.singletonList(Literal.opcode((Long) this.object));
-        } else if (this.object instanceof String) {
-            result = Collections.singletonList(Literal.opcode((String) this.object));
+        final Opcode res;
+        if (this.type.equals(Type.CHAR_TYPE)) {
+            res = Literal.opcode((char) this.value);
+        } else if (this.type.equals(Type.BOOLEAN_TYPE)) {
+            res = Literal.opcode((boolean) this.value);
+        } else if (this.type.equals(Type.BYTE_TYPE)) {
+            res = new Opcode(Opcodes.BIPUSH, this.value);
+        } else if (this.type.equals(Type.SHORT_TYPE)) {
+            res = new Opcode(Opcodes.SIPUSH, this.value);
+        } else if (this.type.equals(Type.INT_TYPE)) {
+            res = Literal.opcode((int) this.value);
+        } else if (this.type.equals(Type.LONG_TYPE)) {
+            res = Literal.opcode((long) this.value);
+        } else if (this.type.equals(Type.FLOAT_TYPE)) {
+            res = new Opcode(Opcodes.LDC, this.value);
+        } else if (this.type.equals(Type.DOUBLE_TYPE)) {
+            res = new Opcode(Opcodes.LDC, this.value);
+        } else if (this.type.equals(Type.getType(String.class))) {
+            res = new Opcode(Opcodes.LDC, this.value);
         } else {
             throw new IllegalArgumentException(
                 String.format(
                     "Unsupported literal type %s, value is %s",
-                    this.object.getClass().getName(),
-                    this.object
+                    this.type.getClassName(),
+                    this.value
                 )
             );
         }
-        return result;
+        return Collections.singletonList(res);
     }
 
     @Override
     public Type type() {
-        final Type result;
-        final Class<?> clazz = this.object.getClass();
-        if (clazz == int.class || clazz == Integer.class) {
-            result = Type.INT_TYPE;
-        } else if (clazz == long.class || clazz == Long.class) {
-            result = Type.LONG_TYPE;
-        } else if (clazz == float.class || clazz == Float.class) {
-            result = Type.FLOAT_TYPE;
-        } else if (clazz == double.class || clazz == Double.class) {
-            result = Type.DOUBLE_TYPE;
-        } else if (clazz == boolean.class || clazz == Boolean.class) {
-            result = Type.BOOLEAN_TYPE;
-        } else if (clazz == char.class || clazz == Character.class) {
-            result = Type.CHAR_TYPE;
-        } else if (clazz == byte.class || clazz == Byte.class) {
-            result = Type.BYTE_TYPE;
-        } else if (clazz == short.class || clazz == Short.class) {
-            result = Type.SHORT_TYPE;
-        } else if (clazz == String.class) {
-            result = Type.getType(String.class);
-        } else {
-            result = Type.getType(clazz);
-        }
-        return result;
-    }
-
-    /**
-     * Convert string into an opcode.
-     * @param value String value.
-     * @return Opcode.
-     */
-    private static Opcode opcode(final String value) {
-        return new Opcode(Opcodes.LDC, value);
+        return this.type;
     }
 
     /**
@@ -148,6 +207,30 @@ public final class Literal implements AstNode, Typed {
                 break;
         }
         return res;
+    }
+
+    /**
+     * Convert char into an opcode.
+     * @param value Char value.
+     * @return Opcode.
+     */
+    private static Opcode opcode(final char value) {
+        return new Opcode(Opcodes.BIPUSH, value);
+    }
+
+    /**
+     * Convert boolean into an opcode.
+     * @param value Boolean value.
+     * @return Opcode.
+     */
+    private static Opcode opcode(final boolean value) {
+        final Opcode result;
+        if (value) {
+            result = new Opcode(Opcodes.ICONST_1);
+        } else {
+            result = new Opcode(Opcodes.ICONST_0);
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/Literal.java
+++ b/src/main/java/org/eolang/opeo/ast/Literal.java
@@ -33,11 +33,6 @@ import org.xembly.Directive;
 /**
  * Literal output.
  * @since 0.1
- * @todo #129:90min Implement all types of literals.
- *  Currently, only int, long and string literals are supported.
- *  Add support for float, double, boolean, char, byte, short and other types.
- *  Don't forget to add tests for all supported types.
- * @checkstyle CyclomaticComplexityCheck (500 lines)
  */
 public final class Literal implements AstNode, Typed {
 

--- a/src/main/java/org/eolang/opeo/ast/Literal.java
+++ b/src/main/java/org/eolang/opeo/ast/Literal.java
@@ -33,18 +33,19 @@ import org.xembly.Directive;
 /**
  * Literal output.
  * @since 0.1
+ * @checkstyle CyclomaticComplexityCheck (500 lines)
  */
 public final class Literal implements AstNode, Typed {
 
     /**
      * Literal value.
      */
-    private final Object value;
+    private final Object lvalue;
 
     /**
      * Literal type.
      */
-    private final Type type;
+    private final Type ltype;
 
     /**
      * Constructor.
@@ -132,44 +133,44 @@ public final class Literal implements AstNode, Typed {
      * @param type Literal type.
      */
     public Literal(final Object value, final Type type) {
-        this.value = value;
-        this.type = type;
+        this.lvalue = value;
+        this.ltype = type;
     }
 
     @Override
     public Iterable<Directive> toXmir() {
-        return new DirectivesData(this.value);
+        return new DirectivesData(this.lvalue);
     }
 
     @Override
     public List<AstNode> opcodes() {
         final Opcode res;
-        if (this.type.equals(Type.CHAR_TYPE)) {
-            res = Literal.opcode((char) this.value);
-        } else if (this.type.equals(Type.BOOLEAN_TYPE)) {
-            res = Literal.opcode((boolean) this.value);
-        } else if (this.type.equals(Type.BYTE_TYPE)) {
-            res = new Opcode(Opcodes.BIPUSH, this.value);
-        } else if (this.type.equals(Type.SHORT_TYPE)) {
-            res = new Opcode(Opcodes.SIPUSH, this.value);
-        } else if (this.type.equals(Type.INT_TYPE)) {
-            res = Literal.opcode((int) this.value);
-        } else if (this.type.equals(Type.LONG_TYPE)) {
-            res = Literal.opcode((long) this.value);
-        } else if (this.type.equals(Type.FLOAT_TYPE)) {
-            res = new Opcode(Opcodes.LDC, this.value);
-        } else if (this.type.equals(Type.DOUBLE_TYPE)) {
-            res = new Opcode(Opcodes.LDC, this.value);
-        } else if (this.type.equals(Type.getType(String.class))) {
-            res = new Opcode(Opcodes.LDC, this.value);
-        } else if (this.type.equals(Type.VOID_TYPE)) {
+        if (this.ltype.equals(Type.CHAR_TYPE)) {
+            res = Literal.opcode((char) this.lvalue);
+        } else if (this.ltype.equals(Type.BOOLEAN_TYPE)) {
+            res = Literal.opcode((boolean) this.lvalue);
+        } else if (this.ltype.equals(Type.BYTE_TYPE)) {
+            res = new Opcode(Opcodes.BIPUSH, this.lvalue);
+        } else if (this.ltype.equals(Type.SHORT_TYPE)) {
+            res = new Opcode(Opcodes.SIPUSH, this.lvalue);
+        } else if (this.ltype.equals(Type.INT_TYPE)) {
+            res = Literal.opcode((int) this.lvalue);
+        } else if (this.ltype.equals(Type.LONG_TYPE)) {
+            res = Literal.opcode((long) this.lvalue);
+        } else if (this.ltype.equals(Type.FLOAT_TYPE)) {
+            res = new Opcode(Opcodes.LDC, this.lvalue);
+        } else if (this.ltype.equals(Type.DOUBLE_TYPE)) {
+            res = new Opcode(Opcodes.LDC, this.lvalue);
+        } else if (this.ltype.equals(Type.getType(String.class))) {
+            res = new Opcode(Opcodes.LDC, this.lvalue);
+        } else if (this.ltype.equals(Type.VOID_TYPE)) {
             res = new Opcode(Opcodes.ACONST_NULL);
         } else {
             throw new IllegalArgumentException(
                 String.format(
                     "Unsupported literal type %s, value is %s",
-                    this.type.getClassName(),
-                    this.value
+                    this.ltype.getClassName(),
+                    this.lvalue
                 )
             );
         }
@@ -178,7 +179,7 @@ public final class Literal implements AstNode, Typed {
 
     @Override
     public Type type() {
-        return this.type;
+        return this.ltype;
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/Opcode.java
+++ b/src/main/java/org/eolang/opeo/ast/Opcode.java
@@ -27,6 +27,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.eolang.jeo.representation.directives.DirectivesInstruction;
 import org.xembly.Directive;
 
@@ -34,6 +36,8 @@ import org.xembly.Directive;
  * Opcode output node.
  * @since 0.1
  */
+@ToString
+@EqualsAndHashCode
 public final class Opcode implements AstNode {
 
     /**

--- a/src/test/java/org/eolang/opeo/ast/LiteralTest.java
+++ b/src/test/java/org/eolang/opeo/ast/LiteralTest.java
@@ -25,7 +25,10 @@ package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Transformers;
 import org.xembly.Xembler;
@@ -43,6 +46,78 @@ class LiteralTest {
             new Xembler(new Literal("Neo").toXmir(), new Transformers.Node()).xml(),
             XhtmlMatchers.hasXPath(
                 "/o[@base='string' and @data='bytes' and text()='4E 65 6F']/text()"
+            )
+        );
+    }
+
+    @Test
+    void dereminesType() {
+        MatcherAssert.assertThat(
+            "We expect the type to be determined as string",
+            new Literal("Neo").type(),
+            Matchers.equalTo(Type.getType(String.class))
+        );
+        MatcherAssert.assertThat(
+            "We expect the type to be determined as int",
+            new Literal(1).type(),
+            Matchers.equalTo(Type.INT_TYPE)
+        );
+        MatcherAssert.assertThat(
+            "We expect the type to be determined as char",
+            new Literal('a').type(),
+            Matchers.equalTo(Type.CHAR_TYPE)
+        );
+        MatcherAssert.assertThat(
+            "We expect the type to be determined as long",
+            new Literal(1L).type(),
+            Matchers.equalTo(Type.LONG_TYPE)
+        );
+        MatcherAssert.assertThat(
+            "We expect the type to be determined as float",
+            new Literal(1.0f).type(),
+            Matchers.equalTo(Type.FLOAT_TYPE)
+        );
+        MatcherAssert.assertThat(
+            "We expect the type to be determined as double",
+            new Literal(1.0d).type(),
+            Matchers.equalTo(Type.DOUBLE_TYPE)
+        );
+        MatcherAssert.assertThat(
+            "We expect the type to be determined as boolean",
+            new Literal(true).type(),
+            Matchers.equalTo(Type.BOOLEAN_TYPE)
+        );
+        MatcherAssert.assertThat(
+            "We expect the type to be determined as byte",
+            new Literal((byte) 1).type(),
+            Matchers.equalTo(Type.BYTE_TYPE)
+        );
+        MatcherAssert.assertThat(
+            "We expect the type to be determined as short",
+            new Literal((short) 1).type(),
+            Matchers.equalTo(Type.SHORT_TYPE)
+        );
+    }
+
+
+    @Test
+    void convertsToOpcodesForBipush() {
+        MatcherAssert.assertThat(
+            "We expect the following opcodes to be generated: bipush 10",
+            new Literal(10).opcodes(),
+            Matchers.contains(
+                new Opcode(Opcodes.BIPUSH, 10)
+            )
+        );
+    }
+
+    @Test
+    void convertsToOpcodesForNull() {
+        MatcherAssert.assertThat(
+            "We expect the following opcodes to be generated: aconst_null",
+            new Literal().opcodes(),
+            Matchers.contains(
+                new Opcode(Opcodes.ACONST_NULL)
             )
         );
     }

--- a/src/test/java/org/eolang/opeo/ast/LiteralTest.java
+++ b/src/test/java/org/eolang/opeo/ast/LiteralTest.java
@@ -99,7 +99,6 @@ class LiteralTest {
         );
     }
 
-
     @Test
     void convertsToOpcodesForBipush() {
         MatcherAssert.assertThat(


### PR DESCRIPTION
Implement all types for `Literal` ast node. Now we can decompile/compile all the java constants.

Closes: #169.
____
History:
- **feat(#169): add types for literals**
- **feat(#169): remove the puzzle for 169 issue**
- **feat(#169): add tests for Literal**
- **feat(#169): fix all qulice suggestions**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add Lombok annotations, implement different types of literals, and add tests for supported types.

### Detailed summary
- Added Lombok annotations to `Opcode`
- Implemented various literal types in `Literal`
- Added tests for different types in `Literal`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->