### PR TITLE
feat(#229): Make 'spring-fat' Integration Test Pass Successfully

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@ SOFTWARE.
   </distributionManagement>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <skipITs/>
   </properties>
   <dependencies>
@@ -137,7 +137,8 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>jeo-maven-plugin</artifactId>
-      <version>0.4.3</version>
+<!--      <version>0.4.3</version>-->
+      <version>1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,8 +137,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>jeo-maven-plugin</artifactId>
-<!--      <version>0.4.3</version>-->
-      <version>1.0-SNAPSHOT</version>
+      <version>0.4.4</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/src/it/spring-fat/README.md
+++ b/src/it/spring-fat/README.md
@@ -44,12 +44,13 @@ mvn clean integration-test invoker:run -Dinvoker.test=spring-fat -DskipTests
 Here is the summary of the first results of the `spring-fat` integration test:
 
 - The application starts and runs successfully.
-- The average test time is approximately **X seconds**.
-- The total number of classes is **Y**.
-- The Disassembly phase takes approximately **Z minutes**.
+- The average test time is approximately **826 seconds (13 minutes)**.
+- The total number of classes is **19511 (19516 — sometimes the number is
+  different? Why?)**.
+- The Disassembly phase takes approximately **1 minute**.
 - The Decompile phase takes approximately **K minutes**.
 - The Compile phase takes approximately **L minutes**.
-- The Assembly phase takes approximately **N minutes**.
+- The Assembly phase takes approximately **56 seconds**.
 
 ## Developer Notes
 

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -53,7 +53,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-<!--    <jeo.version>0.4.3</jeo.version>-->
+    <jeo.version>0.4.4</jeo.version>
     <jeo.version>1.0-SNAPSHOT</jeo.version>
     <ineo.version>0.2.1</ineo.version>
   </properties>
@@ -81,189 +81,120 @@ SOFTWARE.
               <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
+<!--            TODO-->
             <excludes>
               module-info.class
-</excludes>
+             </excludes>
               <outputDirectory>${project.build.outputDirectory}</outputDirectory>
             </configuration>
           </execution>
         </executions>
       </plugin>
-<!--<plugin>-->
-<!--  <groupId>org.apache.maven.plugins</groupId>-->
-<!--  <artifactId>maven-compiler-plugin</artifactId>-->
-<!--  <configuration>-->
-<!--    <source>1.8</source>-->
-<!--    <target>1.8</target>-->
-<!--  </configuration>-->
-<!--  <executions>-->
-<!--    <execution>-->
-<!--      <id>test-compile</id>-->
-<!--      <phase>process-test-sources</phase>-->
-<!--      <goals>-->
-<!--        <goal>testCompile</goal>-->
-<!--      </goals>-->
-<!--    </execution>-->
-<!--  </executions>-->
-<!--</plugin>-->
-
-
-<!--           <plugin>-->
-<!--              <groupId>org.eolang</groupId>-->
-<!--              <artifactId>jeo-maven-plugin</artifactId>-->
-<!--              <version>${jeo.version}</version>-->
-<!--              <executions>-->
-<!--                <execution>-->
-<!--                  <id>bytecode-to-eo</id>-->
-<!--                  <goals>-->
-<!--                    <goal>disassemble</goal>-->
-<!--                  </goals>-->
-<!--                  <configuration>-->
-<!--                    <outputDir>${project.build.directory}/generated-sources/jeo-disassemble-xmir</outputDir>-->
-<!--                  </configuration>-->
-<!--                </execution>-->
-<!--              </executions>-->
-<!--            </plugin>-->
-<!--            <plugin>-->
-<!--              <groupId>org.codehaus.mojo</groupId>-->
-<!--              <artifactId>exec-maven-plugin</artifactId>-->
-<!--              <version>3.2.0</version>-->
-<!--              <configuration>-->
-<!--                <executable>mvn</executable>-->
-<!--              </configuration>-->
-<!--              <executions>-->
-<!--                <execution>-->
-<!--                  <id>jeo-to-bytecode</id>-->
-<!--                  <phase>generate-test-sources</phase>-->
-<!--                  <goals>-->
-<!--                    <goal>exec</goal>-->
-<!--                  </goals>-->
-<!--                  <configuration>-->
-<!--                    <arguments combine.children="append">-->
-<!--                      <argument>org.eolang:jeo-maven-plugin:${jeo.version}:assemble</argument>-->
-<!--                      <argument>-Djeo.assemble.sourcesDir=${project.build.directory}/generated-sources/jeo-disassemble-xmir</argument>-->
-<!--                      &lt;!&ndash;-->
-<!--                        @todo #200:90min Enable Bytecode Verification For Spring Fat Integration Test.-->
-<!--                         We skip verification because the Spring Framework uses many classes that-->
-<!--                         are not in the classpath and the plugin cannot verify the correctness of-->
-<!--                         the transformation. For not it's not so crucial, but in the future, we-->
-<!--                         should enable it.-->
-<!--                      &ndash;&gt;-->
-<!--                      <argument>-Djeo.assemble.skip.verification=true</argument>-->
-<!--                      <argument>-e</argument>-->
-<!--                    </arguments>-->
-<!--                  </configuration>-->
-<!--                </execution>-->
-<!--              </executions>-->
-<!--            </plugin>-->
-
-
-
-<!--      <plugin>-->
-<!--        <groupId>org.eolang</groupId>-->
-<!--        <artifactId>jeo-maven-plugin</artifactId>-->
-<!--        <version>${jeo.version}</version>-->
-<!--        <executions>-->
-<!--          <execution>-->
-<!--            <id>bytecode-to-eo</id>-->
-<!--            <goals>-->
-<!--              <goal>disassemble</goal>-->
-<!--            </goals>-->
-<!--            <configuration>-->
-<!--              <outputDir>${project.build.directory}/generated-sources/jeo-disassemble-xmir</outputDir>-->
-<!--            </configuration>-->
-<!--          </execution>-->
-<!--        </executions>-->
-<!--      </plugin>-->
-<!--      <plugin>-->
-<!--        <groupId>org.eolang</groupId>-->
-<!--        <artifactId>opeo-maven-plugin</artifactId>-->
-<!--        <version>@project.version@</version>-->
-<!--        &lt;!&ndash;-->
-<!--            @todo #219:90min Enable Opeo Spring Fat Integration Test.-->
-<!--             The test is disabled because it fails in many places.-->
-<!--             We have to fix all the tests steps and enable this test.-->
-<!--             Don't forget to add this test to the merge workflow.-->
-<!--             see .github/workflows/maven.test.yaml-->
-<!--             Also don't forget to remove the disabled tag from the configuration.-->
-<!--          &ndash;&gt;-->
-<!--        <configuration>-->
-<!--          <disabled>true</disabled>-->
-<!--        </configuration>-->
-<!--        <executions>-->
-<!--          <execution>-->
-<!--            <id>opeo-decompile</id>-->
-<!--            <goals>-->
-<!--              <goal>decompile</goal>-->
-<!--            </goals>-->
-<!--            <configuration>-->
-<!--              <sourcesDir>${project.build.directory}/generated-sources/jeo-disassemble-xmir</sourcesDir>-->
-<!--              <outputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</outputDir>-->
-<!--            </configuration>-->
-<!--          </execution>-->
-<!--          <execution>-->
-<!--            <id>opeo-compile</id>-->
-<!--            <phase>generate-test-sources</phase>-->
-<!--            <goals>-->
-<!--              <goal>compile</goal>-->
-<!--            </goals>-->
-<!--            <configuration>-->
-<!--              <sourcesDir>${project.build.directory}/generated-sources/ineo-staticize-xmir</sourcesDir>-->
-<!--              <outputDir>${project.build.directory}/generated-sources/opeo-compile-xmir</outputDir>-->
-<!--            </configuration>-->
-<!--          </execution>-->
-<!--        </executions>-->
-<!--      </plugin>-->
-<!--      <plugin>-->
-<!--        <groupId>org.eolang</groupId>-->
-<!--        <artifactId>ineo-maven-plugin</artifactId>-->
-<!--        <version>${ineo.version}</version>-->
-<!--        <executions>-->
-<!--          <execution>-->
-<!--            <id>ineo-staticize</id>-->
-<!--            <phase>process-classes</phase>-->
-<!--            <goals>-->
-<!--              <goal>staticize</goal>-->
-<!--            </goals>-->
-<!--            <configuration>-->
-<!--              <sourcesDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</sourcesDir>-->
-<!--              <outputDir>${project.build.directory}/generated-sources/ineo-staticize-xmir</outputDir>-->
-<!--            </configuration>-->
-<!--          </execution>-->
-<!--        </executions>-->
-<!--      </plugin>-->
-<!--      <plugin>-->
-<!--        <groupId>org.codehaus.mojo</groupId>-->
-<!--        <artifactId>exec-maven-plugin</artifactId>-->
-<!--        <version>3.2.0</version>-->
-<!--        <configuration>-->
-<!--          <executable>mvn</executable>-->
-<!--        </configuration>-->
-<!--        <executions>-->
-<!--          <execution>-->
-<!--            <id>jeo-to-bytecode</id>-->
-<!--            <phase>generate-test-sources</phase>-->
-<!--            <goals>-->
-<!--              <goal>exec</goal>-->
-<!--            </goals>-->
-<!--            <configuration>-->
-<!--              <arguments combine.children="append">-->
-<!--                <argument>org.eolang:jeo-maven-plugin:${jeo.version}:assemble</argument>-->
-<!--                <argument>-Djeo.assemble.sourcesDir=${project.build.directory}/generated-sources/opeo-compile-xmir</argument>-->
-<!--                &lt;!&ndash;-->
-<!--                  @todo #200:90min Enable Bytecode Verification For Spring Fat Integration Test.-->
-<!--                   We skip verification because the Spring Framework uses many classes that-->
-<!--                   are not in the classpath and the plugin cannot verify the correctness of-->
-<!--                   the transformation. For not it's not so crucial, but in the future, we-->
-<!--                   should enable it.-->
-<!--                &ndash;&gt;-->
-<!--                <argument>-Djeo.assemble.skip.verification=true</argument>-->
-<!--                <argument>-e</argument>-->
-<!--              </arguments>-->
-<!--            </configuration>-->
-<!--          </execution>-->
-<!--        </executions>-->
-<!--      </plugin>-->
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>jeo-maven-plugin</artifactId>
+        <version>${jeo.version}</version>
+        <executions>
+          <execution>
+            <id>bytecode-to-eo</id>
+            <goals>
+              <goal>disassemble</goal>
+            </goals>
+            <configuration>
+              <outputDir>${project.build.directory}/generated-sources/jeo-disassemble-xmir</outputDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>opeo-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <!--
+            @todo #219:90min Enable Opeo Spring Fat Integration Test.
+             The test is disabled because it fails in many places.
+             We have to fix all the tests steps and enable this test.
+             Don't forget to add this test to the merge workflow.
+             see .github/workflows/maven.test.yaml
+             Also don't forget to remove the disabled tag from the configuration.
+          -->
+        <configuration>
+          <disabled>true</disabled>
+        </configuration>
+        <executions>
+          <execution>
+            <id>opeo-decompile</id>
+            <goals>
+              <goal>decompile</goal>
+            </goals>
+            <configuration>
+              <sourcesDir>${project.build.directory}/generated-sources/jeo-disassemble-xmir</sourcesDir>
+              <outputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</outputDir>
+            </configuration>
+          </execution>
+          <execution>
+            <id>opeo-compile</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <sourcesDir>${project.build.directory}/generated-sources/ineo-staticize-xmir</sourcesDir>
+              <outputDir>${project.build.directory}/generated-sources/opeo-compile-xmir</outputDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>ineo-maven-plugin</artifactId>
+        <version>${ineo.version}</version>
+        <executions>
+          <execution>
+            <id>ineo-staticize</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>staticize</goal>
+            </goals>
+            <configuration>
+              <sourcesDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</sourcesDir>
+              <outputDir>${project.build.directory}/generated-sources/ineo-staticize-xmir</outputDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <executable>mvn</executable>
+        </configuration>
+        <executions>
+          <execution>
+            <id>jeo-to-bytecode</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <arguments combine.children="append">
+                <argument>org.eolang:jeo-maven-plugin:${jeo.version}:assemble</argument>
+                <argument>-Djeo.assemble.sourcesDir=${project.build.directory}/generated-sources/opeo-compile-xmir</argument>
+                <!--
+                  @todo #200:90min Enable Bytecode Verification For Spring Fat Integration Test.
+                   We skip verification because the Spring Framework uses many classes that
+                   are not in the classpath and the plugin cannot verify the correctness of
+                   the transformation. For not it's not so crucial, but in the future, we
+                   should enable it.
+                -->
+                <argument>-Djeo.assemble.skip.verification=true</argument>
+                <argument>-e</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -81,16 +81,16 @@ SOFTWARE.
               <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-            <!--
+              <!--
                @todo #229:90min Handle module-info.class files correctly.
                 Currently we just exclude all `module-info.class` files from the downloaded dependencies.
                 This means that we don't support Java 9+ modules.
                 We should handle them correctly and ensure support Java 9+ modules in 'spring-fat' integration test.
                 Otherwise the application of our solution will be limited to Java 8.
              -->
-            <excludes>
-              module-info.class
-             </excludes>
+              <excludes>
+                module-info.class
+              </excludes>
               <outputDirectory>${project.build.outputDirectory}</outputDirectory>
             </configuration>
           </execution>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -81,7 +81,13 @@ SOFTWARE.
               <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-<!--            TODO-->
+            <!--
+               @todo #229:90min Handle module-info.class files correctly.
+                Currently we just exclude all `module-info.class` files from the downloaded dependencies.
+                This means that we don't support Java 9+ modules.
+                We should handle them correctly and ensure support Java 9+ modules in 'spring-fat' integration test.
+                Otherwise the application of our solution will be limited to Java 8.
+             -->
             <excludes>
               module-info.class
              </excludes>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -54,7 +54,6 @@ SOFTWARE.
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <jeo.version>0.4.4</jeo.version>
-    <jeo.version>1.0-SNAPSHOT</jeo.version>
     <ineo.version>0.2.1</ineo.version>
   </properties>
   <dependencies>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -53,7 +53,8 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <jeo.version>0.4.3</jeo.version>
+<!--    <jeo.version>0.4.3</jeo.version>-->
+    <jeo.version>1.0-SNAPSHOT</jeo.version>
     <ineo.version>0.2.1</ineo.version>
   </properties>
   <dependencies>
@@ -80,116 +81,189 @@ SOFTWARE.
               <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
+            <excludes>
+              module-info.class
+</excludes>
               <outputDirectory>${project.build.outputDirectory}</outputDirectory>
             </configuration>
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.eolang</groupId>
-        <artifactId>jeo-maven-plugin</artifactId>
-        <version>${jeo.version}</version>
-        <executions>
-          <execution>
-            <id>bytecode-to-eo</id>
-            <goals>
-              <goal>disassemble</goal>
-            </goals>
-            <configuration>
-              <outputDir>${project.build.directory}/generated-sources/jeo-disassemble-xmir</outputDir>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.eolang</groupId>
-        <artifactId>opeo-maven-plugin</artifactId>
-        <version>@project.version@</version>
-        <!--
-            @todo #219:90min Enable Opeo Spring Fat Integration Test.
-             The test is disabled because it fails in many places.
-             We have to fix all the tests steps and enable this test.
-             Don't forget to add this test to the merge workflow.
-             see .github/workflows/maven.test.yaml
-             Also don't forget to remove the disabled tag from the configuration.
-          -->
-        <configuration>
-          <disabled>true</disabled>
-        </configuration>
-        <executions>
-          <execution>
-            <id>opeo-decompile</id>
-            <goals>
-              <goal>decompile</goal>
-            </goals>
-            <configuration>
-              <sourcesDir>${project.build.directory}/generated-sources/jeo-disassemble-xmir</sourcesDir>
-              <outputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</outputDir>
-            </configuration>
-          </execution>
-          <execution>
-            <id>opeo-compile</id>
-            <phase>generate-test-sources</phase>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <configuration>
-              <sourcesDir>${project.build.directory}/generated-sources/ineo-staticize-xmir</sourcesDir>
-              <outputDir>${project.build.directory}/generated-sources/opeo-compile-xmir</outputDir>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.eolang</groupId>
-        <artifactId>ineo-maven-plugin</artifactId>
-        <version>${ineo.version}</version>
-        <executions>
-          <execution>
-            <id>ineo-staticize</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>staticize</goal>
-            </goals>
-            <configuration>
-              <sourcesDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</sourcesDir>
-              <outputDir>${project.build.directory}/generated-sources/ineo-staticize-xmir</outputDir>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.2.0</version>
-        <configuration>
-          <executable>mvn</executable>
-        </configuration>
-        <executions>
-          <execution>
-            <id>jeo-to-bytecode</id>
-            <phase>generate-test-sources</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <arguments combine.children="append">
-                <argument>org.eolang:jeo-maven-plugin:${jeo.version}:assemble</argument>
-                <argument>-Djeo.assemble.sourcesDir=${project.build.directory}/generated-sources/opeo-compile-xmir</argument>
-                <!--
-                  @todo #200:90min Enable Bytecode Verification For Spring Fat Integration Test.
-                   We skip verification because the Spring Framework uses many classes that
-                   are not in the classpath and the plugin cannot verify the correctness of
-                   the transformation. For not it's not so crucial, but in the future, we
-                   should enable it.
-                -->
-                <argument>-Djeo.assemble.skip.verification=true</argument>
-                <argument>-e</argument>
-              </arguments>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+<!--<plugin>-->
+<!--  <groupId>org.apache.maven.plugins</groupId>-->
+<!--  <artifactId>maven-compiler-plugin</artifactId>-->
+<!--  <configuration>-->
+<!--    <source>1.8</source>-->
+<!--    <target>1.8</target>-->
+<!--  </configuration>-->
+<!--  <executions>-->
+<!--    <execution>-->
+<!--      <id>test-compile</id>-->
+<!--      <phase>process-test-sources</phase>-->
+<!--      <goals>-->
+<!--        <goal>testCompile</goal>-->
+<!--      </goals>-->
+<!--    </execution>-->
+<!--  </executions>-->
+<!--</plugin>-->
+
+
+<!--           <plugin>-->
+<!--              <groupId>org.eolang</groupId>-->
+<!--              <artifactId>jeo-maven-plugin</artifactId>-->
+<!--              <version>${jeo.version}</version>-->
+<!--              <executions>-->
+<!--                <execution>-->
+<!--                  <id>bytecode-to-eo</id>-->
+<!--                  <goals>-->
+<!--                    <goal>disassemble</goal>-->
+<!--                  </goals>-->
+<!--                  <configuration>-->
+<!--                    <outputDir>${project.build.directory}/generated-sources/jeo-disassemble-xmir</outputDir>-->
+<!--                  </configuration>-->
+<!--                </execution>-->
+<!--              </executions>-->
+<!--            </plugin>-->
+<!--            <plugin>-->
+<!--              <groupId>org.codehaus.mojo</groupId>-->
+<!--              <artifactId>exec-maven-plugin</artifactId>-->
+<!--              <version>3.2.0</version>-->
+<!--              <configuration>-->
+<!--                <executable>mvn</executable>-->
+<!--              </configuration>-->
+<!--              <executions>-->
+<!--                <execution>-->
+<!--                  <id>jeo-to-bytecode</id>-->
+<!--                  <phase>generate-test-sources</phase>-->
+<!--                  <goals>-->
+<!--                    <goal>exec</goal>-->
+<!--                  </goals>-->
+<!--                  <configuration>-->
+<!--                    <arguments combine.children="append">-->
+<!--                      <argument>org.eolang:jeo-maven-plugin:${jeo.version}:assemble</argument>-->
+<!--                      <argument>-Djeo.assemble.sourcesDir=${project.build.directory}/generated-sources/jeo-disassemble-xmir</argument>-->
+<!--                      &lt;!&ndash;-->
+<!--                        @todo #200:90min Enable Bytecode Verification For Spring Fat Integration Test.-->
+<!--                         We skip verification because the Spring Framework uses many classes that-->
+<!--                         are not in the classpath and the plugin cannot verify the correctness of-->
+<!--                         the transformation. For not it's not so crucial, but in the future, we-->
+<!--                         should enable it.-->
+<!--                      &ndash;&gt;-->
+<!--                      <argument>-Djeo.assemble.skip.verification=true</argument>-->
+<!--                      <argument>-e</argument>-->
+<!--                    </arguments>-->
+<!--                  </configuration>-->
+<!--                </execution>-->
+<!--              </executions>-->
+<!--            </plugin>-->
+
+
+
+<!--      <plugin>-->
+<!--        <groupId>org.eolang</groupId>-->
+<!--        <artifactId>jeo-maven-plugin</artifactId>-->
+<!--        <version>${jeo.version}</version>-->
+<!--        <executions>-->
+<!--          <execution>-->
+<!--            <id>bytecode-to-eo</id>-->
+<!--            <goals>-->
+<!--              <goal>disassemble</goal>-->
+<!--            </goals>-->
+<!--            <configuration>-->
+<!--              <outputDir>${project.build.directory}/generated-sources/jeo-disassemble-xmir</outputDir>-->
+<!--            </configuration>-->
+<!--          </execution>-->
+<!--        </executions>-->
+<!--      </plugin>-->
+<!--      <plugin>-->
+<!--        <groupId>org.eolang</groupId>-->
+<!--        <artifactId>opeo-maven-plugin</artifactId>-->
+<!--        <version>@project.version@</version>-->
+<!--        &lt;!&ndash;-->
+<!--            @todo #219:90min Enable Opeo Spring Fat Integration Test.-->
+<!--             The test is disabled because it fails in many places.-->
+<!--             We have to fix all the tests steps and enable this test.-->
+<!--             Don't forget to add this test to the merge workflow.-->
+<!--             see .github/workflows/maven.test.yaml-->
+<!--             Also don't forget to remove the disabled tag from the configuration.-->
+<!--          &ndash;&gt;-->
+<!--        <configuration>-->
+<!--          <disabled>true</disabled>-->
+<!--        </configuration>-->
+<!--        <executions>-->
+<!--          <execution>-->
+<!--            <id>opeo-decompile</id>-->
+<!--            <goals>-->
+<!--              <goal>decompile</goal>-->
+<!--            </goals>-->
+<!--            <configuration>-->
+<!--              <sourcesDir>${project.build.directory}/generated-sources/jeo-disassemble-xmir</sourcesDir>-->
+<!--              <outputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</outputDir>-->
+<!--            </configuration>-->
+<!--          </execution>-->
+<!--          <execution>-->
+<!--            <id>opeo-compile</id>-->
+<!--            <phase>generate-test-sources</phase>-->
+<!--            <goals>-->
+<!--              <goal>compile</goal>-->
+<!--            </goals>-->
+<!--            <configuration>-->
+<!--              <sourcesDir>${project.build.directory}/generated-sources/ineo-staticize-xmir</sourcesDir>-->
+<!--              <outputDir>${project.build.directory}/generated-sources/opeo-compile-xmir</outputDir>-->
+<!--            </configuration>-->
+<!--          </execution>-->
+<!--        </executions>-->
+<!--      </plugin>-->
+<!--      <plugin>-->
+<!--        <groupId>org.eolang</groupId>-->
+<!--        <artifactId>ineo-maven-plugin</artifactId>-->
+<!--        <version>${ineo.version}</version>-->
+<!--        <executions>-->
+<!--          <execution>-->
+<!--            <id>ineo-staticize</id>-->
+<!--            <phase>process-classes</phase>-->
+<!--            <goals>-->
+<!--              <goal>staticize</goal>-->
+<!--            </goals>-->
+<!--            <configuration>-->
+<!--              <sourcesDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</sourcesDir>-->
+<!--              <outputDir>${project.build.directory}/generated-sources/ineo-staticize-xmir</outputDir>-->
+<!--            </configuration>-->
+<!--          </execution>-->
+<!--        </executions>-->
+<!--      </plugin>-->
+<!--      <plugin>-->
+<!--        <groupId>org.codehaus.mojo</groupId>-->
+<!--        <artifactId>exec-maven-plugin</artifactId>-->
+<!--        <version>3.2.0</version>-->
+<!--        <configuration>-->
+<!--          <executable>mvn</executable>-->
+<!--        </configuration>-->
+<!--        <executions>-->
+<!--          <execution>-->
+<!--            <id>jeo-to-bytecode</id>-->
+<!--            <phase>generate-test-sources</phase>-->
+<!--            <goals>-->
+<!--              <goal>exec</goal>-->
+<!--            </goals>-->
+<!--            <configuration>-->
+<!--              <arguments combine.children="append">-->
+<!--                <argument>org.eolang:jeo-maven-plugin:${jeo.version}:assemble</argument>-->
+<!--                <argument>-Djeo.assemble.sourcesDir=${project.build.directory}/generated-sources/opeo-compile-xmir</argument>-->
+<!--                &lt;!&ndash;-->
+<!--                  @todo #200:90min Enable Bytecode Verification For Spring Fat Integration Test.-->
+<!--                   We skip verification because the Spring Framework uses many classes that-->
+<!--                   are not in the classpath and the plugin cannot verify the correctness of-->
+<!--                   the transformation. For not it's not so crucial, but in the future, we-->
+<!--                   should enable it.-->
+<!--                &ndash;&gt;-->
+<!--                <argument>-Djeo.assemble.skip.verification=true</argument>-->
+<!--                <argument>-e</argument>-->
+<!--              </arguments>-->
+<!--            </configuration>-->
+<!--          </execution>-->
+<!--        </executions>-->
+<!--      </plugin>-->
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
In this PR I made `spring-fat` integration test pass. But it is worth mentioning that not all components of the test are workinkg:

- `jeo:dissassemble` - works entirely
- `opeo:decompile` - does nothing, just copies files
- `ineo:staticize` - does nothing, just copies files
- `opeo:compile` - doesn nothing, just copies files
- `jeo:assemble` - works entirely

Risk 1: When we download all dependencies for `spring-fat` integration test, we exclude `module-info.class` files because they make `spring-fat` integration test fail. It means we don't support Java 9 modules feature. I added one more puzzle to investigate the problem.

Related to #229.
History:
- **feat(#229): use 2.7.18 version of spring boot**
- **feat(#229): use jeo snapshot instead of a stable version**
- **feat(#229): make Storage to return Stream instead of Collection**
- **feat(#229): make XmirEntry to load XML in a lazy mode**
- **feat(#229): use 0.4.3 version of the jeo-maven-plugin**
- **feat(#229): parallelize compiler and decompiler**
- **feat(#229): use generate-test-sources phase for spring-fat integration test**
- **feat(#229): disable ineo plugin and bytecode verification in jeo plugin**
- **feat(#229): enable ineo plugin back**
- **feat(#229): improve formatting of spring-fat/pom.xml**
- **feat(#229): fix qulice suggestions**
- **feat(#229): exclude module-info.class files from dependencies**
- **feat(#229): enable all phases of 'spring-fat' integration test**
- **feat(#229): add one more puzzle**
- **feat(#229): fix spring-fat/pom.xml formatting**

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the Java compiler version to 1.8, upgrade the `jeo-maven-plugin` version to 0.4.4, and improve handling of `module-info.class` files in the integration test.

### Detailed summary
- Updated Java compiler version to 1.8
- Upgraded `jeo-maven-plugin` version to 0.4.4
- Improved handling of `module-info.class` files in integration test

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->