### PR TITLE
feat(#189): Enable All Integration Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,23 +182,6 @@ SOFTWARE.
     </dependency>
   </dependencies>
   <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-invoker-plugin</artifactId>
-        <configuration>
-          <pomExcludes>
-            <!--
-            @todo #174:30min Enable the following integration tests when it's possible.
-             Now this integration tests are disabled, because optimizations generate wrongly formatted
-             EO code. We need to fix this issue and enable the tests.
-            -->
-            <exclude>staticize/pom.xml</exclude>
-            <exclude>fuse/pom.xml</exclude>
-          </pomExcludes>
-        </configuration>
-      </plugin>
-    </plugins>
     <testResources>
       <testResource>
         <directory>src/test/resources</directory>

--- a/src/main/java/org/eolang/opeo/ast/Label.java
+++ b/src/main/java/org/eolang/opeo/ast/Label.java
@@ -55,7 +55,7 @@ public final class Label implements AstNode {
      * @param identifier Label identifier.
      */
     public Label(final String identifier) {
-        this.identifier = new HexString(identifier).decode();
+        this.identifier = new HexString(identifier.trim()).decode();
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/ast/Label.java
+++ b/src/main/java/org/eolang/opeo/ast/Label.java
@@ -47,7 +47,7 @@ public final class Label implements AstNode {
      * @param node XML node.
      */
     public Label(final XmlNode node) {
-        this(new HexString(node.text()).decode());
+        this(node.text());
     }
 
     /**
@@ -55,7 +55,7 @@ public final class Label implements AstNode {
      * @param identifier Label identifier.
      */
     public Label(final String identifier) {
-        this.identifier = identifier;
+        this.identifier = new HexString(identifier).decode();
     }
 
     @Override

--- a/src/test/java/org/eolang/opeo/ast/LabelTest.java
+++ b/src/test/java/org/eolang/opeo/ast/LabelTest.java
@@ -41,7 +41,7 @@ final class LabelTest {
     void convertsToXmir() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "The label should be converted to XMIR",
-            new Xembler(new Label("foo").toXmir(), new Transformers.Node()).xml(),
+            new Xembler(new Label("66 6F 6F").toXmir(), new Transformers.Node()).xml(),
             Matchers.equalTo("<o base=\"label\" data=\"bytes\">66 6F 6F</o>")
         );
     }

--- a/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
@@ -24,7 +24,6 @@
 package org.eolang.opeo.decompilation;
 
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.eolang.jeo.representation.xmir.AllLabels;
 import org.eolang.opeo.LabelInstruction;

--- a/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
@@ -192,8 +192,7 @@ final class DecompilerMachineTest {
     @Test
     void decompilesIfStatement() {
         final AllLabels labels = new AllLabels();
-        final String uid = UUID.randomUUID().toString();
-        final Label label = labels.label(uid);
+        final Label label = labels.label("66 6F 6F");
         Assertions.assertDoesNotThrow(
             () -> {
                 new DecompilerMachine().decompile(


### PR DESCRIPTION

In this PR I enable all the integration tests that were temporarly disabled. Now all the integration tests work perfectly.
Closes: #189.
____
History:
- **feat(#189): fix small problems with labels identifiers encoding/decoding**
- **feat(#189): fix decompile-compile integration test**
- **feat(#189): fix all the linter suggestions**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `Label` class to handle hexadecimal identifiers and replaces UUIDs with hexadecimal values in tests.

### Detailed summary
- `Label` class now decodes hexadecimal identifiers
- Test values replaced with hexadecimal strings
- Removed unused imports and commented-out code in `pom.xml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->