### PR TITLE
feat(#229): Optimize Memory Consumption

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>jeo-maven-plugin</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>0.4.3</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>jeo-maven-plugin</artifactId>
-      <version>0.4.2</version>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/src/it/spring-fat/invoker.properties
+++ b/src/it/spring-fat/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals=clean process-classes -e
+invoker.goals=clean generate-test-sources -e

--- a/src/it/spring-fat/invoker.properties
+++ b/src/it/spring-fat/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals=clean generate-test-sources -e
+invoker.goals=clean test -e

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -97,7 +97,6 @@ SOFTWARE.
             </goals>
             <configuration>
               <outputDir>${project.build.directory}/generated-sources/jeo-disassemble-xmir</outputDir>
-              <skipVerification>true</skipVerification>
             </configuration>
           </execution>
         </executions>
@@ -139,6 +138,7 @@ SOFTWARE.
               <outputDir>${project.build.directory}/generated-sources/opeo-compile-xmir</outputDir>
             </configuration>
           </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.eolang</groupId>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -53,7 +53,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <jeo.version>1.0-SNAPSHOT</jeo.version>
+    <jeo.version>0.4.3</jeo.version>
     <ineo.version>0.2.1</ineo.version>
   </properties>
   <dependencies>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -53,7 +53,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <jeo.version>0.4.2</jeo.version>
+    <jeo.version>1.0-SNAPSHOT</jeo.version>
     <ineo.version>0.2.1</ineo.version>
   </properties>
   <dependencies>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -33,7 +33,7 @@ SOFTWARE.
       here that requires java 11 since our plugin should be compatible with
       java 11.
     -->
-    <version>3.2.5</version>
+    <version>2.7.18</version>
     <relativePath/>
   </parent>
   <groupId>org.eolang</groupId>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -128,17 +128,6 @@ SOFTWARE.
               <outputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</outputDir>
             </configuration>
           </execution>
-<!--          <execution>-->
-<!--            <id>opeo-compile</id>-->
-<!--            <phase>generate-test-sources</phase>-->
-<!--            <goals>-->
-<!--              <goal>compile</goal>-->
-<!--            </goals>-->
-<!--            <configuration>-->
-<!--              <sourcesDir>${project.build.directory}/generated-sources/ineo-staticize-xmir</sourcesDir>-->
-<!--              <outputDir>${project.build.directory}/generated-sources/opeo-compile-xmir</outputDir>-->
-<!--            </configuration>-->
-<!--          </execution>-->
           <execution>
             <id>opeo-compile</id>
             <phase>generate-test-sources</phase>
@@ -146,30 +135,29 @@ SOFTWARE.
               <goal>compile</goal>
             </goals>
             <configuration>
-              <sourcesDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</sourcesDir>
+              <sourcesDir>${project.build.directory}/generated-sources/ineo-staticize-xmir</sourcesDir>
               <outputDir>${project.build.directory}/generated-sources/opeo-compile-xmir</outputDir>
+            </configuration>
+          </execution>
+      </plugin>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>ineo-maven-plugin</artifactId>
+        <version>${ineo.version}</version>
+        <executions>
+          <execution>
+            <id>ineo-staticize</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>staticize</goal>
+            </goals>
+            <configuration>
+              <sourcesDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</sourcesDir>
+              <outputDir>${project.build.directory}/generated-sources/ineo-staticize-xmir</outputDir>
             </configuration>
           </execution>
         </executions>
       </plugin>
-<!--      <plugin>-->
-<!--        <groupId>org.eolang</groupId>-->
-<!--        <artifactId>ineo-maven-plugin</artifactId>-->
-<!--        <version>${ineo.version}</version>-->
-<!--        <executions>-->
-<!--          <execution>-->
-<!--            <id>ineo-staticize</id>-->
-<!--            <phase>process-classes</phase>-->
-<!--            <goals>-->
-<!--              <goal>staticize</goal>-->
-<!--            </goals>-->
-<!--            <configuration>-->
-<!--              <sourcesDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</sourcesDir>-->
-<!--              <outputDir>${project.build.directory}/generated-sources/ineo-staticize-xmir</outputDir>-->
-<!--            </configuration>-->
-<!--          </execution>-->
-<!--        </executions>-->
-<!--      </plugin>-->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -97,6 +97,7 @@ SOFTWARE.
             </goals>
             <configuration>
               <outputDir>${project.build.directory}/generated-sources/jeo-disassemble-xmir</outputDir>
+              <skipVerification>true</skipVerification>
             </configuration>
           </execution>
         </executions>
@@ -127,6 +128,17 @@ SOFTWARE.
               <outputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</outputDir>
             </configuration>
           </execution>
+<!--          <execution>-->
+<!--            <id>opeo-compile</id>-->
+<!--            <phase>generate-test-sources</phase>-->
+<!--            <goals>-->
+<!--              <goal>compile</goal>-->
+<!--            </goals>-->
+<!--            <configuration>-->
+<!--              <sourcesDir>${project.build.directory}/generated-sources/ineo-staticize-xmir</sourcesDir>-->
+<!--              <outputDir>${project.build.directory}/generated-sources/opeo-compile-xmir</outputDir>-->
+<!--            </configuration>-->
+<!--          </execution>-->
           <execution>
             <id>opeo-compile</id>
             <phase>generate-test-sources</phase>
@@ -134,30 +146,30 @@ SOFTWARE.
               <goal>compile</goal>
             </goals>
             <configuration>
-              <sourcesDir>${project.build.directory}/generated-sources/ineo-staticize-xmir</sourcesDir>
+              <sourcesDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</sourcesDir>
               <outputDir>${project.build.directory}/generated-sources/opeo-compile-xmir</outputDir>
             </configuration>
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.eolang</groupId>
-        <artifactId>ineo-maven-plugin</artifactId>
-        <version>${ineo.version}</version>
-        <executions>
-          <execution>
-            <id>ineo-staticize</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>staticize</goal>
-            </goals>
-            <configuration>
-              <sourcesDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</sourcesDir>
-              <outputDir>${project.build.directory}/generated-sources/ineo-staticize-xmir</outputDir>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+<!--      <plugin>-->
+<!--        <groupId>org.eolang</groupId>-->
+<!--        <artifactId>ineo-maven-plugin</artifactId>-->
+<!--        <version>${ineo.version}</version>-->
+<!--        <executions>-->
+<!--          <execution>-->
+<!--            <id>ineo-staticize</id>-->
+<!--            <phase>process-classes</phase>-->
+<!--            <goals>-->
+<!--              <goal>staticize</goal>-->
+<!--            </goals>-->
+<!--            <configuration>-->
+<!--              <sourcesDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</sourcesDir>-->
+<!--              <outputDir>${project.build.directory}/generated-sources/ineo-staticize-xmir</outputDir>-->
+<!--            </configuration>-->
+<!--          </execution>-->
+<!--        </executions>-->
+<!--      </plugin>-->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
@@ -183,7 +195,7 @@ SOFTWARE.
                    the transformation. For not it's not so crucial, but in the future, we
                    should enable it.
                 -->
-                <argument>-Djeo.assemble.skipVerification=true</argument>
+                <argument>-Djeo.assemble.skip.verification=true</argument>
                 <argument>-e</argument>
               </arguments>
             </configuration>

--- a/src/it/spring-fat/src/test/java/org/eolang/jeo/spring/FactorialApplicationTest.java
+++ b/src/it/spring-fat/src/test/java/org/eolang/jeo/spring/FactorialApplicationTest.java
@@ -61,6 +61,7 @@ class FactorialApplicationTest {
             "Response body is empty"
         );
         final String expected = "sum=3628800";
+        System.out.printf("Expected %s%n", expected);
         Assertions.assertTrue(
             resp.getBody().contains(expected),
             String.format(

--- a/src/main/java/org/eolang/opeo/compilation/DefaultCompiler.java
+++ b/src/main/java/org/eolang/opeo/compilation/DefaultCompiler.java
@@ -72,10 +72,7 @@ public class DefaultCompiler implements Compiler {
         Logger.info(
             this,
             "Compiled %d sources",
-            this.storage.all()
-                .stream()
-                .mapToInt(this::compile)
-                .sum()
+            this.storage.all().mapToInt(this::compile).sum()
         );
     }
 

--- a/src/main/java/org/eolang/opeo/compilation/DefaultCompiler.java
+++ b/src/main/java/org/eolang/opeo/compilation/DefaultCompiler.java
@@ -72,7 +72,10 @@ public class DefaultCompiler implements Compiler {
         Logger.info(
             this,
             "Compiled %d sources",
-            this.storage.all().mapToInt(this::compile).sum()
+            this.storage.all()
+                .parallel()
+                .mapToInt(this::compile)
+                .sum()
         );
     }
 

--- a/src/main/java/org/eolang/opeo/decompilation/DefaultDecompiler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DefaultDecompiler.java
@@ -78,7 +78,9 @@ public final class DefaultDecompiler implements Decompiler {
         Logger.info(
             this,
             "Decompiled %d EO sources",
-            this.storage.all().mapToInt(this::decompile).sum()
+            this.storage.all()
+                .parallel()
+                .mapToInt(this::decompile).sum()
         );
     }
 

--- a/src/main/java/org/eolang/opeo/decompilation/DefaultDecompiler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DefaultDecompiler.java
@@ -78,7 +78,7 @@ public final class DefaultDecompiler implements Decompiler {
         Logger.info(
             this,
             "Decompiled %d EO sources",
-            this.storage.all().stream().mapToInt(this::decompile).sum()
+            this.storage.all().mapToInt(this::decompile).sum()
         );
     }
 

--- a/src/main/java/org/eolang/opeo/storage/CompilationStorage.java
+++ b/src/main/java/org/eolang/opeo/storage/CompilationStorage.java
@@ -27,7 +27,7 @@ import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collection;
+import java.util.stream.Stream;
 
 /**
  * Compilation storage.
@@ -66,7 +66,7 @@ public final class CompilationStorage implements Storage {
     }
 
     @Override
-    public Collection<XmirEntry> all() {
+    public Stream<XmirEntry> all() {
         Logger.info(this, "Compiling EO sources from %[file]s", this.xmirs);
         Logger.info(this, "Saving new compiled EO sources to %[file]s", this.output);
         return this.original.all();

--- a/src/main/java/org/eolang/opeo/storage/DecompilationStorage.java
+++ b/src/main/java/org/eolang/opeo/storage/DecompilationStorage.java
@@ -27,7 +27,7 @@ import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collection;
+import java.util.stream.Stream;
 
 /**
  * Decompilation storage.
@@ -66,7 +66,7 @@ public final class DecompilationStorage implements Storage {
     }
 
     @Override
-    public Collection<XmirEntry> all() {
+    public Stream<XmirEntry> all() {
         Logger.info(this, "Decompiling EO sources from %[file]s", this.xmirs);
         Logger.info(this, "Saving new decompiled EO sources to %[file]s", this.output);
         return this.original.all();

--- a/src/main/java/org/eolang/opeo/storage/FileStorage.java
+++ b/src/main/java/org/eolang/opeo/storage/FileStorage.java
@@ -137,14 +137,7 @@ public final class FileStorage implements Storage {
      * @return XMIR entry.
      */
     private XmirEntry entry(final Path path) {
-        try {
-            return new XmirEntry(new XMLDocument(path), this.xmirs.relativize(path).toString());
-        } catch (final FileNotFoundException exception) {
-            throw new IllegalStateException(
-                String.format("Can't decompile '%x'", path),
-                exception
-            );
-        }
+        return new XmirEntry(path, this.xmirs.relativize(path).toString());
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/storage/FileStorage.java
+++ b/src/main/java/org/eolang/opeo/storage/FileStorage.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.opeo.storage;
 
-import com.jcabi.xml.XMLDocument;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/org/eolang/opeo/storage/FileStorage.java
+++ b/src/main/java/org/eolang/opeo/storage/FileStorage.java
@@ -30,8 +30,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collection;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -61,7 +59,7 @@ public final class FileStorage implements Storage {
     }
 
     @Override
-    public Collection<XmirEntry> all() {
+    public Stream<XmirEntry> all() {
         if (!Files.exists(this.xmirs)) {
             throw new IllegalArgumentException(
                 String.format(
@@ -70,10 +68,11 @@ public final class FileStorage implements Storage {
                 )
             );
         }
-        try (Stream<Path> files = Files.walk(this.xmirs).filter(Files::isRegularFile)) {
-            return files.filter(FileStorage::isXmir)
-                .map(this::entry)
-                .collect(Collectors.toList());
+        try {
+            return Files.walk(this.xmirs)
+                .filter(Files::isRegularFile)
+                .filter(FileStorage::isXmir)
+                .map(this::entry);
         } catch (final IOException exception) {
             throw new IllegalStateException(
                 String.format("Can't retrieve XMIR files from the '%s' folder", this.xmirs),

--- a/src/main/java/org/eolang/opeo/storage/Storage.java
+++ b/src/main/java/org/eolang/opeo/storage/Storage.java
@@ -23,7 +23,7 @@
  */
 package org.eolang.opeo.storage;
 
-import java.util.Collection;
+import java.util.stream.Stream;
 
 /**
  * Storage.
@@ -36,7 +36,7 @@ public interface Storage {
      * Get all XMIRs.
      * @return All XMIRs
      */
-    Collection<XmirEntry> all();
+    Stream<XmirEntry> all();
 
     /**
      * Save XMIR.

--- a/src/main/java/org/eolang/opeo/storage/XmirEntry.java
+++ b/src/main/java/org/eolang/opeo/storage/XmirEntry.java
@@ -67,7 +67,7 @@ public final class XmirEntry {
      * @param pckg Package name.
      */
     XmirEntry(final XML xmir, final String pckg) {
-        this(XmirEntry.fromXML(xmir), pckg);
+        this(XmirEntry.fromXml(xmir), pckg);
     }
 
     /**
@@ -134,7 +134,7 @@ public final class XmirEntry {
      * @param xml XML.
      * @return Lazy XMIR entry.
      */
-    private static Unchecked<XML> fromXML(final XML xml) {
+    private static Unchecked<XML> fromXml(final XML xml) {
         return new Unchecked<>(new Synced<>(new Sticky<>(() -> xml)));
     }
 


### PR DESCRIPTION
In this PR I optimized memory usage in the plugin. Now we use a streamed approach to handle files (we handle them one by one). Before that we just read all files at the beggining and handled them later.
Also I paralleled 'decompile' and 'compile' goals.

Related to #229
History:
- **feat(#229): use 2.7.18 version of spring boot**
- **feat(#229): use jeo snapshot instead of a stable version**
- **feat(#229): make Storage to return Stream instead of Collection**
- **feat(#229): make XmirEntry to load XML in a lazy mode**
- **feat(#229): use 0.4.3 version of the jeo-maven-plugin**
- **feat(#229): parallelize compiler and decompiler**
- **feat(#229): use generate-test-sources phase for spring-fat integration test**
- **feat(#229): disable ineo plugin and bytecode verification in jeo plugin**
- **feat(#229): enable ineo plugin back**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates Maven dependencies and switches from using `Collection` to `Stream` for storage operations. It also refactors `XmirEntry` to use lazy loading for XML data.

### Detailed summary
- Updated Maven dependencies to `0.4.3` and `2.7.18`
- Replaced `Collection` with `Stream` in storage classes
- Refactored `XmirEntry` to use lazy loading for XML data

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->