### PR TITLE
feat(#185): Actualize jtcop and qulice dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@ SOFTWARE.
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
-            <version>1.1.1</version>
+            <version>1.2.0</version>
             <executions>
               <execution>
                 <phase>verify</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@ SOFTWARE.
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.22.0</version>
+            <version>0.22.1</version>
             <configuration>
               <license>file:${basedir}/LICENSE.txt</license>
               <excludes>
@@ -212,6 +212,7 @@ SOFTWARE.
                 <exclude>pmd:/src/it/.*</exclude>
                 <exclude>checkstyle:/src/test/resources/.*</exclude>
                 <exclude>checkstyle:/src/it/.*</exclude>
+                <exclude>checkstyle:/src/site/.*</exclude>
                 <exclude>duplicatefinder:.*</exclude>
                 <!--
                   @todo #1:30min Enable dependency check.

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -120,11 +120,6 @@ final class XmirParser {
      * Convert XmlNode to AstNode.
      * @param node XmlNode
      * @return Ast node
-     * @checkstyle CyclomaticComplexityCheck (200 lines)
-     * @checkstyle ExecutableStatementCountCheck (200 lines)
-     * @checkstyle JavaNCSSCheck (200 lines)
-     * @checkstyle NestedIfDepthCheck (200 lines)
-     * @checkstyle MethodLengthCheck (200 lines)
      * @todo #77:90min Refactor this.node() method.
      *  The parsing method this.node() looks overcomplicated and violates many
      *  code quality standards. We should refactor the method and remove all
@@ -135,6 +130,11 @@ final class XmirParser {
      *  to remove all the if statements that use concerete class names as:
      *  - "org/eolang/benchmark/B"
      *  - "org/eolang/benchmark/BA"
+     * @checkstyle CyclomaticComplexityCheck (200 lines)
+     * @checkstyle ExecutableStatementCountCheck (200 lines)
+     * @checkstyle JavaNCSSCheck (200 lines)
+     * @checkstyle NestedIfDepthCheck (200 lines)
+     * @checkstyle MethodLengthCheck (200 lines)     *
      */
     @SuppressWarnings({"PMD.NcssCount", "PMD.ExcessiveMethodLength"})
     private AstNode node(final XmlNode node) {

--- a/src/test/java/org/eolang/opeo/CompileMojoTest.java
+++ b/src/test/java/org/eolang/opeo/CompileMojoTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
  *
  * @since 0.1
  */
-class CompileMojoTest {
+final class CompileMojoTest {
 
     @Test
     void createsMojoWithoutProblems() {

--- a/src/test/java/org/eolang/opeo/DecompileMojoTest.java
+++ b/src/test/java/org/eolang/opeo/DecompileMojoTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
  *
  * @since 0.1
  */
-class DecompileMojoTest {
+final class DecompileMojoTest {
 
     @Test
     void createsMojoWithoutProblems() {

--- a/src/test/java/org/eolang/opeo/ast/AddTest.java
+++ b/src/test/java/org/eolang/opeo/ast/AddTest.java
@@ -37,7 +37,7 @@ import org.xembly.Xembler;
  * Test case for {@link Add}.
  * @since 0.1
  */
-class AddTest {
+final class AddTest {
 
     @Test
     void convertsToXmir() throws ImpossibleModificationException {

--- a/src/test/java/org/eolang/opeo/ast/ArrayConstructorTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ArrayConstructorTest.java
@@ -35,7 +35,7 @@ import org.xembly.Xembler;
  * Test case for {@link ArrayConstructor}.
  * @since 0.1
  */
-class ArrayConstructorTest {
+final class ArrayConstructorTest {
 
     @Test
     void compilesSimpleArrayCreation() {

--- a/src/test/java/org/eolang/opeo/ast/ConstructorTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ConstructorTest.java
@@ -34,7 +34,7 @@ import org.xembly.Xembler;
  * Test case for {@link Constructor}.
  * @since 0.1
  */
-class ConstructorTest {
+final class ConstructorTest {
 
     @Test
     void transformsIntoXmir() throws ImpossibleModificationException {

--- a/src/test/java/org/eolang/opeo/ast/FieldRetrievalTest.java
+++ b/src/test/java/org/eolang/opeo/ast/FieldRetrievalTest.java
@@ -36,7 +36,7 @@ import org.xembly.Xembler;
  * Test case for {@link FieldRetrieval}.
  * @since 0.1
  */
-class FieldRetrievalTest {
+final class FieldRetrievalTest {
 
     @Test
     void convertsToXmir() throws ImpossibleModificationException {

--- a/src/test/java/org/eolang/opeo/ast/InvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InvocationTest.java
@@ -37,7 +37,7 @@ import org.xembly.Xembler;
  * Test case for {@link Invocation}.
  * @since 0.1
  */
-class InvocationTest {
+final class InvocationTest {
 
     @Test
     void transformsToXmir() throws ImpossibleModificationException {

--- a/src/test/java/org/eolang/opeo/ast/LiteralTest.java
+++ b/src/test/java/org/eolang/opeo/ast/LiteralTest.java
@@ -37,7 +37,7 @@ import org.xembly.Xembler;
  * Test case for {@link Literal}.
  * @since 0.1
  */
-class LiteralTest {
+final class LiteralTest {
 
     @Test
     void transformsToXmir() throws ImpossibleModificationException {

--- a/src/test/java/org/eolang/opeo/ast/MulTest.java
+++ b/src/test/java/org/eolang/opeo/ast/MulTest.java
@@ -33,7 +33,7 @@ import org.xembly.Xembler;
  * Test case for {@link Mul}.
  * @since 0.1
  */
-class MulTest {
+final class MulTest {
 
     @Test
     void convertsToXmir() throws ImpossibleModificationException {

--- a/src/test/java/org/eolang/opeo/ast/OpcodeTest.java
+++ b/src/test/java/org/eolang/opeo/ast/OpcodeTest.java
@@ -35,7 +35,7 @@ import org.xembly.Xembler;
  * Test case for {@link Opcode}.
  * @since 0.1
  */
-class OpcodeTest {
+final class OpcodeTest {
 
     @Test
     void transformsToXml() {

--- a/src/test/java/org/eolang/opeo/ast/RootTest.java
+++ b/src/test/java/org/eolang/opeo/ast/RootTest.java
@@ -36,7 +36,7 @@ import org.xembly.Xembler;
  * Test case for {@link Root}.
  * @since 0.1
  */
-class RootTest {
+final class RootTest {
 
     @Test
     void combinesAllChildElementsIntoSingleXmir() throws ImpossibleModificationException {

--- a/src/test/java/org/eolang/opeo/ast/SubstractionTest.java
+++ b/src/test/java/org/eolang/opeo/ast/SubstractionTest.java
@@ -39,7 +39,7 @@ import org.xembly.Xembler;
  *
  * @since 0.2
  */
-class SubstractionTest {
+final class SubstractionTest {
 
     @Test
     void convertsToXmir() throws ImpossibleModificationException {

--- a/src/test/java/org/eolang/opeo/ast/SuperTest.java
+++ b/src/test/java/org/eolang/opeo/ast/SuperTest.java
@@ -36,7 +36,7 @@ import org.xembly.Xembler;
  * Test case for {@link Super}.
  * @since 0.1
  */
-class SuperTest {
+final class SuperTest {
 
     @Test
     void convertsToXmir() throws ImpossibleModificationException {

--- a/src/test/java/org/eolang/opeo/ast/ThisTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ThisTest.java
@@ -33,7 +33,7 @@ import org.xembly.Xembler;
  * Test case for {@link org.eolang.opeo.ast.This}.
  * @since 0.1
  */
-class ThisTest {
+final class ThisTest {
 
     @Test
     void convertsToXmir() throws ImpossibleModificationException {

--- a/src/test/java/org/eolang/opeo/compilation/HasInstructions.java
+++ b/src/test/java/org/eolang/opeo/compilation/HasInstructions.java
@@ -41,7 +41,11 @@ import org.xembly.Xembler;
  * Matcher for {@link List} of {@link XmlNode} to have specific instructions.
  * @since 0.1
  */
-@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleCorrectTestName"})
+@SuppressWarnings({
+    "JTCOP.RuleAllTestsHaveProductionClass",
+    "JTCOP.RuleCorrectTestName",
+    "JTCOP.RuleInheritanceInTests"
+})
 public final class HasInstructions extends TypeSafeMatcher<List<XmlNode>> {
 
     /**

--- a/src/test/java/org/eolang/opeo/decompilation/DecompilerTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/DecompilerTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.io.TempDir;
  * Test case for {@link Decompiler}.
  * @since 0.1
  */
-class DecompilerTest {
+final class DecompilerTest {
 
     @Test
     void decompilesSeveralFiles(@TempDir final Path temp) throws Exception {

--- a/src/test/java/org/eolang/opeo/decompilation/LocalVariablesTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/LocalVariablesTest.java
@@ -35,7 +35,7 @@ import org.objectweb.asm.Type;
  * Test for {@link LocalVariables}.
  * @since 0.1
  */
-class LocalVariablesTest {
+final class LocalVariablesTest {
 
     @Test
     void returnsVariable() {

--- a/src/test/java/org/eolang/opeo/jeo/JeoInstructionsTest.java
+++ b/src/test/java/org/eolang/opeo/jeo/JeoInstructionsTest.java
@@ -35,7 +35,7 @@ import org.objectweb.asm.Opcodes;
  * Test case for {@link JeoInstructions}.
  * @since 0.1
  */
-class JeoInstructionsTest {
+final class JeoInstructionsTest {
 
     @Test
     void parsesJeoInstructions() {


### PR DESCRIPTION
In thir PR I updated `jtcop-maven-plugin` to `1.2.0` version and `qulice-maven-plugin` to `0.22.1` version.

Closes: #185.
____
History:
- **feat(#185): update jtcop 1.2.0**
- **feat(#185): update qulice 0.22.1**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to make classes `final` and update plugin versions.

### Detailed summary
- Made test classes `final`
- Updated Qulice and Jtcop plugin versions
- Added new exclusions in Qulice plugin configuration
- Refactored parsing method in `XmirParser.java` to comply with code quality standards

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->