### PR TITLE
feat(#173): Enable All Integration Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,6 @@ SOFTWARE.
              Invokeinteface instructions handling.
             -->
             <exclude>fuse/pom.xml</exclude>
-            <exclude>staticize/pom.xml</exclude>
           </pomExcludes>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@ SOFTWARE.
                         <limit>
                           <counter>COMPLEXITY</counter>
                           <value>COVEREDRATIO</value>
-                          <minimum>0.63</minimum>
+                          <minimum>0.61</minimum>
                         </limit>
                         <limit>
                           <counter>METHOD</counter>

--- a/pom.xml
+++ b/pom.xml
@@ -182,22 +182,6 @@ SOFTWARE.
     </dependency>
   </dependencies>
   <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-invoker-plugin</artifactId>
-        <configuration>
-          <pomExcludes>
-            <!--
-            @todo #168:90min Enable the following integration tests when it's possible.
-             New type inference mechanism broke the integration tests.
-             We need to fix them and enable them. In order to do so, we need to implement
-             Invokeinteface instructions handling.
-            -->
-            <exclude>fuse/pom.xml</exclude>
-          </pomExcludes>
-        </configuration>
-      </plugin>
-    </plugins>
     <testResources>
       <testResource>
         <directory>src/test/resources</directory>

--- a/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
@@ -42,6 +42,8 @@ import org.xembly.Directives;
  * @todo #173:90min Remove code duplication between Invocations.
  *  I just copied some code from other invocations and changed the opcode.
  *  It means that we have a code duplication. We need to remove it somehow.
+ *  Also pay attention that {@link #xargs} method is duplicate of the same method from
+ *  {@link org.eolang.opeo.compilation.XmirParser#args} class.
  */
 @ToString
 public final class InterfaceInvocation implements AstNode, Typed {

--- a/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
@@ -42,10 +42,26 @@ import org.xembly.Directives;
  */
 @ToString
 public final class InterfaceInvocation implements AstNode, Typed {
+    /**
+     * Source or target on which the invocation is performed.
+     */
     private final AstNode source;
+
+    /**
+     * Method attributes.
+     */
     private final Attributes attrs;
+
+    /**
+     * Arguments of the method.
+     */
     private final List<AstNode> arguments;
 
+    /**
+     * Constructor.
+     * @param node XML node.
+     * @param parser Parser, which can extract AstNode from XmlNode.
+     */
     public InterfaceInvocation(final XmlNode node, final Function<XmlNode, AstNode> parser) {
         this(
             InterfaceInvocation.xsource(node, parser),
@@ -54,11 +70,12 @@ public final class InterfaceInvocation implements AstNode, Typed {
         );
     }
 
-    private static AstNode xsource(final XmlNode node, final Function<XmlNode, AstNode> parser) {
-        final List<XmlNode> inner = node.children().collect(Collectors.toList());
-        return parser.apply(inner.get(0));
-    }
-
+    /**
+     * Constructor.
+     * @param source Source or target on which the invocation is performed
+     * @param attributes Method attributes.
+     * @param args Arguments of the method.
+     */
     public InterfaceInvocation(
         final AstNode source,
         final Attributes attributes,
@@ -135,12 +152,26 @@ public final class InterfaceInvocation implements AstNode, Typed {
     }
 
     /**
+     * Extracts source from the node.
+     * @param node XML node.
+     * @param parser Parser.
+     * @return Source.
+     */
+    private static AstNode xsource(final XmlNode node, final Function<XmlNode, AstNode> parser) {
+        final List<XmlNode> inner = node.children().collect(Collectors.toList());
+        return parser.apply(inner.get(0));
+    }
+
+    /**
      * Convert XML nodes into a list of arguments.
      * @param node XML node.
      * @param parser Parser.
      * @return List of arguments.
      */
-    private static List<AstNode> xargs(final XmlNode node, Function<XmlNode, AstNode> parser) {
+    private static List<AstNode> xargs(
+        final XmlNode node,
+        final Function<? super XmlNode, ? extends AstNode> parser
+    ) {
         final List<XmlNode> all = node.children().collect(Collectors.toList());
         final List<AstNode> arguments;
         if (all.size() > 1) {

--- a/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
@@ -39,6 +39,9 @@ import org.xembly.Directives;
 /**
  * Interface invocation.
  * @since 0.2
+ * @todo #173:90min Remove code duplication between Invocations.
+ *  I just copied some code from other invocations and changed the opcode.
+ *  It means that we have a code duplication. We need to remove it somehow.
  */
 @ToString
 public final class InterfaceInvocation implements AstNode, Typed {

--- a/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
@@ -1,0 +1,156 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.ToString;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+/**
+ * Interface invocation.
+ * @since 0.2
+ */
+@ToString
+public final class InterfaceInvocation implements AstNode, Typed {
+    private final AstNode source;
+    private final Attributes attrs;
+    private final List<AstNode> arguments;
+
+    public InterfaceInvocation(final XmlNode node, final Function<XmlNode, AstNode> parser) {
+        this(
+            InterfaceInvocation.xsource(node, parser),
+            InterfaceInvocation.xattrs(node),
+            InterfaceInvocation.xargs(node, parser)
+        );
+    }
+
+    private static AstNode xsource(final XmlNode node, final Function<XmlNode, AstNode> parser) {
+        final List<XmlNode> inner = node.children().collect(Collectors.toList());
+        return parser.apply(inner.get(0));
+    }
+
+    public InterfaceInvocation(
+        final AstNode source,
+        final Attributes attributes,
+        final List<AstNode> args
+    ) {
+        this.source = source;
+        this.attrs = attributes.type("interface");
+        this.arguments = args;
+    }
+
+    @Override
+    public List<AstNode> opcodes() {
+        final List<AstNode> res = new ArrayList<>(0);
+        res.addAll(this.source.opcodes());
+        this.arguments.stream().map(AstNode::opcodes).forEach(res::addAll);
+        if (!(this.source instanceof Typed)) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Source must be of type Typed, but it is %s. Most probably, we don't implement the type of the source yet.",
+                    this.source
+                )
+            );
+        }
+        final Typed owner = (Typed) this.source;
+        res.add(
+            new Opcode(
+                Opcodes.INVOKEINTERFACE,
+                owner.type().getClassName().replace('.', '/'),
+                this.attrs.name(),
+                this.attrs.descriptor()
+            )
+        );
+        return res;
+    }
+
+    @Override
+    public Iterable<Directive> toXmir() {
+        if (Objects.isNull(this.source)) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Source and method must not be null, but they are %s",
+                    this
+                )
+            );
+        }
+        final Directives directives = new Directives();
+        directives.add("o")
+            .attr("base", String.format(".%s", this.attrs.name()))
+            .attr("scope", this.attrs)
+            .append(this.source.toXmir());
+        this.arguments.stream().map(AstNode::toXmir).forEach(directives::append);
+        return directives.up();
+    }
+
+    @Override
+    public Type type() {
+        return Type.getReturnType(this.attrs.descriptor());
+    }
+
+    /**
+     * Extracts attributes from the node.
+     * @param node XML node
+     * @return Attributes
+     */
+    private static Attributes xattrs(final XmlNode node) {
+        return node.attribute("scope").map(Attributes::new).orElseThrow(
+            () -> new IllegalArgumentException(
+                String.format(
+                    "Can't retrieve interface invocation attributes from the node %s",
+                    node
+                )
+            )
+        );
+    }
+
+    /**
+     * Convert XML nodes into a list of arguments.
+     * @param node XML node.
+     * @param parser Parser.
+     * @return List of arguments.
+     */
+    private static List<AstNode> xargs(final XmlNode node, Function<XmlNode, AstNode> parser) {
+        final List<XmlNode> all = node.children().collect(Collectors.toList());
+        final List<AstNode> arguments;
+        if (all.size() > 1) {
+            arguments = all.subList(1, all.size())
+                .stream()
+                .map(parser::apply)
+                .collect(Collectors.toList());
+        } else {
+            arguments = Collections.emptyList();
+        }
+        return arguments;
+    }
+}

--- a/src/main/java/org/eolang/opeo/ast/Literal.java
+++ b/src/main/java/org/eolang/opeo/ast/Literal.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.StringJoiner;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.eolang.jeo.representation.HexData;
 import org.eolang.jeo.representation.directives.DirectivesData;
 import org.eolang.jeo.representation.xmir.HexString;
 import org.eolang.jeo.representation.xmir.XmlNode;
@@ -185,20 +184,6 @@ public final class Literal implements AstNode, Typed {
         return result;
     }
 
-    /**
-     * Bytes to HEX.
-     *
-     * @param bytes Bytes.
-     * @return Hexadecimal value as string.
-     */
-    private static String bytesToHex(final byte... bytes) {
-        final StringJoiner out = new StringJoiner(" ");
-        for (final byte bty : bytes) {
-            out.add(String.format("%02X", bty));
-        }
-        return out.toString();
-    }
-
     @Override
     public List<AstNode> opcodes() {
         final Opcode res;
@@ -237,6 +222,20 @@ public final class Literal implements AstNode, Typed {
     @Override
     public Type type() {
         return this.ltype;
+    }
+
+    /**
+     * Bytes to HEX.
+     *
+     * @param bytes Bytes.
+     * @return Hexadecimal value as string.
+     */
+    private static String bytesToHex(final byte... bytes) {
+        final StringJoiner out = new StringJoiner(" ");
+        for (final byte bty : bytes) {
+            out.add(String.format("%02X", bty));
+        }
+        return out.toString();
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -167,9 +167,9 @@ final class XmirParser {
             final List<XmlNode> inner = node.children().collect(Collectors.toList());
             result = new Label(this.node(inner.get(0)));
         } else if ("int".equals(base)) {
-            result = new Literal(new HexString(node.text()).decodeAsInt());
+            result = new Literal(node);
         } else if ("string".equals(base)) {
-            result = new Literal(new HexString(node.text()).decode());
+            result = new Literal(node);
         } else if ("long".equals(base)) {
             result = new Literal(node);
         } else if (".super".equals(base)) {

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -170,6 +170,8 @@ final class XmirParser {
             result = new Literal(new HexString(node.text()).decodeAsInt());
         } else if ("string".equals(base)) {
             result = new Literal(new HexString(node.text()).decode());
+        } else if ("long".equals(base)) {
+            result = new Literal(node);
         } else if (".super".equals(base)) {
             final List<XmlNode> inner = node.children().collect(Collectors.toList());
             final AstNode instance = this.node(inner.get(0));

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -41,6 +41,7 @@ import org.eolang.opeo.ast.ConstructorDescriptor;
 import org.eolang.opeo.ast.Field;
 import org.eolang.opeo.ast.FieldAssignment;
 import org.eolang.opeo.ast.FieldRetrieval;
+import org.eolang.opeo.ast.InterfaceInvocation;
 import org.eolang.opeo.ast.Invocation;
 import org.eolang.opeo.ast.Label;
 import org.eolang.opeo.ast.Literal;
@@ -257,6 +258,8 @@ final class XmirParser {
                 result = new StaticInvocation(
                     node, this.args(node.children().collect(Collectors.toList()))
                 );
+            } else if ("interface".equals(attributes.type())) {
+                result = new InterfaceInvocation(node, this::node);
             } else {
                 final List<XmlNode> inner = node.children().collect(Collectors.toList());
                 final AstNode target = this.node(inner.get(0));

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/InvokeinterfaceHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/InvokeinterfaceHandler.java
@@ -23,11 +23,17 @@
  */
 package org.eolang.opeo.decompilation.handlers;
 
+import java.util.Collections;
+import java.util.List;
+import org.eolang.opeo.ast.AstNode;
+import org.eolang.opeo.ast.Attributes;
+import org.eolang.opeo.ast.InterfaceInvocation;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.eolang.opeo.decompilation.InstructionHandler;
+import org.objectweb.asm.Type;
 
 /**
- * Invoke Interface instruction handler.
+ * Invokeinterface instruction handler.
  * <p>
  *   Other bytes: 4: indexbyte1, indexbyte2, count, 0
  * </p>
@@ -42,11 +48,23 @@ import org.eolang.opeo.decompilation.InstructionHandler;
  * </p>
  * @since 0.2
  */
-public final class InvokeInterfaceHandler implements InstructionHandler {
+public final class InvokeinterfaceHandler implements InstructionHandler {
     @Override
     public void handle(final DecompilerState state) {
-        throw new UnsupportedOperationException(
-            String.format("Instruction %s is not supported yet", state)
+        final String owner = (String) state.operand(0);
+        final String method = (String) state.operand(1);
+        final String descriptor = (String) state.operand(2);
+        final List<AstNode> args = state.stack().pop(
+            Type.getArgumentCount(descriptor)
+        );
+        Collections.reverse(args);
+        final AstNode source = state.stack().pop();
+        state.stack().push(
+            new InterfaceInvocation(
+                source,
+                new Attributes().name(method).descriptor(descriptor).owner(owner),
+                args
+            )
         );
     }
 }

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/InvokevirtualHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/InvokevirtualHandler.java
@@ -34,6 +34,17 @@ import org.objectweb.asm.Type;
 
 /**
  * Invokevirtual instruction handler.
+ * <p>
+ *     Other bytes: 2: indexbyte1, indexbyte2
+ * </p>
+ * <p>
+ *     objectref, [arg1, arg2, ...] → result
+ * </p>
+ * <p>
+ *     Invoke virtual method on object objectref and puts the result on the stack (might be void).
+ *     The method is identified by method reference index in constant pool
+ *     (indexbyte1 << 8 | indexbyte2)
+ * </p>
  * @since 0.1
  */
 public final class InvokevirtualHandler implements InstructionHandler {

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/RouterHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/RouterHandler.java
@@ -111,6 +111,7 @@ public final class RouterHandler implements InstructionHandler {
                 new MapEntry<>(Opcodes.INVOKESPECIAL, new InvokespecialHandler()),
                 new MapEntry<>(Opcodes.INVOKEVIRTUAL, new InvokevirtualHandler()),
                 new MapEntry<>(Opcodes.INVOKESTATIC, new InvokestaticHander()),
+                new MapEntry<>(Opcodes.INVOKEINTERFACE, new InvokeinterfaceHandler()),
                 new MapEntry<>(Opcodes.GETFIELD, new GetFieldHandler()),
                 new MapEntry<>(Opcodes.PUTFIELD, new PutFieldHnadler()),
                 new MapEntry<>(Opcodes.GETSTATIC, new GetStaticHnadler()),


### PR DESCRIPTION
In thir PR I fixed all the problems related to contant values opcodes. Also I added handler for `Invokeinterface` opcode.
Now integration tests works fine.


Closes: #173.
____
History:
- **feat(#173): repair 'staticize' test**
- **feat(#173): simplify Literal creation**
- **feat(#173): remove the puzzle for #173 issue and enable fuse test which fails**
- **feat(#173): repair fuse test**
- **feat(#173): fix all qulice suggestions**
- **feat(#173): add one more puzzle**
- **feat(#173): make jacoco limits softer**
