### PR TITLE
feat(#272): Fix Doc Mistake in PHI Printing

### DIFF
--- a/src/it/spring-fat/README.md
+++ b/src/it/spring-fat/README.md
@@ -51,7 +51,7 @@ mvn clean integration-test invoker:run -Dinvoker.test=spring-fat -DskipTests -Di
 ```
 
 After running this command, you can find the PHI expressions in
-the `target/generated-sources/phi-expressions` directory.
+the `./target/it/spring-fat/target/generated-sources/phi-expressions` directory.
 
 **Pay attention!**
 You need to run this command from the root directory of the project, not from


### PR DESCRIPTION
In this PR I fixed a minor mistake in PHI printing documentation.
Closes: #272.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the file path in the README.md file for finding PHI expressions.

### Detailed summary
- Updated the file path to find PHI expressions in the `./target/it/spring-fat/target/generated-sources/phi-expressions` directory.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->