### PR TITLE
feat(#226): Decompile Only Files With Supported Opcodes"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@ SOFTWARE.
   </distributionManagement>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <skipITs/>
   </properties>
   <dependencies>

--- a/src/it/fuse/pom.xml
+++ b/src/it/fuse/pom.xml
@@ -82,6 +82,7 @@ SOFTWARE.
             <configuration>
               <sourcesDir>${project.build.directory}/generated-sources/jeo-decompile-xmir</sourcesDir>
               <outputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</outputDir>
+              <modifiedDir>${project.build.directory}/generated-sources/opep-decompile-xmir-modified</modifiedDir>
             </configuration>
           </execution>
           <execution>

--- a/src/it/staticize/pom.xml
+++ b/src/it/staticize/pom.xml
@@ -85,6 +85,7 @@ SOFTWARE.
             <configuration>
               <sourcesDir>${project.build.directory}/generated-sources/jeo-decompile-xmir</sourcesDir>
               <outputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</outputDir>
+              <copyDir>${project.build.directory}/generated-sources/opep-decompile-xmir-copy</copyDir>
             </configuration>
           </execution>
           <execution>

--- a/src/it/staticize/pom.xml
+++ b/src/it/staticize/pom.xml
@@ -85,7 +85,7 @@ SOFTWARE.
             <configuration>
               <sourcesDir>${project.build.directory}/generated-sources/jeo-decompile-xmir</sourcesDir>
               <outputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</outputDir>
-              <copyDir>${project.build.directory}/generated-sources/opep-decompile-xmir-copy</copyDir>
+              <modifiedDir>${project.build.directory}/generated-sources/opep-decompile-xmir-modified</modifiedDir>
             </configuration>
           </execution>
           <execution>

--- a/src/main/java/org/eolang/opeo/DecompileMojo.java
+++ b/src/main/java/org/eolang/opeo/DecompileMojo.java
@@ -31,8 +31,8 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.eolang.opeo.decompilation.Decompiler;
-import org.eolang.opeo.decompilation.NaiveDecompiler;
 import org.eolang.opeo.decompilation.DummyDecompiler;
+import org.eolang.opeo.decompilation.NaiveDecompiler;
 
 /**
  * Decompiles bytecode in EO representation into high-level EO representation.
@@ -70,6 +70,17 @@ public final class DecompileMojo extends AbstractMojo {
     )
     private File outputDir;
 
+    /**
+     * Directory where modified XMIRs are stored.
+     * It is an optional folder that is used to separate files that were modified.
+     * In some cases, the decompilation phase might just skip some files because some instructions
+     * are not supported yet.
+     * To "see" what we actually decompiled, we store the modified files in this folder.
+     * It doesn't affect {@link #outputDir}.
+     *
+     * @since 0.2.0
+     * @checkstyle MemberNameCheck (6 lines)
+     */
     @Parameter(property = "opeo.decompile.modifiedDir")
     private File modifiedDir;
 

--- a/src/main/java/org/eolang/opeo/DecompileMojo.java
+++ b/src/main/java/org/eolang/opeo/DecompileMojo.java
@@ -30,7 +30,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.eolang.opeo.decompilation.Decompiler;
-import org.eolang.opeo.decompilation.DefaultDecompiler;
+import org.eolang.opeo.decompilation.NaiveDecompiler;
 import org.eolang.opeo.decompilation.DummyDecompiler;
 
 /**
@@ -89,7 +89,7 @@ public final class DecompileMojo extends AbstractMojo {
             Logger.info(this, "Decompiler is disabled");
             decompiler = new DummyDecompiler(this.sourcesDir.toPath(), this.outputDir.toPath());
         } else {
-            decompiler = new DefaultDecompiler(this.sourcesDir.toPath(), this.outputDir.toPath());
+            decompiler = new NaiveDecompiler(this.sourcesDir.toPath(), this.outputDir.toPath());
         }
         decompiler.decompile();
     }

--- a/src/main/java/org/eolang/opeo/DecompileMojo.java
+++ b/src/main/java/org/eolang/opeo/DecompileMojo.java
@@ -25,6 +25,7 @@ package org.eolang.opeo;
 
 import com.jcabi.log.Logger;
 import java.io.File;
+import java.util.Objects;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -69,6 +70,9 @@ public final class DecompileMojo extends AbstractMojo {
     )
     private File outputDir;
 
+    @Parameter(property = "opeo.decompile.modifiedDir")
+    private File modifiedDir;
+
     /**
      * Whether the plugin is disabled.
      * If it's disabled, then it won't do anything.
@@ -88,7 +92,13 @@ public final class DecompileMojo extends AbstractMojo {
         if (this.disabled) {
             Logger.info(this, "Decompiler is disabled");
             decompiler = new DummyDecompiler(this.sourcesDir.toPath(), this.outputDir.toPath());
+        } else if (Objects.nonNull(this.modifiedDir)) {
+            Logger.info(this, "Use selective decompiler");
+            decompiler = new SelectiveDecompiler(
+                this.sourcesDir.toPath(), this.outputDir.toPath(), this.modifiedDir.toPath()
+            );
         } else {
+            Logger.info(this, "Use naive decompiler");
             decompiler = new NaiveDecompiler(this.sourcesDir.toPath(), this.outputDir.toPath());
         }
         decompiler.decompile();

--- a/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
+++ b/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
@@ -1,8 +1,15 @@
 package org.eolang.opeo;
 
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eolang.opeo.ast.OpcodeName;
 import org.eolang.opeo.decompilation.Decompiler;
+import org.eolang.opeo.decompilation.handlers.RouterHandler;
+import org.eolang.opeo.jeo.JeoDecompiler;
 import org.eolang.opeo.storage.Storage;
+import org.eolang.opeo.storage.XmirEntry;
 
 /**
  * Selective decompiler.
@@ -14,18 +21,57 @@ import org.eolang.opeo.storage.Storage;
  */
 public final class SelectiveDecompiler implements Decompiler {
 
-
     /**
      * The storage where the XMIRs are stored.
      */
     private final Storage storage;
 
+    /**
+     * Where to save the copy of each decompiled file.
+     */
+    private final Storage copy;
+
+
+    private final String[] supported;
+
     public SelectiveDecompiler(final Storage storage) {
+        this(storage, new RouterHandler(true).supportedOpcodes());
+    }
+
+    public SelectiveDecompiler(final Storage storage, String... supported) {
+        this(storage, storage, supported);
+    }
+
+    public SelectiveDecompiler(
+        final Storage storage, final Storage copy, final String... supported
+    ) {
         this.storage = storage;
+        this.copy = copy;
+        this.supported = supported;
     }
 
     @Override
     public void decompile() {
+        this.storage.all().forEach(
+            entry -> {
+                final XmirEntry res;
+                final List<String> xpath = entry.xpath(this.xpath());
+                final boolean empty = xpath.isEmpty();
+                if (empty) {
+                    res = entry.transform(xml -> new JeoDecompiler(xml).decompile());
+                } else {
+                    res = entry;
+                }
+                this.copy.save(res);
+                this.storage.save(res);
+            }
+        );
+    }
 
+    private String xpath() {
+        return String.format(
+            "//o[@base='opcode'][not(contains(' %s ', concat(' ', @name, ' '))) ]/@name",
+            Arrays.stream(this.supported).collect(Collectors.joining(" "))
+        );
     }
 }

--- a/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
+++ b/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
@@ -1,6 +1,7 @@
 package org.eolang.opeo;
 
 
+import com.jcabi.log.Logger;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -75,13 +76,17 @@ public final class SelectiveDecompiler implements Decompiler {
         this.storage.all().forEach(
             entry -> {
                 final XmirEntry res;
-                final String xpath1 = this.xpath();
-                final List<String> xpath = entry.xpath(xpath1);
-                final boolean empty = xpath.isEmpty();
-                if (empty) {
+                final List<String> xpath = entry.xpath(this.xpath());
+                if (xpath.isEmpty()) {
                     res = entry.transform(xml -> new JeoDecompiler(xml).decompile());
                     this.modified.save(res);
                 } else {
+                    Logger.info(
+                        this,
+                        "Skipping %s, because of unsupported opcodes: %s",
+                        entry,
+                        xpath
+                    );
                     res = entry;
                 }
                 this.storage.save(res);

--- a/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
+++ b/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
@@ -1,0 +1,31 @@
+package org.eolang.opeo;
+
+
+import org.eolang.opeo.decompilation.Decompiler;
+import org.eolang.opeo.storage.Storage;
+
+/**
+ * Selective decompiler.
+ * Decompiler that decompiles ONLY fully understandable methods.
+ * These methods contain only instructions that are
+ * supported by {@link org.eolang.opeo.decompilation.handlers.RouterHandler}.
+ *
+ * @since 0.1
+ */
+public final class SelectiveDecompiler implements Decompiler {
+
+
+    /**
+     * The storage where the XMIRs are stored.
+     */
+    private final Storage storage;
+
+    public SelectiveDecompiler(final Storage storage) {
+        this.storage = storage;
+    }
+
+    @Override
+    public void decompile() {
+
+    }
+}

--- a/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
+++ b/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
@@ -39,30 +39,68 @@ public final class SelectiveDecompiler implements Decompiler {
      */
     private final String[] supported;
 
+    /**
+     * Constructor.
+     * @param input Input folder with XMIRs.
+     * @param output Output folder where to save the decompiled files.
+     * @param modified Folder where to save the modified XMIRs.
+     */
     public SelectiveDecompiler(final Path input, final Path output, final Path modified) {
         this(input, output, modified, new RouterHandler(false).supportedOpcodes());
     }
 
+    /**
+     * Constructor.
+     * @param input Input folder with XMIRs.
+     * @param output Output folder where to save the decompiled files.
+     */
     public SelectiveDecompiler(final Path input, final Path output) {
         this(input, output, new RouterHandler(false).supportedOpcodes());
     }
 
-    public SelectiveDecompiler(
-        final Path input, final Path output, final Path modified, String... supported
-    ) {
-        this(new FileStorage(input, output), new FileStorage(modified, modified), supported);
-    }
-
+    /**
+     * Constructor.
+     * @param input Input folder with XMIRs.
+     * @param output Output folder where to save the decompiled files.
+     * @param supported Supported opcodes are used in selection.
+     */
     public SelectiveDecompiler(
         final Path input, final Path output, String... supported
     ) {
         this(new FileStorage(input, output), supported);
     }
 
+    /**
+     * Constructor.
+     * @param input Input folder with XMIRs.
+     * @param output Output folder where to save the decompiled files.
+     * @param modified Folder where to save the modified XMIRs.
+     * @param supported Supported opcodes are used in selection.
+     */
+    public SelectiveDecompiler(
+        final Path input,
+        final Path output,
+        final Path modified,
+        final String... supported
+    ) {
+        this(new FileStorage(input, output), new FileStorage(modified, modified), supported);
+    }
+
+    /**
+     * Constructor.
+     * @param storage Storage from which retrieve the XMIRs and where to save the modified ones.
+     * @param supported Supported opcodes are used in selection.
+     */
     public SelectiveDecompiler(final Storage storage, String... supported) {
         this(storage, new DummyStorage(), supported);
     }
 
+    /**
+     * Constructor.
+     * @param storage Storage from which retrieve the XMIRs and where to save the modified ones.
+     * @param modified Storage where to save the modified of each decompiled file.
+     * @param supported Supported opcodes are used in selection.
+     */
     public SelectiveDecompiler(
         final Storage storage, final Storage modified, final String... supported
     ) {
@@ -94,6 +132,10 @@ public final class SelectiveDecompiler implements Decompiler {
         );
     }
 
+    /**
+     * Xpath to find all opcodes that are not supported.
+     * @return Xpath.
+     */
     private String xpath() {
         return String.format(
             "//o[@base='opcode'][not(contains('%s', substring-before(concat(@name, '-'), '-'))) ]/@name",

--- a/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
+++ b/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
@@ -1,5 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.opeo;
-
 
 import com.jcabi.log.Logger;
 import java.nio.file.Path;
@@ -65,7 +87,7 @@ public final class SelectiveDecompiler implements Decompiler {
      * @param supported Supported opcodes are used in selection.
      */
     public SelectiveDecompiler(
-        final Path input, final Path output, String... supported
+        final Path input, final Path output, final String... supported
     ) {
         this(new FileStorage(input, output), supported);
     }
@@ -76,6 +98,7 @@ public final class SelectiveDecompiler implements Decompiler {
      * @param output Output folder where to save the decompiled files.
      * @param modified Folder where to save the modified XMIRs.
      * @param supported Supported opcodes are used in selection.
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     public SelectiveDecompiler(
         final Path input,
@@ -91,7 +114,7 @@ public final class SelectiveDecompiler implements Decompiler {
      * @param storage Storage from which retrieve the XMIRs and where to save the modified ones.
      * @param supported Supported opcodes are used in selection.
      */
-    public SelectiveDecompiler(final Storage storage, String... supported) {
+    public SelectiveDecompiler(final Storage storage, final String... supported) {
         this(storage, new DummyStorage(), supported);
     }
 
@@ -106,7 +129,7 @@ public final class SelectiveDecompiler implements Decompiler {
     ) {
         this.storage = storage;
         this.modified = modified;
-        this.supported = supported;
+        this.supported = supported.clone();
     }
 
     @Override
@@ -114,8 +137,8 @@ public final class SelectiveDecompiler implements Decompiler {
         this.storage.all().forEach(
             entry -> {
                 final XmirEntry res;
-                final List<String> xpath = entry.xpath(this.xpath());
-                if (xpath.isEmpty()) {
+                final List<String> found = entry.xpath(this.xpath());
+                if (found.isEmpty()) {
                     res = entry.transform(xml -> new JeoDecompiler(xml).decompile());
                     this.modified.save(res);
                 } else {
@@ -123,7 +146,7 @@ public final class SelectiveDecompiler implements Decompiler {
                         this,
                         "Skipping %s, because of unsupported opcodes: %s",
                         entry,
-                        xpath
+                        found
                     );
                     res = entry;
                 }

--- a/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
+++ b/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
@@ -1,6 +1,7 @@
 package org.eolang.opeo;
 
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -8,6 +9,8 @@ import org.eolang.opeo.ast.OpcodeName;
 import org.eolang.opeo.decompilation.Decompiler;
 import org.eolang.opeo.decompilation.handlers.RouterHandler;
 import org.eolang.opeo.jeo.JeoDecompiler;
+import org.eolang.opeo.storage.DummyStorage;
+import org.eolang.opeo.storage.FileStorage;
 import org.eolang.opeo.storage.Storage;
 import org.eolang.opeo.storage.XmirEntry;
 
@@ -34,12 +37,30 @@ public final class SelectiveDecompiler implements Decompiler {
 
     private final String[] supported;
 
-    public SelectiveDecompiler(final Storage storage) {
-        this(storage, new RouterHandler(true).supportedOpcodes());
+
+    public SelectiveDecompiler(final Path input, final Path output, final Path copy) {
+        this(input, output, copy, new RouterHandler(false).supportedOpcodes());
+    }
+
+    public SelectiveDecompiler(final Path input, final Path output) {
+        this(input, output, new RouterHandler(false).supportedOpcodes());
+    }
+
+
+    public SelectiveDecompiler(
+        final Path input, final Path output, final Path copy, String... supported
+    ) {
+        this(new FileStorage(input, output), new FileStorage(copy, copy), supported);
+    }
+
+    public SelectiveDecompiler(
+        final Path input, final Path output, String... supported
+    ) {
+        this(new FileStorage(input, output), supported);
     }
 
     public SelectiveDecompiler(final Storage storage, String... supported) {
-        this(storage, storage, supported);
+        this(storage, new DummyStorage(), supported);
     }
 
     public SelectiveDecompiler(

--- a/src/main/java/org/eolang/opeo/ast/RawXml.java
+++ b/src/main/java/org/eolang/opeo/ast/RawXml.java
@@ -1,32 +1,77 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.opeo.ast;
 
 import com.jcabi.xml.XMLDocument;
 import java.util.Collections;
 import java.util.List;
 import org.eolang.jeo.representation.xmir.XmlNode;
-import org.w3c.dom.Node;
 import org.xembly.Directive;
 import org.xembly.Directives;
-import org.xembly.ImpossibleModificationException;
-import org.xembly.Xembler;
 
+/**
+ * This class represents a raw XML node.
+ * It is used to represent nodes that we don't know how to parse yet.
+ *
+ * @since 0.1
+ */
 public final class RawXml implements AstNode {
 
+    /**
+     * XML node.
+     */
     private final XmlNode node;
 
+    /**
+     * Constructor.
+     * @param node XML node.
+     */
     public RawXml(final XmlNode node) {
         this.node = node;
     }
 
     @Override
     public List<AstNode> opcodes() {
+        //@checkstyle MethodBodyCommentsCheck (10 lines)
+        // @todo #226:90min Refactor AstNode#opcodes() Method Usage.
+        //  This method is used improperly in the codebase since we have such strange
+        //  implementations as in the RawXml class. We need to refactor the codebase
+        //  and maybe just remove this method and use only `toXmir`.
+        //  So, we need to investigate this.
         return Collections.singletonList(this);
     }
 
     @Override
     public Iterable<Directive> toXmir() {
-        //todo!
-        return new Directives().append(new XMLDocument(
-            new XMLDocument(this.node.node()).toString()).node());
+        //@checkstyle MethodBodyCommentsCheck (10 line)
+        // @todo #226:90min Inefficient RawXml#toXmir() Method Implementation.
+        //  This method is inefficient because it creates a new XMLDocument
+        //  instance and then converts it to a string. We need to refactor this
+        //  method to be more efficient.
+        return new Directives().append(
+            new XMLDocument(
+                new XMLDocument(this.node.node()).toString()).node()
+        );
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/RawXml.java
+++ b/src/main/java/org/eolang/opeo/ast/RawXml.java
@@ -1,0 +1,32 @@
+package org.eolang.opeo.ast;
+
+import com.jcabi.xml.XMLDocument;
+import java.util.Collections;
+import java.util.List;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.w3c.dom.Node;
+import org.xembly.Directive;
+import org.xembly.Directives;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+public final class RawXml implements AstNode {
+
+    private final XmlNode node;
+
+    public RawXml(final XmlNode node) {
+        this.node = node;
+    }
+
+    @Override
+    public List<AstNode> opcodes() {
+        return Collections.singletonList(this);
+    }
+
+    @Override
+    public Iterable<Directive> toXmir() {
+        //todo!
+        return new Directives().append(new XMLDocument(
+            new XMLDocument(this.node.node()).toString()).node());
+    }
+}

--- a/src/main/java/org/eolang/opeo/ast/RawXml.java
+++ b/src/main/java/org/eolang/opeo/ast/RawXml.java
@@ -71,7 +71,8 @@ public final class RawXml implements AstNode {
         //  method to be more efficient.
         return new Directives().append(
             new XMLDocument(
-                new XMLDocument(this.node.node()).toString()).node()
+                new XMLDocument(this.node.node()).toString()
+            ).node()
         );
     }
 }

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -48,6 +48,7 @@ import org.eolang.opeo.ast.Label;
 import org.eolang.opeo.ast.Literal;
 import org.eolang.opeo.ast.LocalVariable;
 import org.eolang.opeo.ast.Opcode;
+import org.eolang.opeo.ast.RawXml;
 import org.eolang.opeo.ast.StaticInvocation;
 import org.eolang.opeo.ast.StoreArray;
 import org.eolang.opeo.ast.Substraction;
@@ -160,6 +161,8 @@ final class XmirParser {
             result = new Substraction(node, this::node);
         } else if ("cast".equals(base)) {
             result = new Cast(node, this::node);
+        } else if ("frame".equals(base)) {
+            result = new RawXml(node);
         } else if ("opcode".equals(base)) {
             final XmlInstruction instruction = new XmlInstruction(node);
             final int opcode = instruction.opcode();

--- a/src/main/java/org/eolang/opeo/decompilation/NaiveDecompiler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/NaiveDecompiler.java
@@ -31,14 +31,16 @@ import org.eolang.opeo.storage.Storage;
 import org.eolang.opeo.storage.XmirEntry;
 
 /**
- * Default Decompiler.
+ * Naive Decompiler.
  * This class is a high-level abstraction of the decompilation process.
  * The main purpose of this class is to get the output of the jeo-maven-plugin
  * and decompile it into high-level EO constructs.
  *
+ * This class just tries to decompile ALL possible files.
+ *
  * @since 0.1
  */
-public final class DefaultDecompiler implements Decompiler {
+public final class NaiveDecompiler implements Decompiler {
 
     /**
      * The storage where the XMIRs are stored.
@@ -50,7 +52,7 @@ public final class DefaultDecompiler implements Decompiler {
      * @param xmirs Path to the generated XMIRs by jeo-maven-plugin.
      * @param output Path to the output directory.
      */
-    public DefaultDecompiler(
+    public NaiveDecompiler(
         final Path xmirs,
         final Path output
     ) {
@@ -61,7 +63,7 @@ public final class DefaultDecompiler implements Decompiler {
      * Constructor.
      * @param generated The default Maven 'generated-sources' directory.
      */
-    DefaultDecompiler(final Path generated) {
+    NaiveDecompiler(final Path generated) {
         this(generated.resolve("xmir"), generated.resolve("opeo-xmir"));
     }
 
@@ -69,7 +71,7 @@ public final class DefaultDecompiler implements Decompiler {
      * Constructor.
      * @param storage The storage where the XMIRs are stored.
      */
-    private DefaultDecompiler(final Storage storage) {
+    private NaiveDecompiler(final Storage storage) {
         this.storage = storage;
     }
 

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/RouterHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/RouterHandler.java
@@ -121,6 +121,7 @@ public final class RouterHandler implements InstructionHandler {
                 new MapEntry<>(Opcodes.LDC, new LdcHandler()),
                 new MapEntry<>(Opcodes.POP, new PopHandler()),
                 new MapEntry<>(Opcodes.RETURN, new ReturnHandler(counting)),
+                new MapEntry<>(Opcodes.IRETURN, new ReturnHandler(counting)),
                 new MapEntry<>(JeoLabel.LABEL_OPCODE, new LabelHandler()),
                 new MapEntry<>(
                     RouterHandler.UNIMPLEMENTED, new UnimplementedHandler(counting)

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/RouterHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/RouterHandler.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.MapOf;
 import org.eolang.opeo.ast.Opcode;
+import org.eolang.opeo.ast.OpcodeName;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.eolang.opeo.decompilation.InstructionHandler;
 import org.eolang.opeo.jeo.JeoLabel;
@@ -139,6 +140,18 @@ public final class RouterHandler implements InstructionHandler {
     @Override
     public void handle(final DecompilerState state) {
         this.handler(state.instruction().opcode()).handle(state);
+    }
+
+    /**
+     * Get supported opcodes.
+     * @return Supported opcodes.
+     */
+    public String[] supportedOpcodes() {
+        return this.handlers.keySet()
+            .stream()
+            .map(OpcodeName::new)
+            .map(OpcodeName::simplified)
+            .toArray(String[]::new);
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/storage/DummyStorage.java
+++ b/src/main/java/org/eolang/opeo/storage/DummyStorage.java
@@ -1,8 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.opeo.storage;
 
 import com.jcabi.log.Logger;
 import java.util.stream.Stream;
 
+/**
+ * Dummy storage.
+ * This storage does nothing.
+ * @since 0.1
+ */
 public final class DummyStorage implements Storage {
     @Override
     public Stream<XmirEntry> all() {

--- a/src/main/java/org/eolang/opeo/storage/DummyStorage.java
+++ b/src/main/java/org/eolang/opeo/storage/DummyStorage.java
@@ -1,0 +1,16 @@
+package org.eolang.opeo.storage;
+
+import com.jcabi.log.Logger;
+import java.util.stream.Stream;
+
+public final class DummyStorage implements Storage {
+    @Override
+    public Stream<XmirEntry> all() {
+        return Stream.empty();
+    }
+
+    @Override
+    public void save(final XmirEntry xmir) {
+        Logger.debug(this, "Dummy storage: skip %s", xmir);
+    }
+}

--- a/src/main/java/org/eolang/opeo/storage/XmirEntry.java
+++ b/src/main/java/org/eolang/opeo/storage/XmirEntry.java
@@ -46,6 +46,7 @@ public final class XmirEntry {
     /**
      * XML representation of XMIR.
      */
+    @ToString.Exclude
     private final Unchecked<XML> xml;
 
     /**

--- a/src/main/java/org/eolang/opeo/storage/XmirEntry.java
+++ b/src/main/java/org/eolang/opeo/storage/XmirEntry.java
@@ -27,6 +27,7 @@ import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Function;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -87,6 +88,15 @@ public final class XmirEntry {
      */
     public XmirEntry transform(final Function<? super XML, ? extends XML> transformer) {
         return new XmirEntry(transformer.apply(this.xml.value()), this.pckg);
+    }
+
+    /**
+     * Apply XPath query.
+     * @param query XPath query.
+     * @return List of strings returned by query.
+     */
+    public List<String> xpath(final String query) {
+        return this.xml.value().xpath(query);
     }
 
     /**

--- a/src/test/java/org/eolang/opeo/decompilation/NaiveDecompilerTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/NaiveDecompilerTest.java
@@ -34,10 +34,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Test case for {@link DefaultDecompiler}.
+ * Test case for {@link NaiveDecompiler}.
  * @since 0.1
  */
-final class DecompilerTest {
+final class NaiveDecompilerTest {
 
     @Test
     void decompilesSeveralFiles(@TempDir final Path temp) throws Exception {
@@ -46,7 +46,7 @@ final class DecompilerTest {
         final Path input = temp.resolve("xmir").resolve(subpath).resolve(name);
         Files.createDirectories(input.getParent());
         Files.write(input, new BytesOf(new ResourceOf("xmir/Bar.xmir")).asBytes());
-        new DefaultDecompiler(temp).decompile();
+        new NaiveDecompiler(temp).decompile();
         final Path expected = temp.resolve("opeo-xmir").resolve(subpath).resolve(name);
         MatcherAssert.assertThat(
             String.format(

--- a/src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java
@@ -40,9 +40,20 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * Test cases for {@link org.eolang.opeo.SelectiveDecompiler}.
  * @since 0.1
+ * @todo #226:90min Refactor SelectiveDecompilerTest.
+ *  This test has a lot of string literals that are duplicated.
+ *  Moreover, it has a {@link SelectiveDecompilerTest#supported} field that should be removed.
+ *  See the javadoc for 'supported' field.
+ *  Also we have some sort of duplication between method initializations.
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class SelectiveDecompilerTest {
 
+    /**
+     * Supported opcodes.
+     * Here we intentionally expand the list of supported opcodes to test the decompiler.
+     * Bar.xmir contains the IFLE instruction which is not supported by the decompiler yet.
+     */
     private final String[] supported =
         Stream.concat(
             Arrays.stream(new RouterHandler(false).supportedOpcodes()),
@@ -157,5 +168,4 @@ final class SelectiveDecompilerTest {
             Matchers.arrayWithSize(2)
         );
     }
-
 }

--- a/src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java
@@ -1,0 +1,110 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.decompilation;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.cactoos.bytes.BytesOf;
+import org.cactoos.io.ResourceOf;
+import org.eolang.opeo.SelectiveDecompiler;
+import org.eolang.opeo.storage.FileStorage;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.hamcrest.io.FileMatchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test cases for {@link org.eolang.opeo.SelectiveDecompiler}.
+ * @since 0.1
+ */
+final class SelectiveDecompilerTest {
+
+    @Test
+    void decompiles(@TempDir final Path temp) throws Exception {
+        final byte[] known = new BytesOf(new ResourceOf("xmir/Bar.xmir")).asBytes();
+        final Path input = temp.resolve("input");
+        final Path output = temp.resolve("output");
+        Files.createDirectories(input);
+        Files.createDirectories(output);
+        Files.write(input.resolve("Bar.xmir"), known);
+        new SelectiveDecompiler(new FileStorage(input, output)).decompile();
+        MatcherAssert.assertThat(
+            "We expect that decompiler will decompile the input file and store the result into the output folder.",
+            output.resolve("Bar.xmir").toFile(),
+            FileMatchers.anExistingFile()
+        );
+        MatcherAssert.assertThat(
+            "We expect that the decompiled file won't be the same as the input file. Since the decompiler should change the file.",
+            new BytesOf(output.resolve("Bar.xmir")),
+            Matchers.not(Matchers.equalTo(new BytesOf(known)))
+        );
+    }
+
+    @Test
+    void decompilesNothing(@TempDir final Path temp) throws Exception {
+        final byte[] known = new BytesOf(new ResourceOf("xmir/Bar.xmir")).asBytes();
+        final Path input = temp.resolve("input");
+        final Path output = temp.resolve("output");
+        Files.createDirectories(input);
+        Files.createDirectories(output);
+        Files.write(input.resolve("Bar.xmir"), known);
+        new SelectiveDecompiler(new FileStorage(input, output)).decompile();
+        MatcherAssert.assertThat(
+            "We expect that decompiler will copy the input file and store the result into the output folder.",
+            output.resolve("Bar.xmir").toFile(),
+            FileMatchers.anExistingFile()
+        );
+        MatcherAssert.assertThat(
+            "We expect that the decompiled file will be the same as the input file. Since the decompiler doesn't know some instructions.",
+            new BytesOf(output.resolve("Bar.xmir")),
+            Matchers.equalTo(new BytesOf(known))
+        );
+    }
+
+    @Test
+    void decompilesOnlySomeFiles(@TempDir final Path temp) throws Exception {
+        final byte[] known = new BytesOf(new ResourceOf("xmir/Bar.xmir")).asBytes();
+        final byte[] unknown = new BytesOf(new ResourceOf("xmir/Bar.xmir")).asBytes();
+        final Path input = temp.resolve("input");
+        final Path output = temp.resolve("output");
+        Files.createDirectories(input);
+        Files.createDirectories(output);
+        Files.write(input.resolve("Known.xmir"), known);
+        Files.write(input.resolve("Unknown.xmir"), known);
+        new SelectiveDecompiler(new FileStorage(input, output)).decompile();
+        MatcherAssert.assertThat(
+            "We expect that the decompiled file will be changed since the decompiler knows all instructions.",
+            new BytesOf(output.resolve("Known.xmir")),
+            Matchers.not(Matchers.equalTo(new BytesOf(known)))
+        );
+        MatcherAssert.assertThat(
+            "We expect that the decompiled file won't be changed since the decompiler doesn't know some instructions.",
+            new BytesOf(output.resolve("Unknown.xmir")),
+            Matchers.equalTo(new BytesOf(unknown))
+        );
+    }
+
+}

--- a/src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java
@@ -94,14 +94,14 @@ final class SelectiveDecompilerTest {
 
     @Test
     void decompilesOnlySomeFiles(@TempDir final Path temp) throws Exception {
-        final byte[] known = new BytesOf(new ResourceOf("xmir/Bar.xmir")).asBytes();
+        final byte[] known = new BytesOf(new ResourceOf("xmir/Known.xmir")).asBytes();
         final byte[] unknown = new BytesOf(new ResourceOf("xmir/Bar.xmir")).asBytes();
         final Path input = temp.resolve("input");
         final Path output = temp.resolve("output");
         Files.createDirectories(input);
         Files.createDirectories(output);
         Files.write(input.resolve("Known.xmir"), known);
-        Files.write(input.resolve("Unknown.xmir"), known);
+        Files.write(input.resolve("Unknown.xmir"), unknown);
         new SelectiveDecompiler(new FileStorage(input, output)).decompile();
         MatcherAssert.assertThat(
             "We expect that the decompiled file will be changed since the decompiler knows all instructions.",

--- a/src/test/resources/xmir/Known.xmir
+++ b/src/test/resources/xmir/Known.xmir
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<program dob="2023-12-26T10:50:41.482996Z"
+         ms="1703587841483"
+         name="j$Bar"
+         revision="0.0.0"
+         time="2023-12-26T10:50:41.482996Z"
+         version="0.0.0">
+   <listing>yv66vgAAADQAFQoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWBwAIAQASb3JnL2VvbGFuZy9qZW8vQmFyAQAEQ29kZQEAD0xpbmVOdW1iZXJUYWJsZQEAEkxvY2FsVmFyaWFibGVUYWJsZQEABHRoaXMBABRMb3JnL2VvbGFuZy9qZW8vQmFyOwEAA2ZvbwEABChJKUkBAAF4AQABSQEADVN0YWNrTWFwVGFibGUBAApTb3VyY2VGaWxlAQAIQmFyLmphdmEAIQAHAAIAAAAAAAIAAQAFAAYAAQAJAAAALwABAAEAAAAFKrcAAbEAAAACAAoAAAAGAAEAAAADAAsAAAAMAAEAAAAFAAwADQAAAAEADgAPAAEACQAAAE0AAQACAAAACBueAAUErAWsAAAAAwAKAAAADgADAAAABQAEAAYABgAIAAsAAAAWAAIAAAAIAAwADQAAAAAACAAQABEAAQASAAAAAwABBgABABMAAAACABQ=</listing>
+   <errors/>
+   <sheets/>
+   <license/>
+   <metas>
+      <meta>
+         <head>package</head>
+         <tail>org.eolang.jeo</tail>
+         <part>org.eolang.jeo</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>org.eolang.jeo.opcode</tail>
+         <part>org.eolang.jeo.opcode</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>org.eolang.jeo.label</tail>
+         <part>org.eolang.jeo.label</part>
+      </meta>
+   </metas>
+   <objects>
+      <o abstract="" name="j$Bar">
+         <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 21</o>
+         <o base="string" data="bytes" name="supername">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
+         <o base="tuple" name="interfaces" star=""/>
+         <o abstract="" name="new">
+            <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 01</o>
+            <o base="string" data="bytes" name="descriptor">28 29 56</o>
+            <o base="string" data="bytes" name="signature"/>
+            <o base="tuple" name="exceptions" star=""/>
+            <o base="seq" name="@">
+               <o base="tuple" star="">
+                  <o base="label" data="bytes">38 63 33 33 31 33 39 37 2D 32 35 39 35 2D 34 66 35 64 2D 38 65 62 30 2D 33 62 30 63 34 62 35 34 36 35 66 32</o>
+                  <o base="opcode" line="999" name="ALOAD">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKESPECIAL">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 B7</o>
+                     <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
+                     <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
+                     <o base="string" data="bytes">28 29 56</o>
+                     <o base="bool" data="bytes">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="RETURN">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 B1</o>
+                  </o>
+                  <o base="label" data="bytes">35 39 66 37 31 33 30 63 2D 32 33 62 37 2D 34 64 37 30 2D 38 30 30 65 2D 32 66 61 34 65 30 63 64 65 38 66 34</o>
+               </o>
+            </o>
+         </o>
+      </o>
+   </objects>
+</program>


### PR DESCRIPTION
In this PR I added `SelectiveDecompiler` that decompiles only files that contain supported opcodes. If `SelectiveDecompiler` faces a file with unknown opcode, it just skips it and copies as is.
I encorporated this decompiler to `staticize` and `fuse` integration tests.

This changes are important printing `xmir`->`phi`. Now we can print only files that are fully decompiled. This saves time for `spring-fat` integration test.

Related to #226.
History:
- **feat(#226): add unit tests for selective decompiler**
- **feat(#226): calculate supported opcodes**
- **feat(#226): make all tests pass**
- **feat(#226): add DummyStorage**
- **feat(#226): try to integrate SelectiveDecompiler**
- **feat(#226): fix the bug related to 'frame' parsing**
- **feat(#226): add logs**
- **feat(#226): add selective decompiler to 'fuse' integration test**
- **feat(#226): add IRETURN handler to decompiler**
- **feat(#226): add several puzzles for RawXml class**
- **feat(#226): add puzzle to refactor SelectiveDecompilerTest**
- **feat(#226): add javadocs for SelectiveDecompiler**
- **feat(#226): fix all the rest qulice suggestions**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the project to use Java 11, adds a new `RawXml` class, enhances `XmirEntry` with an XPath method, and refactors the decompiler classes.

### Detailed summary
- Updated project to use Java 11.
- Added `RawXml` class for parsing XML.
- Enhanced `XmirEntry` with an `xpath` method.
- Refactored decompiler classes for better clarity.

> The following files were skipped due to too many changes: `src/test/resources/xmir/Known.xmir`, `src/main/java/org/eolang/opeo/ast/RawXml.java`, `src/main/java/org/eolang/opeo/SelectiveDecompiler.java`, `src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->