### PR TITLE
feat(#229): Fix The Bug With Parsing Integer Values From Decompiled XMIR

### DIFF
--- a/src/it/fuse/src/main/java/org/eolang/other/MinusOne.java
+++ b/src/it/fuse/src/main/java/org/eolang/other/MinusOne.java
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.other;
+
+/**
+ * This class was added to check if can successfully decompile and compile integer value with
+ * value "-1".
+ * @since 0.
+ */
+class MinusOne {
+    public static void main(String... args) {
+        System.out.printf("Hello %d", args.length * -1);
+    }
+}

--- a/src/main/java/org/eolang/opeo/ast/Literal.java
+++ b/src/main/java/org/eolang/opeo/ast/Literal.java
@@ -357,9 +357,9 @@ public final class Literal implements AstNode, Typed {
     private static byte[] parseBytes(final String hex) {
         final String[] split = hex.split(" ");
         final int length = split.length;
-        byte[] res = new byte[length];
-        for (int i = 0; i < length; i++) {
-            res[i] = (byte) Integer.parseInt(split[i], 16);
+        final byte[] res = new byte[length];
+        for (int index = 0; index < length; ++index) {
+            res[index] = (byte) Integer.parseInt(split[index], 16);
         }
         return res;
     }

--- a/src/main/java/org/eolang/opeo/ast/Literal.java
+++ b/src/main/java/org/eolang/opeo/ast/Literal.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.opeo.ast;
 
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import lombok.EqualsAndHashCode;
@@ -319,15 +320,48 @@ public final class Literal implements AstNode, Typed {
         final Object result;
         final Type type = Literal.xtype(node);
         if (type.equals(Type.INT_TYPE)) {
-            result = new HexString(node.text()).decodeAsInt();
+            result = Literal.parseInt(node.text());
         } else if (type.equals(Type.BOOLEAN_TYPE)) {
             result = new HexString(node.text()).decodeAsBoolean();
         } else if (type.equals(Type.LONG_TYPE)) {
-            result = Long.parseLong(node.text().trim().replace(" ", ""), 16);
+            result = Literal.parseLong(node.text());
         } else {
             result = new HexString(node.text()).decode();
         }
         return result;
+    }
+
+    /**
+     * Parse hex string into integer.
+     * @param hex Hex string
+     * @return Integer.
+     */
+    private static int parseInt(final String hex) {
+        return ByteBuffer.wrap(Literal.parseBytes(hex), 4, 4).getInt();
+    }
+
+    /**
+     * Parse hex string into long.
+     * @param hex Hex string
+     * @return Long.
+     */
+    private static long parseLong(final String hex) {
+        return ByteBuffer.wrap(Literal.parseBytes(hex)).getLong();
+    }
+
+    /**
+     * Parse hex string into bytes.
+     * @param hex Hex string
+     * @return Bytes.
+     */
+    private static byte[] parseBytes(final String hex) {
+        final String[] split = hex.split(" ");
+        final int length = split.length;
+        byte[] res = new byte[length];
+        for (int i = 0; i < length; i++) {
+            res[i] = (byte) Integer.parseInt(split[i], 16);
+        }
+        return res;
     }
 
     /**

--- a/src/test/java/org/eolang/opeo/ast/LiteralTest.java
+++ b/src/test/java/org/eolang/opeo/ast/LiteralTest.java
@@ -24,9 +24,12 @@
 package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import org.eolang.jeo.representation.xmir.XmlNode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.xembly.ImpossibleModificationException;
@@ -118,6 +121,51 @@ final class LiteralTest {
             Matchers.contains(
                 new Opcode(Opcodes.ACONST_NULL)
             )
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "FF FF FF FF FF FF FF FF, 2, ICONST_M1",
+        "00 00 00 00 00 00 00 00, 3, ICONST_0",
+        "00 00 00 00 00 00 00 01, 4, ICONST_1",
+        "00 00 00 00 00 00 00 02, 5, ICONST_2",
+        "00 00 00 00 00 00 00 03, 6, ICONST_3",
+        "00 00 00 00 00 00 00 04, 7, ICONST_4",
+        "00 00 00 00 00 00 00 05, 8, ICONST_5"
+    })
+    void constructsIntFromXmir(final String input, final int opcode, final String expected) {
+        final AstNode actual = new Literal(
+            new XmlNode(String.format("<o base='int' data='bytes'>%s</o>", input))
+        ).opcodes().get(0);
+        MatcherAssert.assertThat(
+            String.format(
+                "We expect the following opcodes to be generated: '%s', but was '%s'",
+                expected,
+                actual
+            ),
+            actual,
+            Matchers.equalTo(new Opcode(opcode))
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "00 00 00 00 00 00 00 00, 9, LCONST_0",
+        "00 00 00 00 00 00 00 01, 10, LCONST_1"
+    })
+    void constructsLongFromXmir(final String input, final int opcode, final String expected) {
+        final AstNode actual = new Literal(
+            new XmlNode(String.format("<o base='long' data='bytes'>%s</o>", input))
+        ).opcodes().get(0);
+        MatcherAssert.assertThat(
+            String.format(
+                "We expect the following opcodes to be generated: '%s', but was '%s'",
+                expected,
+                actual
+            ),
+            actual,
+            Matchers.equalTo(new Opcode(opcode))
         );
     }
 }


### PR DESCRIPTION
In this PR I fix the bug related to incorrect parsing of int values from Literals. I also added a few tests to check new implementation.
Related to #229.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new class `MinusOne` to test integer decompilation/compilation and refactors `Literal` to parse hex strings into different data types.

### Detailed summary
- Added `MinusOne` class to test integer decompilation/compilation
- Refactored `Literal` to parse hex strings into integer, long, and bytes
- Added methods to parse hex strings into different data types
- Added tests to construct int and long from XMIR input

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->