### PR TITLE
fix: add maven opts to avoid problem with java modules

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -12,6 +12,8 @@ release:
   pre: false
   script: |-
     echo "Master branch"
+    export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
+    echo "MAVEN_OPTS: $MAVEN_OPTS"
     [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit -1
     mvn versions:set "-DnewVersion=${tag}" 
     git commit -am "${tag}"

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
     <skipITs/>
   </properties>
   <dependencies>


### PR DESCRIPTION
Add maven opts to avoid problem with releasing a new version of `opeo-maven-plugin`.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating Maven compiler configuration and adding MAVEN_OPTS in the build script.

### Detailed summary
- Updated Maven compiler configuration to use Java 11 release
- Added MAVEN_OPTS in build script for specific Java base packages
- Added version check before setting new version in Maven
- Git commit message now includes the tag

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->