### PR TITLE
feat(#247): Refactor SelectiveDecompilerTest and Add InMemoryStorage

### DIFF
--- a/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
+++ b/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
@@ -122,6 +122,17 @@ public final class SelectiveDecompiler implements Decompiler {
      * Constructor.
      * @param storage Storage from which retrieve the XMIRs and where to save the modified ones.
      * @param modified Storage where to save the modified of each decompiled file.
+     */
+    public SelectiveDecompiler(
+        final Storage storage, final Storage modified
+    ) {
+        this(storage, modified, new RouterHandler(false).supportedOpcodes());
+    }
+
+    /**
+     * Constructor.
+     * @param storage Storage from which retrieve the XMIRs and where to save the modified ones.
+     * @param modified Storage where to save the modified of each decompiled file.
      * @param supported Supported opcodes are used in selection.
      */
     public SelectiveDecompiler(

--- a/src/main/java/org/eolang/opeo/storage/InMemoryStorage.java
+++ b/src/main/java/org/eolang/opeo/storage/InMemoryStorage.java
@@ -71,10 +71,10 @@ public final class InMemoryStorage implements Storage {
      * @return The last saved entry.
      */
     public XmirEntry last() {
-        if (!this.container.isEmpty()) {
-            return this.container.get(this.container.size() - 1);
-        } else {
+        if (this.container.isEmpty()) {
             throw new IllegalStateException("Storage is empty");
+        } else {
+            return this.container.get(this.container.size() - 1);
         }
     }
 }

--- a/src/main/java/org/eolang/opeo/storage/InMemoryStorage.java
+++ b/src/main/java/org/eolang/opeo/storage/InMemoryStorage.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.opeo.storage;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Stream;
@@ -57,7 +56,9 @@ public final class InMemoryStorage implements Storage {
 
     @Override
     public Stream<XmirEntry> all() {
-        return this.container.stream();
+        final Stream<XmirEntry> stream = this.container.stream();
+        this.container.clear();
+        return stream;
     }
 
     @Override
@@ -65,6 +66,10 @@ public final class InMemoryStorage implements Storage {
         this.container.add(xmir);
     }
 
+    /**
+     * Get the last saved entry.
+     * @return The last saved entry.
+     */
     public XmirEntry last() {
         if (!this.container.isEmpty()) {
             return this.container.get(this.container.size() - 1);

--- a/src/main/java/org/eolang/opeo/storage/InMemoryStorage.java
+++ b/src/main/java/org/eolang/opeo/storage/InMemoryStorage.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.storage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+
+/**
+ * Storage that keeps everything in memory.
+ * This storage is rather useful for unit tests.
+ * @since 0.2
+ */
+public final class InMemoryStorage implements Storage {
+
+    /**
+     * Container where everything is stored.
+     */
+    private final List<XmirEntry> container;
+
+    /**
+     * Constructor.
+     */
+    public InMemoryStorage() {
+        this(new CopyOnWriteArrayList<>());
+    }
+
+    /**
+     * Constructor.
+     * @param container Container where everything is stored.
+     */
+    public InMemoryStorage(final List<XmirEntry> container) {
+        this.container = container;
+    }
+
+    @Override
+    public Stream<XmirEntry> all() {
+        return this.container.stream();
+    }
+
+    @Override
+    public void save(final XmirEntry xmir) {
+        this.container.add(xmir);
+    }
+
+    public XmirEntry last() {
+        if (!this.container.isEmpty()) {
+            return this.container.get(this.container.size() - 1);
+        } else {
+            throw new IllegalStateException("Storage is empty");
+        }
+    }
+}

--- a/src/main/java/org/eolang/opeo/storage/XmirEntry.java
+++ b/src/main/java/org/eolang/opeo/storage/XmirEntry.java
@@ -26,7 +26,6 @@ package org.eolang.opeo.storage;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.FileNotFoundException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Function;

--- a/src/main/java/org/eolang/opeo/storage/XmirEntry.java
+++ b/src/main/java/org/eolang/opeo/storage/XmirEntry.java
@@ -26,11 +26,13 @@ package org.eolang.opeo.storage;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.FileNotFoundException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Function;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.cactoos.Input;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Synced;
 import org.cactoos.scalar.Unchecked;
@@ -70,6 +72,15 @@ public final class XmirEntry {
      */
     XmirEntry(final XML xmir, final String pckg) {
         this(XmirEntry.fromXml(xmir), pckg);
+    }
+
+    /**
+     * Constructor.
+     * @param input Input.
+     * @param pckg Package name.
+     */
+    public XmirEntry(final Input input, final String pckg) {
+        this(XmirEntry.fromInput(input), pckg);
     }
 
     /**
@@ -135,6 +146,21 @@ public final class XmirEntry {
                             );
                         }
                     }
+                )
+            )
+        );
+    }
+
+    /**
+     * Prestructor from input.
+     * @param input Input.
+     * @return Lazy XMIR entry.
+     */
+    private static Unchecked<XML> fromInput(final Input input) {
+        return new Unchecked<>(
+            new Synced<>(
+                new Sticky<>(
+                    () -> new XMLDocument(input.stream())
                 )
             )
         );

--- a/src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java
@@ -23,11 +23,6 @@
  */
 package org.eolang.opeo.decompilation;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.stream.Stream;
-import org.cactoos.bytes.BytesOf;
 import org.cactoos.io.ResourceOf;
 import org.eolang.opeo.SelectiveDecompiler;
 import org.eolang.opeo.decompilation.handlers.RouterHandler;
@@ -35,9 +30,7 @@ import org.eolang.opeo.storage.InMemoryStorage;
 import org.eolang.opeo.storage.XmirEntry;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.hamcrest.io.FileMatchers;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test cases for {@link org.eolang.opeo.SelectiveDecompiler}.
@@ -129,22 +122,6 @@ final class SelectiveDecompilerTest {
             "We expect that the decompiled file will be the same in the output and copy folders.",
             storage.last(),
             Matchers.equalTo(modified.last())
-        );
-    }
-
-    @Test
-    void doesNotCopyDecompiledFiles(@TempDir final Path temp) throws Exception {
-        final byte[] known = new BytesOf(new ResourceOf("xmir/Known.xmir")).asBytes();
-        final Path input = temp.resolve("input");
-        final Path output = temp.resolve("output");
-        Files.createDirectories(input);
-        Files.createDirectories(output);
-        Files.write(input.resolve("Known.xmir"), known);
-        new SelectiveDecompiler(input, output).decompile();
-        MatcherAssert.assertThat(
-            "We expect that nothing additional will be stored in the folder instead of 'input' and 'output' folders.",
-            temp.toFile().listFiles(),
-            Matchers.arrayWithSize(2)
         );
     }
 

--- a/src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java
@@ -35,18 +35,25 @@ import org.junit.jupiter.api.Test;
 /**
  * Test cases for {@link org.eolang.opeo.SelectiveDecompiler}.
  * @since 0.1
- * @todo #226:90min Refactor SelectiveDecompilerTest.
- *  This test has a lot of string literals that are duplicated.
- *  Moreover, it has a {@link SelectiveDecompilerTest#supported} field that should be removed.
- *  See the javadoc for 'supported' field.
- *  Also we have some sort of duplication between method initializations.
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class SelectiveDecompilerTest {
+
+    /**
+     * Xmir with known instructions.
+     */
+    private static final String KNOWN = "xmir/Known.xmir";
+
+    /**
+     * Xmir with unknown instructions.
+     */
+    private static final String UNKNOWN = "xmir/Bar.xmir";
 
     @Test
     void decompiles() {
-        final XmirEntry known = new XmirEntry(new ResourceOf("xmir/Known.xmir"), "pckg");
+        final XmirEntry known = new XmirEntry(
+            new ResourceOf(SelectiveDecompilerTest.KNOWN),
+            "pckg"
+        );
         final InMemoryStorage storage = new InMemoryStorage();
         storage.save(known);
         final InMemoryStorage modified = new InMemoryStorage();
@@ -79,8 +86,12 @@ final class SelectiveDecompilerTest {
 
     @Test
     void decompilesOnlySomeFiles() {
-        final XmirEntry known = new XmirEntry(new ResourceOf("xmir/Known.xmir"), "known");
-        final XmirEntry unknown = new XmirEntry(new ResourceOf("xmir/Bar.xmir"), "unknown");
+        final XmirEntry known = new XmirEntry(
+            new ResourceOf(SelectiveDecompilerTest.KNOWN), "known"
+        );
+        final XmirEntry unknown = new XmirEntry(
+            new ResourceOf(SelectiveDecompilerTest.UNKNOWN), "unknown"
+        );
         final InMemoryStorage storage = new InMemoryStorage();
         storage.save(known);
         storage.save(unknown);
@@ -103,7 +114,9 @@ final class SelectiveDecompilerTest {
 
     @Test
     void copiesDecompiledFiles() {
-        final XmirEntry known = new XmirEntry(new ResourceOf("xmir/Known.xmir"), "known");
+        final XmirEntry known = new XmirEntry(
+            new ResourceOf(SelectiveDecompilerTest.KNOWN), "known"
+        );
         final InMemoryStorage storage = new InMemoryStorage();
         storage.save(known);
         final InMemoryStorage modified = new InMemoryStorage();

--- a/src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java
@@ -109,30 +109,26 @@ final class SelectiveDecompilerTest {
     }
 
     @Test
-    void copiesDecompiledFiles(@TempDir final Path temp) throws Exception {
-        final byte[] known = new BytesOf(new ResourceOf("xmir/Known.xmir")).asBytes();
-        final Path input = temp.resolve("input");
-        final Path output = temp.resolve("output");
-        final Path copy = temp.resolve("copy");
-        Files.createDirectories(input);
-        Files.createDirectories(output);
-        Files.createDirectories(copy);
-        Files.write(input.resolve("Known.xmir"), known);
-        new SelectiveDecompiler(input, output, copy).decompile();
+    void copiesDecompiledFiles() {
+        final XmirEntry known = new XmirEntry(new ResourceOf("xmir/Known.xmir"), "known");
+        final InMemoryStorage storage = new InMemoryStorage();
+        storage.save(known);
+        final InMemoryStorage modified = new InMemoryStorage();
+        new SelectiveDecompiler(storage, modified).decompile();
         MatcherAssert.assertThat(
-            "We expect that the decompiled file will be stored in the output folder.",
-            output.resolve("Known.xmir").toFile(),
-            FileMatchers.anExistingFile()
+            "We expect that the decompiled file will be stored in the output folder, but it should be modified",
+            storage.last(),
+            Matchers.not(Matchers.equalTo(known))
         );
         MatcherAssert.assertThat(
-            "We expect that the decompiled file will be stored in the copy folder.",
-            copy.resolve("Known.xmir").toFile(),
-            FileMatchers.anExistingFile()
+            "We expect that the decompiled file will be stored in the copy folder, but it should be modified",
+            modified.last(),
+            Matchers.not(Matchers.equalTo(known))
         );
         MatcherAssert.assertThat(
             "We expect that the decompiled file will be the same in the output and copy folders.",
-            new BytesOf(output.resolve("Known.xmir")).asBytes(),
-            Matchers.equalTo(new BytesOf(copy.resolve("Known.xmir")).asBytes())
+            storage.last(),
+            Matchers.equalTo(modified.last())
         );
     }
 

--- a/src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java
@@ -51,24 +51,13 @@ import org.junit.jupiter.api.io.TempDir;
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class SelectiveDecompilerTest {
 
-    /**
-     * Supported opcodes.
-     * Here we intentionally expand the list of supported opcodes to test the decompiler.
-     * Bar.xmir contains the IFLE instruction which is not supported by the decompiler yet.
-     */
-    private final String[] supported =
-        Stream.concat(
-            Arrays.stream(new RouterHandler(false).supportedOpcodes()),
-            Stream.of("IRETURN", "IFLE")
-        ).toArray(String[]::new);
-
     @Test
     void decompiles() {
-        final XmirEntry known = new XmirEntry(new ResourceOf("xmir/Bar.xmir"), "pckg");
+        final XmirEntry known = new XmirEntry(new ResourceOf("xmir/Known.xmir"), "pckg");
         final InMemoryStorage storage = new InMemoryStorage();
         storage.save(known);
         final InMemoryStorage modified = new InMemoryStorage();
-        new SelectiveDecompiler(storage, modified, this.supported).decompile();
+        new SelectiveDecompiler(storage, modified).decompile();
         MatcherAssert.assertThat(
             "We expect that the decompiled file won't be the same as the input file. Since the decompiler should change the file.",
             modified.last(),
@@ -129,7 +118,7 @@ final class SelectiveDecompilerTest {
         Files.createDirectories(output);
         Files.createDirectories(copy);
         Files.write(input.resolve("Known.xmir"), known);
-        new SelectiveDecompiler(input, output, copy, this.supported).decompile();
+        new SelectiveDecompiler(input, output, copy).decompile();
         MatcherAssert.assertThat(
             "We expect that the decompiled file will be stored in the output folder.",
             output.resolve("Known.xmir").toFile(),
@@ -155,7 +144,7 @@ final class SelectiveDecompilerTest {
         Files.createDirectories(input);
         Files.createDirectories(output);
         Files.write(input.resolve("Known.xmir"), known);
-        new SelectiveDecompiler(input, output, this.supported).decompile();
+        new SelectiveDecompiler(input, output).decompile();
         MatcherAssert.assertThat(
             "We expect that nothing additional will be stored in the folder instead of 'input' and 'output' folders.",
             temp.toFile().listFiles(),


### PR DESCRIPTION
In this PR I significantly refactored and simplified the `SelectiveDecompilerTest`.
I removed literal duplication and redundant field.
Also I added `InMemoryStorage` that speeds up testing since we don't need to interact with filesystem anymore.
However, we might encounter some problems with `InMemoryStorage` since it removes all the elements when recepient gets this elements.
So, `InMemorySorage` implicitly works like a queue.

Closes: #247

History:
- **feat(#247): add in memory storage for tests**
- **feat(#247): refactor decompilesOnlySomeFiles test**
- **feat(#247): remove 'supported' fied**
- **feat(#247): refactor #copiesDecompiledFiles test'**
- **feat(#247): remove redundant test**
- **feat(#247): remove the puzzle description for #247 issue**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds constructors and methods, implements InMemoryStorage, and refactors SelectiveDecompilerTest. 

### Detailed summary
- Added constructors and methods in `SelectiveDecompiler`, `XmirEntry`, and `InMemoryStorage`
- Implemented `InMemoryStorage` for unit tests
- Refactored `SelectiveDecompilerTest` to remove duplicated string literals and unused fields

> The following files were skipped due to too many changes: `src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->