### PR TITLE
feat(#284): Add Support of IF_ICMPGT Instruction

### DIFF
--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -126,6 +126,8 @@ SOFTWARE.
               <goal>xmir-to-phi</goal>
             </goals>
             <configuration>
+              <phiSkipFailed>true</phiSkipFailed>
+              <phiOptimize>false</phiOptimize>
               <phiInputDir>${project.build.directory}/generated-sources/opeo-decompile-modified-xmir</phiInputDir>
               <phiOutputDir>${project.build.directory}/generated-sources/phi-expressions</phiOutputDir>
             </configuration>

--- a/src/main/java/org/eolang/opeo/CompileMojo.java
+++ b/src/main/java/org/eolang/opeo/CompileMojo.java
@@ -30,7 +30,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.eolang.opeo.compilation.Compiler;
-import org.eolang.opeo.compilation.DefaultCompiler;
 import org.eolang.opeo.compilation.DummyCompiler;
 import org.eolang.opeo.compilation.SelectiveCompiler;
 

--- a/src/main/java/org/eolang/opeo/CompileMojo.java
+++ b/src/main/java/org/eolang/opeo/CompileMojo.java
@@ -32,6 +32,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.eolang.opeo.compilation.Compiler;
 import org.eolang.opeo.compilation.DefaultCompiler;
 import org.eolang.opeo.compilation.DummyCompiler;
+import org.eolang.opeo.compilation.SelectiveCompiler;
 
 /**
  * Compiles high-level EO representation into low-level representation.
@@ -89,7 +90,7 @@ public final class CompileMojo extends AbstractMojo {
             Logger.info(this, "Compiler is disabled");
             compiler = new DummyCompiler(this.sourcesDir.toPath(), this.outputDir.toPath());
         } else {
-            compiler = new DefaultCompiler(this.sourcesDir.toPath(), this.outputDir.toPath());
+            compiler = new SelectiveCompiler(this.sourcesDir.toPath(), this.outputDir.toPath());
         }
         compiler.compile();
     }

--- a/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
+++ b/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
@@ -138,7 +138,7 @@ public final class SelectiveDecompiler implements Decompiler {
             entry -> {
                 final XmirEntry res;
                 final List<String> opcodes = entry.xpath(this.unsupportedOpcodes());
-                final List<String> trycatches = entry.xpath(this.trycatches());
+                final List<String> trycatches = entry.xpath(SelectiveDecompiler.trycatches());
                 if (opcodes.isEmpty() && trycatches.isEmpty()) {
                     res = entry.transform(
                         xml -> new JeoDecompiler(xml, entry.relative()).decompile()
@@ -173,9 +173,12 @@ public final class SelectiveDecompiler implements Decompiler {
     /**
      * Xpath to find all try-catch blocks.
      * @return Xpath.
-     * !todo!why?
+     * @todo #284:90min Decompile try-catch blocks.
+     *  Currently we skip decompilation of methods that contain try-catch blocks.
+     *  We need to implement decompilation of try-catch blocks.
+     *  Don't forget to add tests for the new functionality.
      */
-    private String trycatches() {
+    private static String trycatches() {
         return "//o[@base='tuple' and @name='trycatchblocks']/@name";
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Constant.java
+++ b/src/main/java/org/eolang/opeo/ast/Constant.java
@@ -25,6 +25,8 @@ package org.eolang.opeo.ast;
 
 import java.util.Collections;
 import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.eolang.jeo.representation.DataType;
 import org.eolang.jeo.representation.directives.DirectivesData;
 import org.eolang.jeo.representation.xmir.XmlNode;
@@ -43,6 +45,8 @@ import org.xembly.Directives;
  *  If we can't remove this class, we need to add more tests to cover all the cases
  *  where {@link Constant} is used.
  */
+@ToString
+@EqualsAndHashCode
 public final class Constant implements AstNode, Typed {
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/If.java
+++ b/src/main/java/org/eolang/opeo/ast/If.java
@@ -1,0 +1,138 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.objectweb.asm.Opcodes;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+/**
+ * If ast node.
+ * @since 0.2
+ */
+@ToString
+@EqualsAndHashCode
+public final class If implements AstNode {
+
+    /**
+     * First value to compare.
+     */
+    private final AstNode first;
+
+    /**
+     * Second value to compare.
+     */
+    private final AstNode second;
+
+    /**
+     * Where to jump if the comparison is true.
+     */
+    private final Label target;
+
+    /**
+     * Constructor.
+     * @param node XMIR node.
+     */
+    public If(final XmlNode node, Function<XmlNode, AstNode> search) {
+        this(If.xfirst(node, search), If.xsecond(node, search), If.xtarget(node));
+    }
+
+    /**
+     * Constructor.
+     * @param first First value.
+     * @param second Second value.
+     * @param target Target label.
+     */
+    public If(
+        final AstNode first,
+        final AstNode second,
+        final Label target
+    ) {
+        this.first = first;
+        this.second = second;
+        this.target = target;
+    }
+
+    @Override
+    public List<AstNode> opcodes() {
+        return Stream.concat(
+            Stream.concat(
+                this.first.opcodes().stream(),
+                this.second.opcodes().stream()
+            ),
+            Stream.of(new Opcode(Opcodes.IF_ICMPGT, this.target))
+        ).collect(Collectors.toList());
+    }
+
+    @Override
+    public Iterable<Directive> toXmir() {
+        return new Directives()
+            .add("o").attr("base", ".if")
+            .add("o").attr("base", ".gt")
+            .append(this.first.toXmir())
+            .append(this.second.toXmir())
+            .up()
+            .append(this.target.toXmir())
+            .add("o").attr("base", "nop").up()
+            .up();
+    }
+
+    /**
+     * Extracts the first value.
+     * @param node XMIR node where to extract the value.
+     * @return Value.
+     */
+    private static AstNode xfirst(final XmlNode node, Function<XmlNode, AstNode> search) {
+        return search.apply(node.child("base", ".gt").firstChild());
+    }
+
+    /**
+     * Extracts the second value.
+     * @param node XMIR node where to extract the value.
+     * @return Value.
+     */
+    private static AstNode xsecond(final XmlNode node, Function<XmlNode, AstNode> search) {
+        final List<XmlNode> children = node.child("base", ".gt").children()
+            .collect(Collectors.toList());
+        return search.apply(children.get(children.size() - 1));
+
+    }
+
+    /**
+     * Extracts the target label.
+     * @param node XMIR node where to extract the label.
+     * @return Label.
+     */
+    private static Label xtarget(final XmlNode node) {
+        return new Label(node.child("base", "label"));
+    }
+
+}

--- a/src/main/java/org/eolang/opeo/ast/If.java
+++ b/src/main/java/org/eolang/opeo/ast/If.java
@@ -31,7 +31,6 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.HexData;
 import org.eolang.jeo.representation.xmir.AllLabels;
-import org.eolang.jeo.representation.xmir.HexString;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
@@ -43,6 +42,7 @@ import org.xembly.Directives;
  */
 @ToString
 @EqualsAndHashCode
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class If implements AstNode {
 
     /**
@@ -63,8 +63,9 @@ public final class If implements AstNode {
     /**
      * Constructor.
      * @param node XMIR node.
+     * @param search Search function.
      */
-    public If(final XmlNode node, Function<XmlNode, AstNode> search) {
+    public If(final XmlNode node, final Function<XmlNode, AstNode> search) {
         this(If.xfirst(node, search), If.xsecond(node, search), If.xtarget(node));
     }
 
@@ -121,18 +122,20 @@ public final class If implements AstNode {
     /**
      * Extracts the first value.
      * @param node XMIR node where to extract the value.
+     * @param search Search function to parse child nodes.
      * @return Value.
      */
-    private static AstNode xfirst(final XmlNode node, Function<XmlNode, AstNode> search) {
+    private static AstNode xfirst(final XmlNode node, final Function<XmlNode, AstNode> search) {
         return search.apply(node.child("base", ".gt").firstChild());
     }
 
     /**
      * Extracts the second value.
      * @param node XMIR node where to extract the value.
+     * @param search Search function to parse child nodes.
      * @return Value.
      */
-    private static AstNode xsecond(final XmlNode node, Function<XmlNode, AstNode> search) {
+    private static AstNode xsecond(final XmlNode node, final Function<XmlNode, AstNode> search) {
         final List<XmlNode> children = node.child("base", ".gt").children()
             .collect(Collectors.toList());
         return search.apply(children.get(children.size() - 1));

--- a/src/main/java/org/eolang/opeo/ast/If.java
+++ b/src/main/java/org/eolang/opeo/ast/If.java
@@ -29,6 +29,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eolang.jeo.representation.HexData;
+import org.eolang.jeo.representation.xmir.AllLabels;
+import org.eolang.jeo.representation.xmir.HexString;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
@@ -74,8 +77,18 @@ public final class If implements AstNode {
     public If(
         final AstNode first,
         final AstNode second,
-        final Label target
+        final org.objectweb.asm.Label target
     ) {
+        this(first, second, new Label(new HexData(new AllLabels().uid(target)).value()));
+    }
+
+    /**
+     * Constructor.
+     * @param first First value.
+     * @param second Second value.
+     * @param target Target label.
+     */
+    public If(final AstNode first, final AstNode second, final Label target) {
         this.first = first;
         this.second = second;
         this.target = target;
@@ -88,7 +101,7 @@ public final class If implements AstNode {
                 this.first.opcodes().stream(),
                 this.second.opcodes().stream()
             ),
-            Stream.of(new Opcode(Opcodes.IF_ICMPGT, this.target))
+            Stream.of(new Opcode(Opcodes.IF_ICMPGT, this.target.toAsmLabel()))
         ).collect(Collectors.toList());
     }
 
@@ -123,7 +136,6 @@ public final class If implements AstNode {
         final List<XmlNode> children = node.child("base", ".gt").children()
             .collect(Collectors.toList());
         return search.apply(children.get(children.size() - 1));
-
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/Label.java
+++ b/src/main/java/org/eolang/opeo/ast/Label.java
@@ -72,4 +72,8 @@ public final class Label implements AstNode {
         return Collections.singletonList(this);
     }
 
+    public org.objectweb.asm.Label toAsmLabel() {
+        return new AllLabels().label(this.identifier);
+    }
+
 }

--- a/src/main/java/org/eolang/opeo/ast/Label.java
+++ b/src/main/java/org/eolang/opeo/ast/Label.java
@@ -25,6 +25,8 @@ package org.eolang.opeo.ast;
 
 import java.util.Collections;
 import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.eolang.jeo.representation.directives.DirectivesData;
 import org.eolang.jeo.representation.xmir.AllLabels;
 import org.eolang.jeo.representation.xmir.HexString;
@@ -35,6 +37,8 @@ import org.xembly.Directive;
  * Label ast node.
  * @since 0.1
  */
+@ToString
+@EqualsAndHashCode
 public final class Label implements AstNode {
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/Label.java
+++ b/src/main/java/org/eolang/opeo/ast/Label.java
@@ -72,11 +72,12 @@ public final class Label implements AstNode {
         return Collections.singletonList(this);
     }
 
-    public org.objectweb.asm.Label toAsmLabel() {
+    /**
+     * Convert to ASM label.
+     * @return ASM label.
+     */
+    org.objectweb.asm.Label toAsmLabel() {
         return new AllLabels().label(this.identifier);
     }
 
-    public String identifier(){
-        return identifier;
-    }
 }

--- a/src/main/java/org/eolang/opeo/ast/Label.java
+++ b/src/main/java/org/eolang/opeo/ast/Label.java
@@ -76,4 +76,7 @@ public final class Label implements AstNode {
         return new AllLabels().label(this.identifier);
     }
 
+    public String identifier(){
+        return identifier;
+    }
 }

--- a/src/main/java/org/eolang/opeo/ast/Labeled.java
+++ b/src/main/java/org/eolang/opeo/ast/Labeled.java
@@ -57,22 +57,13 @@ public final class Labeled implements AstNode, Typed {
      */
     private final Label label;
 
-    public Labeled(final XmlNode node, Function<XmlNode, AstNode> search) {
-        this(xnode(node, search), xlabel(node));
-    }
-
-    private static AstNode xnode(final XmlNode root, final Function<XmlNode, AstNode> search) {
-        if (root.children().count() > 1) {
-            return search.apply(root.firstChild());
-        } else {
-            return new Empty();
-        }
-    }
-
-    private static Label xlabel(final XmlNode root) {
-        final List<XmlNode> all = root.children().collect(Collectors.toList());
-        final XmlNode last = all.get(all.size() - 1);
-        return new Label(last);
+    /**
+     * Constructor.
+     * @param node Original node to parse.
+     * @param search Search function to parse child nodes.
+     */
+    public Labeled(final XmlNode node, final Function<XmlNode, AstNode> search) {
+        this(Labeled.xnode(node, search), Labeled.xlabel(node));
     }
 
     /**
@@ -95,12 +86,10 @@ public final class Labeled implements AstNode, Typed {
 
     @Override
     public List<AstNode> opcodes() {
-        final List<AstNode> re = Stream.concat(
+        return Stream.concat(
             this.node.opcodes().stream(),
             this.label.opcodes().stream()
         ).collect(Collectors.toList());
-
-        return re;
     }
 
     @Override
@@ -119,5 +108,32 @@ public final class Labeled implements AstNode, Typed {
         } else {
             throw new IllegalStateException(String.format("Node '%s' is not typed", this.node));
         }
+    }
+
+    /**
+     * Parse original node from XMIR.
+     * @param root Root node where the original node is placed.
+     * @param search Search function to parse child nodes.
+     * @return Original node.
+     */
+    private static AstNode xnode(final XmlNode root, final Function<XmlNode, AstNode> search) {
+        final AstNode result;
+        if (root.children().count() > 1) {
+            result = search.apply(root.firstChild());
+        } else {
+            result = new Empty();
+        }
+        return result;
+    }
+
+    /**
+     * Parse label from XMIR.
+     * @param root Root node where the label is placed.
+     * @return Label.
+     */
+    private static Label xlabel(final XmlNode root) {
+        final List<XmlNode> all = root.children().collect(Collectors.toList());
+        final XmlNode last = all.get(all.size() - 1);
+        return new Label(last);
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Mul.java
+++ b/src/main/java/org/eolang/opeo/ast/Mul.java
@@ -35,6 +35,10 @@ import org.xembly.Directives;
 /**
  * Multiplication.
  * @since 0.1
+ * @todo #284:90min Add types for Multiplication.
+ *  Currently we support only integer multiplication.
+ *  We need to add support for other types, such as floating point numbers, longs, etc.
+ *  Don't forget to add tests for the new types.
  */
 public final class Mul implements AstNode {
 

--- a/src/main/java/org/eolang/opeo/ast/Mul.java
+++ b/src/main/java/org/eolang/opeo/ast/Mul.java
@@ -57,7 +57,7 @@ public final class Mul implements AstNode {
      * @param node XMIR node where to extract the value.
      * @param search Search function.
      */
-    public Mul(final XmlNode node, Function<XmlNode, AstNode> search) {
+    public Mul(final XmlNode node, final Function<XmlNode, AstNode> search) {
         this(Mul.xleft(node, search), xright(node, search));
     }
 

--- a/src/main/java/org/eolang/opeo/ast/Mul.java
+++ b/src/main/java/org/eolang/opeo/ast/Mul.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -75,6 +76,7 @@ public final class Mul implements AstNode {
         final List<AstNode> res = new ArrayList<>(0);
         res.addAll(this.left.opcodes());
         res.addAll(this.right.opcodes());
+        res.add(new Opcode(Opcodes.IMUL));
         return res;
     }
 

--- a/src/main/java/org/eolang/opeo/ast/Mul.java
+++ b/src/main/java/org/eolang/opeo/ast/Mul.java
@@ -52,6 +52,11 @@ public final class Mul implements AstNode {
      */
     private final AstNode right;
 
+    /**
+     * Constructor.
+     * @param node XMIR node where to extract the value.
+     * @param search Search function.
+     */
     public Mul(final XmlNode node, Function<XmlNode, AstNode> search) {
         this(Mul.xleft(node, search), xright(node, search));
     }

--- a/src/main/java/org/eolang/opeo/ast/Mul.java
+++ b/src/main/java/org/eolang/opeo/ast/Mul.java
@@ -25,6 +25,9 @@ package org.eolang.opeo.ast;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.eolang.jeo.representation.xmir.XmlNode;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -43,6 +46,10 @@ public final class Mul implements AstNode {
      * Right operand.
      */
     private final AstNode right;
+
+    public Mul(final XmlNode node, Function<XmlNode, AstNode> search) {
+        this(Mul.xleft(node, search), xright(node, search));
+    }
 
     /**
      * Constructor.
@@ -69,5 +76,26 @@ public final class Mul implements AstNode {
         res.addAll(this.left.opcodes());
         res.addAll(this.right.opcodes());
         return res;
+    }
+
+    /**
+     * Extracts the first value.
+     * @param node XMIR node where to extract the value.
+     * @param search Search function
+     * @return Value.
+     */
+    private static AstNode xright(final XmlNode node, final Function<XmlNode, AstNode> search) {
+        final List<XmlNode> all = node.children().collect(Collectors.toList());
+        return search.apply(all.get(all.size() - 1));
+    }
+
+    /**
+     * Extracts the left value.
+     * @param node XMIR node where to extract the value.
+     * @param search Search function
+     * @return Value.
+     */
+    private static AstNode xleft(final XmlNode node, final Function<XmlNode, AstNode> search) {
+        return search.apply(node.firstChild());
     }
 }

--- a/src/main/java/org/eolang/opeo/compilation/JeoCompiler.java
+++ b/src/main/java/org/eolang/opeo/compilation/JeoCompiler.java
@@ -86,17 +86,20 @@ public final class JeoCompiler {
      *  to avoid a bug in the generation of labels. When we have lot's of methods, the cache grows
      *  and the compilation time increases significantly.
      * @todo #229:90min Calculate the Max Stack Size.
-     *  We should calculate the max stack size of the method and set it in the compiled method.
+     *  We should calculate the max stack size of the method and set it into the compiled method.
+     *  To enforce jeo to calculate the max stack size, we use 'withoutMaxs()' method.
      *  This is important to avoid runtime errors when running the compiled code.
-     *  We used to use 'withoutMaxs()' method to avoid this, but it causes some errors.
-     *  Actually, you can try to use it to see the errors.
+     *  Currently we calculate max stack size only for methods in the org.eolang package.
+     *  This is done intentionally because all the classes for the org.eolang package are
+     *  placed in the classpath and we can actually calculate the max stack size.
+     *  Other packages, for example, spring framework, have some 'optional' dependencies
+     *  that are not in the classpath and byt this reason, jeo can't calculate the max stack size.
      * @checkstyle IllegalCatch (50 lines)
      */
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.IdenticalCatchBranches"})
     private static XmlMethod compile(final XmlMethod method, final String pckg) {
         try {
             new AllLabels().clearCache();
-            //@todo: explain!
             if (pckg.contains("org.eolang")) {
                 return method.withoutMaxs().withInstructions(
                     new XmirParser(method.nodes()).toJeoNodes().toArray(XmlNode[]::new)

--- a/src/main/java/org/eolang/opeo/compilation/JeoCompiler.java
+++ b/src/main/java/org/eolang/opeo/compilation/JeoCompiler.java
@@ -26,11 +26,9 @@ package org.eolang.opeo.compilation;
 import com.jcabi.xml.XML;
 import org.eolang.jeo.representation.xmir.AllLabels;
 import org.eolang.jeo.representation.xmir.XmlClass;
-import org.eolang.jeo.representation.xmir.XmlInstruction;
 import org.eolang.jeo.representation.xmir.XmlMethod;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.jeo.representation.xmir.XmlProgram;
-import org.objectweb.asm.Opcodes;
 
 /**
  * Compiler of high-level EO programs to low-level EO suitable for jeo-maven-plugin.
@@ -76,6 +74,7 @@ public final class JeoCompiler {
      * Compiles a single method.
      *
      * @param method The method to compile.
+     * @param pckg The package of the method.
      * @return The compiled method.
      * @todo #229:90min Refactor {@link #compile} method to handle exceptions appropriately.
      *  The method {@link #compile} is catching generic exceptions which is bad.
@@ -99,16 +98,18 @@ public final class JeoCompiler {
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.IdenticalCatchBranches"})
     private static XmlMethod compile(final XmlMethod method, final String pckg) {
         try {
+            final XmlMethod result;
             new AllLabels().clearCache();
             if (pckg.contains("org.eolang")) {
-                return method.withoutMaxs().withInstructions(
+                result = method.withoutMaxs().withInstructions(
                     new XmirParser(method.nodes()).toJeoNodes().toArray(XmlNode[]::new)
                 );
             } else {
-                return method.withInstructions(
+                result = method.withInstructions(
                     new XmirParser(method.nodes()).toJeoNodes().toArray(XmlNode[]::new)
                 );
             }
+            return result;
         } catch (final ClassCastException exception) {
             throw new IllegalArgumentException(
                 String.format(

--- a/src/main/java/org/eolang/opeo/compilation/JeoCompiler.java
+++ b/src/main/java/org/eolang/opeo/compilation/JeoCompiler.java
@@ -26,9 +26,11 @@ package org.eolang.opeo.compilation;
 import com.jcabi.xml.XML;
 import org.eolang.jeo.representation.xmir.AllLabels;
 import org.eolang.jeo.representation.xmir.XmlClass;
+import org.eolang.jeo.representation.xmir.XmlInstruction;
 import org.eolang.jeo.representation.xmir.XmlMethod;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.jeo.representation.xmir.XmlProgram;
+import org.objectweb.asm.Opcodes;
 
 /**
  * Compiler of high-level EO programs to low-level EO suitable for jeo-maven-plugin.
@@ -91,9 +93,12 @@ public final class JeoCompiler {
     private static XmlMethod compile(final XmlMethod method) {
         try {
             new AllLabels().clearCache();
-            return method.withInstructions(
-                new XmirParser(method.nodes()).toJeoNodes().toArray(XmlNode[]::new)
-            );
+                return method.withoutMaxs().withInstructions(
+                    new XmirParser(method.nodes()).toJeoNodes().toArray(XmlNode[]::new)
+                );
+//                return method.withoutMaxs().withInstructions(
+//                    new XmirParser(method.nodes()).toJeoNodes().toArray(XmlNode[]::new)
+//                );
         } catch (final ClassCastException exception) {
             throw new IllegalArgumentException(
                 String.format(

--- a/src/main/java/org/eolang/opeo/compilation/SelectiveCompiler.java
+++ b/src/main/java/org/eolang/opeo/compilation/SelectiveCompiler.java
@@ -1,0 +1,64 @@
+package org.eolang.opeo.compilation;
+
+import com.jcabi.log.Logger;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.eolang.opeo.decompilation.handlers.RouterHandler;
+import org.eolang.opeo.storage.CompilationStorage;
+import org.eolang.opeo.storage.Storage;
+import org.eolang.opeo.storage.XmirEntry;
+
+public final class SelectiveCompiler implements Compiler {
+
+    private final Storage storage;
+    private final String[] supported;
+
+    public SelectiveCompiler(final Path xmirs, final Path output) {
+        this(new CompilationStorage(xmirs, output));
+    }
+
+    public SelectiveCompiler(final Storage storage) {
+        this.storage = storage;
+        this.supported = new RouterHandler(false).supportedOpcodes();
+    }
+
+    @Override
+    public void compile() {
+        Logger.info(
+            this,
+            "Compiled %d sources",
+            this.storage.all()
+                .parallel()
+                .mapToInt(this::compile)
+                .sum()
+        );
+    }
+
+    private int compile(final XmirEntry entry) {
+        final XmirEntry res;
+        if (entry.xpath(this.xpath()).isEmpty()) {
+            res = entry.transform(xml -> new JeoCompiler(xml).compile());
+        } else {
+            Logger.info(
+                this,
+                "Skipping %s, because it wasn't previously compiled",
+                entry
+            );
+            res = entry;
+        }
+        this.storage.save(res);
+        return 1;
+    }
+
+    /**
+     * Xpath to find all opcodes that are not supported.
+     * @return Xpath.
+     */
+    private String xpath() {
+        return String.format(
+            "//o[@base='opcode'][not(contains('%s', substring-before(concat(@name, '-'), '-'))) ]/@name",
+            Arrays.stream(this.supported).collect(Collectors.joining(" "))
+        );
+    }
+}

--- a/src/main/java/org/eolang/opeo/compilation/SelectiveCompiler.java
+++ b/src/main/java/org/eolang/opeo/compilation/SelectiveCompiler.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.opeo.compilation;
 
 import com.jcabi.log.Logger;
@@ -9,15 +32,37 @@ import org.eolang.opeo.storage.CompilationStorage;
 import org.eolang.opeo.storage.Storage;
 import org.eolang.opeo.storage.XmirEntry;
 
+/**
+ * Selective compiler.
+ * Compiles only those sources that were previously decompiled.
+ * All the rest are skipped and copied as is without any changes.
+ * @since 0.2
+ */
 public final class SelectiveCompiler implements Compiler {
 
+    /**
+     * Storage.
+     */
     private final Storage storage;
+
+    /**
+     * Supported opcodes.
+     */
     private final String[] supported;
 
+    /**
+     * Constructor.
+     * @param xmirs XMIRs to compile directory.
+     * @param output Output directory
+     */
     public SelectiveCompiler(final Path xmirs, final Path output) {
         this(new CompilationStorage(xmirs, output));
     }
 
+    /**
+     * Constructor.
+     * @param storage Storage.
+     */
     public SelectiveCompiler(final Storage storage) {
         this.storage = storage;
         this.supported = new RouterHandler(false).supportedOpcodes();
@@ -35,9 +80,15 @@ public final class SelectiveCompiler implements Compiler {
         );
     }
 
+    /**
+     * Compile the entry.
+     * @param entry Entry to compile.
+     * @return One if compiled, zero otherwise.
+     */
     private int compile(final XmirEntry entry) {
         final XmirEntry res;
-        if (entry.xpath(this.unsupportedOpcodes()).isEmpty() || entry.xpath(this.trycatches())
+        if (entry.xpath(this.unsupportedOpcodes()).isEmpty()
+            || entry.xpath(SelectiveCompiler.trycatches())
             .isEmpty()) {
             res = entry.transform(xml -> new JeoCompiler(xml).compile());
         } else {
@@ -67,7 +118,7 @@ public final class SelectiveCompiler implements Compiler {
      * Xpath to find all try-catch blocks.
      * @return Xpath.
      */
-    private String trycatches() {
+    private static String trycatches() {
         return "//o[@base='tuple' and @name='trycatchblocks']/@name";
     }
 }

--- a/src/main/java/org/eolang/opeo/compilation/SelectiveCompiler.java
+++ b/src/main/java/org/eolang/opeo/compilation/SelectiveCompiler.java
@@ -37,7 +37,8 @@ public final class SelectiveCompiler implements Compiler {
 
     private int compile(final XmirEntry entry) {
         final XmirEntry res;
-        if (entry.xpath(this.xpath()).isEmpty()) {
+        if (entry.xpath(this.unsupportedOpcodes()).isEmpty() || entry.xpath(this.trycatches())
+            .isEmpty()) {
             res = entry.transform(xml -> new JeoCompiler(xml).compile());
         } else {
             Logger.info(
@@ -55,10 +56,18 @@ public final class SelectiveCompiler implements Compiler {
      * Xpath to find all opcodes that are not supported.
      * @return Xpath.
      */
-    private String xpath() {
+    private String unsupportedOpcodes() {
         return String.format(
             "//o[@base='opcode'][not(contains('%s', substring-before(concat(@name, '-'), '-'))) ]/@name",
             Arrays.stream(this.supported).collect(Collectors.joining(" "))
         );
+    }
+
+    /**
+     * Xpath to find all try-catch blocks.
+     * @return Xpath.
+     */
+    private String trycatches() {
+        return "//o[@base='tuple' and @name='trycatchblocks']/@name";
     }
 }

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -49,6 +49,7 @@ import org.eolang.opeo.ast.If;
 import org.eolang.opeo.ast.InterfaceInvocation;
 import org.eolang.opeo.ast.Invocation;
 import org.eolang.opeo.ast.Label;
+import org.eolang.opeo.ast.Labeled;
 import org.eolang.opeo.ast.Literal;
 import org.eolang.opeo.ast.LocalVariable;
 import org.eolang.opeo.ast.Mul;
@@ -165,6 +166,8 @@ final class XmirParser {
         );
         if (".ignore-result".equals(base)) {
             result = new Popped(this.node(node.firstChild()));
+        } else if ("labeled".equals(base)) {
+            result = new Labeled(node, this::node);
         } else if ("times".equals(base)) {
             result = new Mul(node, this::node);
         } else if (".if".equals(base)) {

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -45,11 +45,13 @@ import org.eolang.opeo.ast.Duplicate;
 import org.eolang.opeo.ast.Field;
 import org.eolang.opeo.ast.FieldAssignment;
 import org.eolang.opeo.ast.FieldRetrieval;
+import org.eolang.opeo.ast.If;
 import org.eolang.opeo.ast.InterfaceInvocation;
 import org.eolang.opeo.ast.Invocation;
 import org.eolang.opeo.ast.Label;
 import org.eolang.opeo.ast.Literal;
 import org.eolang.opeo.ast.LocalVariable;
+import org.eolang.opeo.ast.Mul;
 import org.eolang.opeo.ast.NewAddress;
 import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.ast.Popped;
@@ -163,6 +165,10 @@ final class XmirParser {
         );
         if (".ignore-result".equals(base)) {
             result = new Popped(this.node(node.firstChild()));
+        } else if ("times".equals(base)) {
+            result = new Mul(node, this::node);
+        } else if (".if".equals(base)) {
+            result = new If(node, this::node);
         } else if ("load-constant".equals(base)) {
             result = new Constant(node);
         } else if (".new-type".equals(base)) {

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/IfHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/IfHandler.java
@@ -44,8 +44,8 @@ public final class IfHandler implements InstructionHandler {
     public void handle(final DecompilerState state) {
         if (state.instruction().opcode() == Opcodes.IF_ICMPGT) {
             final OperandStack stack = state.stack();
-            final AstNode first = stack.pop();
             final AstNode second = stack.pop();
+            final AstNode first = stack.pop();
             final Label operand = (Label) state.operand(0);
             stack.push(new If(first, second, operand));
         } else {

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/IfHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/IfHandler.java
@@ -1,11 +1,31 @@
 package org.eolang.opeo.decompilation.handlers;
 
+import org.eolang.opeo.ast.AstNode;
+import org.eolang.opeo.ast.If;
+import org.eolang.opeo.ast.Label;
+import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.eolang.opeo.decompilation.InstructionHandler;
+import org.eolang.opeo.decompilation.OperandStack;
+import org.objectweb.asm.Opcodes;
 
+/**
+ * If instruction handler.
+ * [value1, value2] → []
+ * If value1 is greater than value2, branch to instruction at branchoffset
+ * (signed short constructed from unsigned bytes branchbyte1 << 8 | branchbyte2)
+ * @since 0.2
+ */
 public final class IfHandler implements InstructionHandler {
     @Override
     public void handle(final DecompilerState state) {
+        if (state.instruction().opcode() == Opcodes.IF_ICMPGT) {
+            final OperandStack stack = state.stack();
+            final AstNode first = stack.pop();
+            final AstNode second = stack.pop();
+            final Label operand = (Label) state.operand(0);
+            stack.push(new If(first, second, operand));
 
+        }
     }
 }

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/IfHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/IfHandler.java
@@ -1,0 +1,11 @@
+package org.eolang.opeo.decompilation.handlers;
+
+import org.eolang.opeo.decompilation.DecompilerState;
+import org.eolang.opeo.decompilation.InstructionHandler;
+
+public final class IfHandler implements InstructionHandler {
+    @Override
+    public void handle(final DecompilerState state) {
+
+    }
+}

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/IfHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/IfHandler.java
@@ -1,12 +1,34 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.opeo.decompilation.handlers;
 
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.If;
-import org.eolang.opeo.ast.Label;
-import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.eolang.opeo.decompilation.InstructionHandler;
 import org.eolang.opeo.decompilation.OperandStack;
+import org.objectweb.asm.Label;
 import org.objectweb.asm.Opcodes;
 
 /**
@@ -17,6 +39,7 @@ import org.objectweb.asm.Opcodes;
  * @since 0.2
  */
 public final class IfHandler implements InstructionHandler {
+
     @Override
     public void handle(final DecompilerState state) {
         if (state.instruction().opcode() == Opcodes.IF_ICMPGT) {
@@ -25,7 +48,13 @@ public final class IfHandler implements InstructionHandler {
             final AstNode second = stack.pop();
             final Label operand = (Label) state.operand(0);
             stack.push(new If(first, second, operand));
-
+        } else {
+            throw new UnsupportedOperationException(
+                String.format(
+                    "Unsupported opcode: %d",
+                    state.instruction().opcode()
+                )
+            );
         }
     }
 }

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/RouterHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/RouterHandler.java
@@ -81,6 +81,7 @@ public final class RouterHandler implements InstructionHandler {
                 new MapEntry<>(Opcodes.FSUB, new SubstractionHandler()),
                 new MapEntry<>(Opcodes.DSUB, new SubstractionHandler()),
                 new MapEntry<>(Opcodes.IMUL, new MulHandler(counting)),
+                new MapEntry<>(Opcodes.IF_ICMPGT, new IfHandler()),
                 new MapEntry<>(Opcodes.I2B, new CastHandler(Type.BYTE_TYPE)),
                 new MapEntry<>(Opcodes.I2C, new CastHandler(Type.CHAR_TYPE)),
                 new MapEntry<>(Opcodes.I2S, new CastHandler(Type.SHORT_TYPE)),

--- a/src/main/java/org/eolang/opeo/jeo/JeoDecompiler.java
+++ b/src/main/java/org/eolang/opeo/jeo/JeoDecompiler.java
@@ -119,6 +119,15 @@ public final class JeoDecompiler {
                 ),
                 exception
             );
+        } catch (final IllegalStateException exception) {
+            throw new IllegalStateException(
+                String.format(
+                    "Failed to decompile method '%s' from the following XMIR: '%s'",
+                    method,
+                    this.prog
+                ),
+                exception
+            );
         }
     }
 }

--- a/src/main/java/org/eolang/opeo/jeo/JeoDecompiler.java
+++ b/src/main/java/org/eolang/opeo/jeo/JeoDecompiler.java
@@ -110,16 +110,7 @@ public final class JeoDecompiler {
                     ).children().collect(Collectors.toList()).toArray(XmlNode[]::new)
                 );
             }
-        } catch (final ClassCastException exception) {
-            throw new IllegalStateException(
-                String.format(
-                    "Failed to decompile method '%s' from the following XMIR: '%s'",
-                    method,
-                    this.prog
-                ),
-                exception
-            );
-        } catch (final IllegalStateException exception) {
+        } catch (final ClassCastException | IllegalStateException exception) {
             throw new IllegalStateException(
                 String.format(
                     "Failed to decompile method '%s' from the following XMIR: '%s'",

--- a/src/test/java/it/JeoAndOpeoTest.java
+++ b/src/test/java/it/JeoAndOpeoTest.java
@@ -117,7 +117,8 @@ final class JeoAndOpeoTest {
         "xmir/disassembled/SmartLifecycle.xmir",
         "xmir/disassembled/FlightRecorderStartupEvent.xmir",
         "xmir/disassembled/SimpleLog.xmir",
-        "xmir/disassembled/OpenSSLContext$1.xmir"
+        "xmir/disassembled/OpenSSLContext$1.xmir",
+        "xmir/disassembled/Factorial.xmir"
     })
     void decompilesCompilesAndKeepsTheSameInstructions(final String path) throws Exception {
         final XMLDocument original = new XMLDocument(new BytesOf(new ResourceOf(path)).asBytes());

--- a/src/test/java/it/JeoAndOpeoTest.java
+++ b/src/test/java/it/JeoAndOpeoTest.java
@@ -23,6 +23,7 @@
  */
 package it;
 
+import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -122,13 +123,17 @@ final class JeoAndOpeoTest {
     })
     void decompilesCompilesAndKeepsTheSameInstructions(final String path) throws Exception {
         final XMLDocument original = new XMLDocument(new BytesOf(new ResourceOf(path)).asBytes());
+        final XML decompiled = new JeoDecompiler(original).decompile();
+        System.out.println(decompiled);
+        final XML compiled = new JeoCompiler(
+            decompiled
+        ).compile();
+        System.out.println(compiled);
         MatcherAssert.assertThat(
             "The original and compiled instructions are not equal",
             new JeoInstructions(
                 new XmlProgram(
-                    new JeoCompiler(
-                        new JeoDecompiler(original).decompile()
-                    ).compile()
+                    compiled
                 ).top().methods().get(0)
             ).instuctionNames(),
             Matchers.equalTo(

--- a/src/test/java/org/eolang/opeo/ast/IfTest.java
+++ b/src/test/java/org/eolang/opeo/ast/IfTest.java
@@ -36,7 +36,7 @@ import org.xembly.Xembler;
  * Test case for {@link If}.
  * @since 0.2
  */
-class IfTest {
+final class IfTest {
 
     /**
      * Xmir for the 'if' statement.
@@ -74,15 +74,18 @@ class IfTest {
     void createsIfStatementFromXmir() {
         MatcherAssert.assertThat(
             "Can create 'if' statement from XMIR",
-            new If(new XmlNode(IfTest.XMIR), xml -> {
-                final AstNode result;
-                if (xml.text().contains("1")) {
-                    result = new Literal(1);
-                } else {
-                    result = new Literal(2);
+            new If(
+                new XmlNode(IfTest.XMIR),
+                xml -> {
+                    final AstNode result;
+                    if (xml.text().contains("1")) {
+                        result = new Literal(1);
+                    } else {
+                        result = new Literal(2);
+                    }
+                    return result;
                 }
-                return result;
-            }),
+            ),
             Matchers.equalTo(
                 new If(
                     new Literal(1),

--- a/src/test/java/org/eolang/opeo/ast/IfTest.java
+++ b/src/test/java/org/eolang/opeo/ast/IfTest.java
@@ -1,0 +1,113 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import com.jcabi.xml.XMLDocument;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link If}.
+ * @since 0.2
+ */
+class IfTest {
+
+    /**
+     * Xmir for the 'if' statement.
+     */
+    private static final String XMIR = String.join(
+        "\n",
+        "<?xml version='1.0' encoding='UTF-8'?>",
+        "<o base='.if'>",
+        "   <o base='.gt'>",
+        "      <o base='int' data='bytes'>00 00 00 00 00 00 00 01</o>",
+        "      <o base='int' data='bytes'>00 00 00 00 00 00 00 02</o>",
+        "   </o>",
+        "   <o base='label' data='bytes'>C3 BF</o>",
+        "   <o base='nop'/>",
+        "</o>",
+        ""
+    );
+
+    @Test
+    void convertsIfStatementToXmir() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "Can convert 'if' statement to correct XMIR",
+            new XMLDocument(
+                new Xembler(
+                    new If(
+                        new Literal(1), new Literal(2), new Label("FF")
+                    ).toXmir()
+                ).xml()
+            ),
+            Matchers.equalTo(new XMLDocument(IfTest.XMIR))
+        );
+    }
+
+    @Test
+    void createsIfStatementFromXmir() {
+        MatcherAssert.assertThat(
+            "Can create 'if' statement from XMIR",
+            new If(new XmlNode(IfTest.XMIR), xml -> {
+                final AstNode result;
+                if (xml.text().contains("1")) {
+                    result = new Literal(1);
+                } else {
+                    result = new Literal(2);
+                }
+                return result;
+            }),
+            Matchers.equalTo(
+                new If(
+                    new Literal(1),
+                    new Literal(2),
+                    new Label("C3 BF")
+                )
+            )
+        );
+    }
+
+    @Test
+    void convertsToOpcodes() {
+        final Label label = new Label("C3 BF");
+        MatcherAssert.assertThat(
+            "Can convert 'if' statement to opcodes",
+            new If(
+                new Literal(1),
+                new Literal(2),
+                label
+            ).opcodes(),
+            Matchers.hasItems(
+                new Opcode(Opcodes.ICONST_1),
+                new Opcode(Opcodes.ICONST_2),
+                new Opcode(Opcodes.IF_ICMPGT, label)
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/opeo/ast/IfTest.java
+++ b/src/test/java/org/eolang/opeo/ast/IfTest.java
@@ -106,7 +106,7 @@ class IfTest {
             Matchers.hasItems(
                 new Opcode(Opcodes.ICONST_1),
                 new Opcode(Opcodes.ICONST_2),
-                new Opcode(Opcodes.IF_ICMPGT, label)
+                new Opcode(Opcodes.IF_ICMPGT, label.toAsmLabel())
             )
         );
     }

--- a/src/test/java/org/eolang/opeo/ast/LabeledTest.java
+++ b/src/test/java/org/eolang/opeo/ast/LabeledTest.java
@@ -1,0 +1,53 @@
+package org.eolang.opeo.ast;
+
+import com.jcabi.xml.XMLDocument;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+class LabeledTest {
+
+    /**
+     * Example of XMIR representation of labeled constant.
+     */
+    private static final String XMIR = "<o base='labeled'><o base='load-constant'><o base='int' data='bytes'>00 00 00 00 00 00 00 01</o></o><o base='label' data='bytes'>01</o></o>";
+
+    @Test
+    void convertsToXmir() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            new XMLDocument(
+                new Xembler(
+                    new Labeled(new Constant(1), new Label("1")).toXmir()
+                ).xml()
+            ),
+            Matchers.equalTo(new XMLDocument(LabeledTest.XMIR))
+        );
+    }
+
+    @Test
+    void convertsFromXmir() {
+        MatcherAssert.assertThat(
+            new Labeled(new XmlNode(LabeledTest.XMIR), node -> new Constant(1)),
+            Matchers.equalTo(
+                new Labeled(new Constant(1), new Label("1"))
+            )
+        );
+    }
+
+    @Test
+    void convertsToOpcodes() {
+        final Label label = new Label("1");
+        MatcherAssert.assertThat(
+            new Labeled(new Constant(1), label).opcodes(),
+            Matchers.contains(
+                new Opcode(Opcodes.LDC, 1),
+                label
+            )
+        );
+    }
+
+}

--- a/src/test/java/org/eolang/opeo/ast/LabeledTest.java
+++ b/src/test/java/org/eolang/opeo/ast/LabeledTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.opeo.ast;
 
 import com.jcabi.xml.XMLDocument;
@@ -9,16 +32,22 @@ import org.objectweb.asm.Opcodes;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
-class LabeledTest {
+/**
+ * Test case for {@link Labeled}.
+ * @since 0.2
+ */
+final class LabeledTest {
 
     /**
      * Example of XMIR representation of labeled constant.
      */
-    private static final String XMIR = "<o base='labeled'><o base='load-constant'><o base='int' data='bytes'>00 00 00 00 00 00 00 01</o></o><o base='label' data='bytes'>01</o></o>";
+    private static final String XMIR =
+        "<o base='labeled'><o base='load-constant'><o base='int' data='bytes'>00 00 00 00 00 00 00 01</o></o><o base='label' data='bytes'>01</o></o>";
 
     @Test
     void convertsToXmir() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
+            "Wrong XMIR is generated for labeled constant",
             new XMLDocument(
                 new Xembler(
                     new Labeled(new Constant(1), new Label("1")).toXmir()
@@ -31,6 +60,7 @@ class LabeledTest {
     @Test
     void convertsFromXmir() {
         MatcherAssert.assertThat(
+            "Wrong labeled constant were generated from XMIR",
             new Labeled(new XmlNode(LabeledTest.XMIR), node -> new Constant(1)),
             Matchers.equalTo(
                 new Labeled(new Constant(1), new Label("1"))
@@ -42,6 +72,7 @@ class LabeledTest {
     void convertsToOpcodes() {
         final Label label = new Label("1");
         MatcherAssert.assertThat(
+            "Wrong opcodes are generated for labeled constant",
             new Labeled(new Constant(1), label).opcodes(),
             Matchers.contains(
                 new Opcode(Opcodes.LDC, 1),

--- a/src/test/resources/xmir/disassembled/Factorial.xmir
+++ b/src/test/resources/xmir/disassembled/Factorial.xmir
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<program dob="2024-05-28T11:19:37.916134Z"
+         ms="1716895177916"
+         name="j$Factorial"
+         revision="0.0.0"
+         time="2024-05-28T11:19:37.916134Z"
+         version="0.0.0">
+   <listing>yv66vgAAADQAHQoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCQAIAAkHAAoMAAsADAEAH29yZy9lb2xhbmcvamVvL3NwcmluZy9GYWN0b3JpYWwBAAFkAQABSQoACAAODAAFAA8BAAQoSSlWCgAIABEMABIAEwEAA2dldAEAAygpSQEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBABJMb2NhbFZhcmlhYmxlVGFibGUBAAR0aGlzAQAhTG9yZy9lb2xhbmcvamVvL3NwcmluZy9GYWN0b3JpYWw7AQAQTWV0aG9kUGFyYW1ldGVycwEADVN0YWNrTWFwVGFibGUBAApTb3VyY2VGaWxlAQAORmFjdG9yaWFsLmphdmEAIAAIAAIAAAABAAIACwAMAAAAAgAAAAUADwACABQAAABGAAIAAgAAAAoqtwABKhu1AAexAAAAAgAVAAAADgADAAAAKQAEACoACQArABYAAAAWAAIAAAAKABcAGAAAAAAACgALAAwAAQAZAAAABQEACwAAAAEAEgATAAEAFAAAAFsABAABAAAAICq0AAcEowAFBKy7AAhZKrQABwRktwANtgAQKrQAB2isAAAAAwAVAAAADgADAAAAMgAIADMACgA1ABYAAAAMAAEAAAAgABcAGAAAABoAAAADAAEKAAEAGwAAAAIAHA==</listing>
+   <errors/>
+   <sheets/>
+   <license/>
+   <metas>
+      <meta>
+         <head>package</head>
+         <tail>org.eolang.jeo.spring</tail>
+         <part>org.eolang.jeo.spring</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>org.eolang.jeo.opcode</tail>
+         <part>org.eolang.jeo.opcode</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>org.eolang.jeo.label</tail>
+         <part>org.eolang.jeo.label</part>
+      </meta>
+   </metas>
+   <objects>
+      <o abstract="" name="j$Factorial">
+         <o base="int" data="bytes" name="version">00 00 00 00 00 00 00 34</o>
+         <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 20</o>
+         <o base="string" data="bytes" name="supername">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
+         <o base="tuple" name="interfaces" star=""/>
+         <o base="field" name="j$d">
+            <o base="int" data="bytes" name="access-j$d">00 00 00 00 00 00 00 02</o>
+            <o base="string" data="bytes" name="descriptor-j$d">49</o>
+            <o base="string" data="bytes" name="signature-j$d"/>
+            <o base="int" data="bytes" name="value-j$d" scope="nullable"/>
+         </o>
+         <o abstract="" name="new">
+            <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 00</o>
+            <o base="string" data="bytes" name="descriptor">28 49 29 56</o>
+            <o base="string" data="bytes" name="signature"/>
+            <o base="tuple" name="exceptions" star=""/>
+            <o name="maxs">
+               <o base="int" data="bytes" name="stack">00 00 00 00 00 00 00 02</o>
+               <o base="int" data="bytes" name="locals">00 00 00 00 00 00 00 02</o>
+            </o>
+            <o abstract="" name="arg__I__0"/>
+            <o base="seq" name="@">
+               <o base="tuple" star="">
+                  <o base="label" data="bytes">34 37 37 34 36 64 66 32 2D 33 36 36 30 2D 34 38 62 66 2D 61 64 34 63 2D 35 64 36 38 38 36 37 35 37 64 36 64</o>
+                  <o base="opcode" line="999" name="ALOAD-1F42F2">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKESPECIAL-1F42F3">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 B7</o>
+                     <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
+                     <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
+                     <o base="string" data="bytes">28 29 56</o>
+                     <o base="bool" data="bytes">00</o>
+                  </o>
+                  <o base="label" data="bytes">65 38 33 62 34 35 32 64 2D 36 30 63 31 2D 34 65 37 33 2D 62 39 32 66 2D 31 36 62 31 63 35 37 34 64 32 31 66</o>
+                  <o base="opcode" line="999" name="ALOAD-1F42F7">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
+                  </o>
+                  <o base="opcode" line="999" name="ILOAD-1F42F9">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 15</o>
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 01</o>
+                  </o>
+                  <o base="opcode" line="999" name="PUTFIELD-1F42FA">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 B5</o>
+                     <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 73 70 72 69 6E 67 2F 46 61 63 74 6F 72 69 61 6C</o>
+                     <o base="string" data="bytes">64</o>
+                     <o base="string" data="bytes">49</o>
+                  </o>
+                  <o base="label" data="bytes">62 66 64 32 62 62 37 30 2D 63 62 39 34 2D 34 66 61 36 2D 39 61 62 63 2D 39 64 32 37 35 66 30 37 30 61 36 65</o>
+                  <o base="opcode" line="999" name="RETURN-1F42FD">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 B1</o>
+                  </o>
+                  <o base="label" data="bytes">62 36 34 62 61 61 65 61 2D 33 62 33 33 2D 34 32 37 63 2D 38 35 31 35 2D 62 63 38 61 34 34 36 66 30 62 36 32</o>
+               </o>
+            </o>
+         </o>
+         <o abstract="" name="j$get">
+            <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 01</o>
+            <o base="string" data="bytes" name="descriptor">28 29 49</o>
+            <o base="string" data="bytes" name="signature"/>
+            <o base="tuple" name="exceptions" star=""/>
+            <o name="maxs">
+               <o base="int" data="bytes" name="stack">00 00 00 00 00 00 00 04</o>
+               <o base="int" data="bytes" name="locals">00 00 00 00 00 00 00 01</o>
+            </o>
+            <o base="seq" name="@">
+               <o base="tuple" star="">
+                  <o base="label" data="bytes">61 37 36 64 36 65 35 32 2D 65 38 61 65 2D 34 62 34 65 2D 38 32 31 36 2D 36 32 61 30 65 63 34 62 39 62 63 61</o>
+                  <o base="opcode" line="999" name="ALOAD-1F4302">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
+                  </o>
+                  <o base="opcode" line="999" name="GETFIELD-1F4303">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 B4</o>
+                     <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 73 70 72 69 6E 67 2F 46 61 63 74 6F 72 69 61 6C</o>
+                     <o base="string" data="bytes">64</o>
+                     <o base="string" data="bytes">49</o>
+                  </o>
+                  <o base="opcode" line="999" name="ICONST_1-1F4305">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 04</o>
+                  </o>
+                  <o base="opcode" line="999" name="IF_ICMPGT-1F4306">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 A3</o>
+                     <o base="label" data="bytes">32 34 62 35 31 36 36 61 2D 38 39 33 61 2D 34 64 61 32 2D 62 64 36 65 2D 31 31 61 37 35 33 37 35 37 33 63 65</o>
+                  </o>
+                  <o base="label" data="bytes">64 39 64 34 35 65 31 30 2D 63 32 33 36 2D 34 63 31 33 2D 61 38 65 33 2D 30 61 30 30 37 63 31 38 63 61 31 61</o>
+                  <o base="opcode" line="999" name="ICONST_1-1F430B">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 04</o>
+                  </o>
+                  <o base="opcode" line="999" name="IRETURN-1F430C">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 AC</o>
+                  </o>
+                  <o base="label" data="bytes">32 34 62 35 31 36 36 61 2D 38 39 33 61 2D 34 64 61 32 2D 62 64 36 65 2D 31 31 61 37 35 33 37 35 37 33 63 65</o>
+                  <o base="frame">
+                     <o base="int" data="bytes" name="type">00 00 00 00 00 00 00 03</o>
+                     <o base="int" data="bytes" name="nlocal">00 00 00 00 00 00 00 00</o>
+                     <o base="tuple" name="local" star=""/>
+                     <o base="int" data="bytes" name="nstack">00 00 00 00 00 00 00 00</o>
+                     <o base="tuple" name="stack" star=""/>
+                  </o>
+                  <o base="opcode" line="999" name="NEW-1F4313">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 BB</o>
+                     <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 73 70 72 69 6E 67 2F 46 61 63 74 6F 72 69 61 6C</o>
+                  </o>
+                  <o base="opcode" line="999" name="DUP-1F4315">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 59</o>
+                  </o>
+                  <o base="opcode" line="999" name="ALOAD-1F4316">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
+                  </o>
+                  <o base="opcode" line="999" name="GETFIELD-1F4317">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 B4</o>
+                     <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 73 70 72 69 6E 67 2F 46 61 63 74 6F 72 69 61 6C</o>
+                     <o base="string" data="bytes">64</o>
+                     <o base="string" data="bytes">49</o>
+                  </o>
+                  <o base="opcode" line="999" name="ICONST_1-1F4318">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 04</o>
+                  </o>
+                  <o base="opcode" line="999" name="ISUB-1F4319">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 64</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKESPECIAL-1F431A">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 B7</o>
+                     <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 73 70 72 69 6E 67 2F 46 61 63 74 6F 72 69 61 6C</o>
+                     <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
+                     <o base="string" data="bytes">28 49 29 56</o>
+                     <o base="bool" data="bytes">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKEVIRTUAL-1F431B">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 B6</o>
+                     <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 73 70 72 69 6E 67 2F 46 61 63 74 6F 72 69 61 6C</o>
+                     <o base="string" data="bytes">67 65 74</o>
+                     <o base="string" data="bytes">28 29 49</o>
+                     <o base="bool" data="bytes">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="ALOAD-1F431E">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
+                  </o>
+                  <o base="opcode" line="999" name="GETFIELD-1F4320">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 B4</o>
+                     <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 73 70 72 69 6E 67 2F 46 61 63 74 6F 72 69 61 6C</o>
+                     <o base="string" data="bytes">64</o>
+                     <o base="string" data="bytes">49</o>
+                  </o>
+                  <o base="opcode" line="999" name="IMUL-1F4322">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 68</o>
+                  </o>
+                  <o base="opcode" line="999" name="IRETURN-1F4323">
+                     <o base="int" data="bytes">00 00 00 00 00 00 00 AC</o>
+                  </o>
+                  <o base="label" data="bytes">37 63 38 39 37 36 30 34 2D 36 65 62 66 2D 34 33 33 39 2D 38 66 32 32 2D 65 34 31 66 36 31 36 39 66 36 35 64</o>
+               </o>
+            </o>
+         </o>
+      </o>
+   </objects>
+</program>


### PR DESCRIPTION
In this PR I added support of `IF_ICMPGT` instruction which made possible to decompile `Factorial` class.

Closes: #284.
History:
- **feat(#284): identify the problem**
- **feat(#284): add first implementation for If node**
- **feat(#284): parse multiplication from XMIR**
- **feat(#284): fix the order of IF arguments and add IMUL opcode to Mul AST node**
- **feat(#284): add one more puzzle**
- **feat(#284): add selective compiler**
- **feat(#284): exclude files with try-catch-blocks**
- **feat(#284): calculate maxs only for org.eolang classes**
- **feat(#284): exclude tests with try-catch-blocks**
- **feat(#284): add one more puzzle**
- **feat(#284): fix all qulice suggestions**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces improvements and new features to the EO language compiler and decompiler.

### Detailed summary
- Added support for new opcodes and types in various classes
- Implemented decompilation of try-catch blocks
- Updated compiler classes for better functionality

> The following files were skipped due to too many changes: `src/test/java/it/JeoAndOpeoTest.java`, `src/main/java/org/eolang/opeo/decompilation/handlers/IfHandler.java`, `src/test/java/org/eolang/opeo/ast/LabeledTest.java`, `src/main/java/org/eolang/opeo/compilation/JeoCompiler.java`, `src/test/java/org/eolang/opeo/ast/IfTest.java`, `src/main/java/org/eolang/opeo/compilation/SelectiveCompiler.java`, `src/main/java/org/eolang/opeo/ast/If.java`, `src/test/resources/xmir/disassembled/Factorial.xmir`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->