### PR TITLE
feat(#190): Update Jeo Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>jeo-maven-plugin</artifactId>
-      <version>0.3.3</version>
+      <version>0.3.4</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/src/main/java/org/eolang/opeo/jeo/JeoLabel.java
+++ b/src/main/java/org/eolang/opeo/jeo/JeoLabel.java
@@ -70,21 +70,6 @@ public final class JeoLabel implements Instruction {
 
     @Override
     public List<Object> operands() {
-        try {
-            // @checkstyle MethodBodyCommentsCheck (10 line)
-            //  @todo #174:30min The following code is a hack to get the label identifier.
-            //   We need to refactor it and handle it differently, in a more straightforward way.
-            //   To do so, we need to open #identifier method in jeo-maven-plugin.
-            final Field field = this.label.getClass().getDeclaredField("node");
-            field.setAccessible(true);
-            return List.of(
-                XmlNode.class.cast(field.get(this.label)).text()
-            );
-        } catch (final IllegalAccessException | NoSuchFieldException exception) {
-            throw new IllegalStateException(
-                "Can't get the label node text",
-                exception
-            );
-        }
+        return List.of(this.label.identifier());
     }
 }

--- a/src/main/java/org/eolang/opeo/jeo/JeoLabel.java
+++ b/src/main/java/org/eolang/opeo/jeo/JeoLabel.java
@@ -23,10 +23,8 @@
  */
 package org.eolang.opeo.jeo;
 
-import java.lang.reflect.Field;
 import java.util.List;
 import org.eolang.jeo.representation.xmir.XmlLabel;
-import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.Instruction;
 
 /**


### PR DESCRIPTION
Update `jeo-maven-plugin` version to `0.3.4`. This update allowed to remove ad-hoc solution for label identifier retrieval.

Closes: #190.
_____
History:
- **feat(#190): remove ad-hoc solution of label identifier retrieval**
- **feat(#190): optimize imports**

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the `operand` method in `JeoLabel.java` to simplify getting the label identifier.

### Detailed summary
- Refactored `operand` method to return label identifier directly
- Removed hacky code for getting label identifier
- Improved code readability and maintainability

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->