### PR TITLE
feat(#316): Refactor Parsing of Attributes and Arguments

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/Arguments.java
+++ b/src/main/java/org/eolang/opeo/ast/Arguments.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.opeo.ast;
 
 import java.util.Collections;
@@ -6,18 +29,44 @@ import java.util.stream.Collectors;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.compilation.Parser;
 
+/**
+ * Arguments of an invocation.
+ * @since 0.2
+ */
 public final class Arguments {
 
+    /**
+     * Root node.
+     */
     private final XmlNode root;
+
+    /**
+     * Parser that understands how to parse subnodes.
+     */
     private final Parser parser;
+
+    /**
+     * Begin index.
+     * We start to parse arguments from this index.
+     */
     private final int begin;
 
+    /**
+     * Constructor.
+     * @param root Root node.
+     * @param parser Parser that understands how to parse subnodes.
+     * @param begin Begin index.
+     */
     public Arguments(final XmlNode root, final Parser parser, final int begin) {
         this.root = root;
         this.parser = parser;
         this.begin = begin;
     }
 
+    /**
+     * Convert to list.
+     * @return List of arguments.
+     */
     public List<AstNode> toList() {
         final List<XmlNode> all = this.root.children().collect(Collectors.toList());
         final List<AstNode> arguments;
@@ -31,5 +80,4 @@ public final class Arguments {
         }
         return arguments;
     }
-
 }

--- a/src/main/java/org/eolang/opeo/ast/Arguments.java
+++ b/src/main/java/org/eolang/opeo/ast/Arguments.java
@@ -1,0 +1,35 @@
+package org.eolang.opeo.ast;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.compilation.Parser;
+
+public final class Arguments {
+
+    private final XmlNode root;
+    private final Parser parser;
+    private final int begin;
+
+    public Arguments(final XmlNode root, final Parser parser, final int begin) {
+        this.root = root;
+        this.parser = parser;
+        this.begin = begin;
+    }
+
+    public List<AstNode> toList() {
+        final List<XmlNode> all = this.root.children().collect(Collectors.toList());
+        final List<AstNode> arguments;
+        if (all.size() > this.begin) {
+            arguments = all.subList(this.begin, all.size())
+                .stream()
+                .map(this.parser::parse)
+                .collect(Collectors.toList());
+        } else {
+            arguments = Collections.emptyList();
+        }
+        return arguments;
+    }
+
+}

--- a/src/main/java/org/eolang/opeo/ast/Attributes.java
+++ b/src/main/java/org/eolang/opeo/ast/Attributes.java
@@ -72,6 +72,15 @@ public final class Attributes {
 
     /**
      * Constructor.
+     * @param node Xmir representation of attributes.
+     * @param fallback Fallback attributes.
+     */
+    public Attributes(final XmlNode node, final Attributes fallback) {
+        this(Attributes.fromXmir(node, fallback));
+    }
+
+    /**
+     * Constructor.
      * @param all All attributes.
      */
     public Attributes(final Map<String, String> all) {
@@ -237,6 +246,15 @@ public final class Attributes {
                     )
                 )
         );
+    }
+
+    /**
+     * Parse attributes from Xmir.
+     * @param node Xmir node with attributes.
+     * @return Map of attributes.
+     */
+    private static Map<String, String> fromXmir(final XmlNode node, final Attributes fallback) {
+        return node.attribute("scope").map(Attributes::parse).orElse(fallback.all);
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/Attributes.java
+++ b/src/main/java/org/eolang/opeo/ast/Attributes.java
@@ -30,6 +30,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import org.cactoos.map.MapEntry;
+import org.eolang.jeo.representation.xmir.XmlNode;
 
 /**
  * Type attributes of AST nodes.
@@ -59,6 +60,14 @@ public final class Attributes {
      */
     public Attributes(final String... entries) {
         this(Attributes.fromEntries(entries));
+    }
+
+    /**
+     * Constructor.
+     * @param node Xmir representation of attributes.
+     */
+    public Attributes(final XmlNode node) {
+        this(Attributes.fromXmir(node));
     }
 
     /**
@@ -209,6 +218,25 @@ public final class Attributes {
             result = res;
         }
         return result;
+    }
+
+    /**
+     * Parse attributes from Xmir.
+     * @param node Xmir node with attributes.
+     * @return Map of attributes.
+     */
+    private static Map<String, String> fromXmir(final XmlNode node) {
+        return Attributes.parse(
+            node.attribute("scope")
+                .orElseThrow(
+                    () -> new IllegalArgumentException(
+                        String.format(
+                            "Can't retrieve attributes from the node %s",
+                            node
+                        )
+                    )
+                )
+        );
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/Attributes.java
+++ b/src/main/java/org/eolang/opeo/ast/Attributes.java
@@ -251,6 +251,7 @@ public final class Attributes {
     /**
      * Parse attributes from Xmir.
      * @param node Xmir node with attributes.
+     * @param fallback Use this attributes if there are no attributes in the node.
      * @return Map of attributes.
      */
     private static Map<String, String> fromXmir(final XmlNode node, final Attributes fallback) {

--- a/src/main/java/org/eolang/opeo/ast/Constructor.java
+++ b/src/main/java/org/eolang/opeo/ast/Constructor.java
@@ -111,6 +111,7 @@ public final class Constructor implements AstNode, Typed {
     /**
      * Constructor.
      * @param node Xmir representation of constructor.
+     * @param parser Parser that understands how to parse subnodes.
      */
     public Constructor(final XmlNode node, final Parser parser) {
         this(
@@ -118,16 +119,6 @@ public final class Constructor implements AstNode, Typed {
             Constructor.xattrs(node, parser),
             new Arguments(node, parser, 1).toList()
         );
-    }
-
-    /**
-     * Get target node.
-     * @param node Constructor node.
-     * @param parser Parser, which can extract AstNode from XmlNode.
-     * @return Target node.
-     */
-    private static AstNode xtarget(final XmlNode node, final Parser parser) {
-        return parser.parse(node.children().collect(Collectors.toList()).get(0));
     }
 
     /**
@@ -225,5 +216,15 @@ public final class Constructor implements AstNode, Typed {
             ).toString()
         );
         return attrs;
+    }
+
+    /**
+     * Get target node.
+     * @param node Constructor node.
+     * @param parser Parser, which can extract AstNode from XmlNode.
+     * @return Target node.
+     */
+    private static AstNode xtarget(final XmlNode node, final Parser parser) {
+        return parser.parse(node.children().collect(Collectors.toList()).get(0));
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Constructor.java
+++ b/src/main/java/org/eolang/opeo/ast/Constructor.java
@@ -26,6 +26,7 @@ package org.eolang.opeo.ast;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.compilation.Parser;
 import org.objectweb.asm.Opcodes;
@@ -111,16 +112,18 @@ public final class Constructor implements AstNode, Typed {
         this(
             Constructor.xtarget(node, parser),
             new Attributes(node),
-            Constructor.xargs(node, parser)
+            new Arguments(node, parser, 1).toList()
         );
     }
 
+    /**
+     * Get target node.
+     * @param node Constructor node.
+     * @param parser Parser, which can extract AstNode from XmlNode.
+     * @return Target node.
+     */
     private static AstNode xtarget(final XmlNode node, final Parser parser) {
-        return null;
-    }
-
-    private static List<AstNode> xargs(final XmlNode node, final Parser parser) {
-        return null;
+        return parser.parse(node.children().collect(Collectors.toList()).get(0));
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/Constructor.java
+++ b/src/main/java/org/eolang/opeo/ast/Constructor.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.compilation.Parser;
 import org.objectweb.asm.Opcodes;
@@ -38,6 +40,8 @@ import org.xembly.Directives;
  * Constructor output node.
  * @since 0.1
  */
+@ToString
+@EqualsAndHashCode
 public final class Constructor implements AstNode, Typed {
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/Constructor.java
+++ b/src/main/java/org/eolang/opeo/ast/Constructor.java
@@ -111,7 +111,7 @@ public final class Constructor implements AstNode, Typed {
     public Constructor(final XmlNode node, final Parser parser) {
         this(
             Constructor.xtarget(node, parser),
-            new Attributes(node),
+            Constructor.xattrs(node, parser),
             new Arguments(node, parser, 1).toList()
         );
     }
@@ -197,5 +197,29 @@ public final class Constructor implements AstNode, Typed {
             );
         }
         return result;
+    }
+
+    /**
+     * Get attributes from XML node.
+     * @param node XML node.
+     * @param parser Parser.
+     * @return Attributes.
+     * @todo #316:90min Refactor {@link Constructor#xattrs(XmlNode, Parser)} method.
+     *  It is too complex and hard to understand.
+     *  We need to refactor it to make it more readable and maintainable.
+     *  As you can see here we create several Attributes classes which looks strange.
+     */
+    private static Attributes xattrs(final XmlNode node, final Parser parser) {
+        final Attributes attrs = new Attributes(
+            node,
+            new Attributes().descriptor("").interfaced(false)
+        );
+        attrs.descriptor(
+            new ConstructorDescriptor(
+                attrs.descriptor(),
+                new Arguments(node, parser, 1).toList()
+            ).toString()
+        );
+        return attrs;
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Constructor.java
+++ b/src/main/java/org/eolang/opeo/ast/Constructor.java
@@ -26,6 +26,8 @@ package org.eolang.opeo.ast;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.compilation.Parser;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.xembly.Directive;
@@ -99,6 +101,26 @@ public final class Constructor implements AstNode, Typed {
         final List<AstNode> args
     ) {
         this(new NewAddress(type), attrs, args);
+    }
+
+    /**
+     * Constructor.
+     * @param node Xmir representation of constructor.
+     */
+    public Constructor(final XmlNode node, final Parser parser) {
+        this(
+            Constructor.xtarget(node, parser),
+            new Attributes(node),
+            Constructor.xargs(node, parser)
+        );
+    }
+
+    private static AstNode xtarget(final XmlNode node, final Parser parser) {
+        return null;
+    }
+
+    private static List<AstNode> xargs(final XmlNode node, final Parser parser) {
+        return null;
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
@@ -72,7 +72,7 @@ public final class InterfaceInvocation implements AstNode, Typed {
         this(
             InterfaceInvocation.xsource(node, parser),
             new Attributes(node),
-            InterfaceInvocation.xargs(node, parser)
+            new Arguments(node, parser, 1).toList()
         );
     }
 
@@ -149,30 +149,6 @@ public final class InterfaceInvocation implements AstNode, Typed {
      * @return Source.
      */
     private static AstNode xsource(final XmlNode node, final Parser parser) {
-        final List<XmlNode> inner = node.children().collect(Collectors.toList());
-        return parser.parse(inner.get(0));
-    }
-
-    /**
-     * Convert XML nodes into a list of arguments.
-     * @param node XML node.
-     * @param parser Parser.
-     * @return List of arguments.
-     */
-    private static List<AstNode> xargs(
-        final XmlNode node,
-        final Parser parser
-    ) {
-        final List<XmlNode> all = node.children().collect(Collectors.toList());
-        final List<AstNode> arguments;
-        if (all.size() > 1) {
-            arguments = all.subList(1, all.size())
-                .stream()
-                .map(parser::parse)
-                .collect(Collectors.toList());
-        } else {
-            arguments = Collections.emptyList();
-        }
-        return arguments;
+        return parser.parse(node.children().collect(Collectors.toList()).get(0));
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.ToString;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.compilation.Parser;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.xembly.Directive;
@@ -67,7 +68,7 @@ public final class InterfaceInvocation implements AstNode, Typed {
      * @param node XML node.
      * @param parser Parser, which can extract AstNode from XmlNode.
      */
-    public InterfaceInvocation(final XmlNode node, final Function<XmlNode, AstNode> parser) {
+    public InterfaceInvocation(final XmlNode node, final Parser parser) {
         this(
             InterfaceInvocation.xsource(node, parser),
             new Attributes(node),
@@ -147,9 +148,9 @@ public final class InterfaceInvocation implements AstNode, Typed {
      * @param parser Parser.
      * @return Source.
      */
-    private static AstNode xsource(final XmlNode node, final Function<XmlNode, AstNode> parser) {
+    private static AstNode xsource(final XmlNode node, final Parser parser) {
         final List<XmlNode> inner = node.children().collect(Collectors.toList());
-        return parser.apply(inner.get(0));
+        return parser.parse(inner.get(0));
     }
 
     /**
@@ -160,14 +161,14 @@ public final class InterfaceInvocation implements AstNode, Typed {
      */
     private static List<AstNode> xargs(
         final XmlNode node,
-        final Function<? super XmlNode, ? extends AstNode> parser
+        final Parser parser
     ) {
         final List<XmlNode> all = node.children().collect(Collectors.toList());
         final List<AstNode> arguments;
         if (all.size() > 1) {
             arguments = all.subList(1, all.size())
                 .stream()
-                .map(parser::apply)
+                .map(parser::parse)
                 .collect(Collectors.toList());
         } else {
             arguments = Collections.emptyList();

--- a/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
@@ -70,7 +70,7 @@ public final class InterfaceInvocation implements AstNode, Typed {
     public InterfaceInvocation(final XmlNode node, final Function<XmlNode, AstNode> parser) {
         this(
             InterfaceInvocation.xsource(node, parser),
-            InterfaceInvocation.xattrs(node),
+            new Attributes(node),
             InterfaceInvocation.xargs(node, parser)
         );
     }
@@ -139,22 +139,6 @@ public final class InterfaceInvocation implements AstNode, Typed {
     @Override
     public Type type() {
         return Type.getReturnType(this.attrs.descriptor());
-    }
-
-    /**
-     * Extracts attributes from the node.
-     * @param node XML node
-     * @return Attributes
-     */
-    private static Attributes xattrs(final XmlNode node) {
-        return node.attribute("scope").map(Attributes::new).orElseThrow(
-            () -> new IllegalArgumentException(
-                String.format(
-                    "Can't retrieve interface invocation attributes from the node %s",
-                    node
-                )
-            )
-        );
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
@@ -24,10 +24,8 @@
 package org.eolang.opeo.ast;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.ToString;
 import org.eolang.jeo.representation.xmir.XmlNode;

--- a/src/main/java/org/eolang/opeo/ast/LocalVariable.java
+++ b/src/main/java/org/eolang/opeo/ast/LocalVariable.java
@@ -65,7 +65,7 @@ public final class LocalVariable implements AstNode, Typed {
      * @param node The XML node that represents variable.
      */
     public LocalVariable(final XmlNode node) {
-        this(LocalVariable.videntifier(node), LocalVariable.vattributes(node));
+        this(LocalVariable.videntifier(node), new Attributes(node));
     }
 
     /**
@@ -129,25 +129,6 @@ public final class LocalVariable implements AstNode, Typed {
                     )
                 )
             ).substring(LocalVariable.PREFIX.length())
-        );
-    }
-
-    /**
-     * Get the attributes of the variable.
-     * @param node The XML node that represents variable.
-     * @return The attributes.
-     */
-    private static Attributes vattributes(final XmlNode node) {
-        return new Attributes(
-            node.attribute("scope")
-                .orElseThrow(
-                    () -> new IllegalArgumentException(
-                        String.format(
-                            "Can't recognize variable node: %n%s%nWe expected to find 'scope' attribute",
-                            node
-                        )
-                    )
-                )
         );
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/StaticInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/StaticInvocation.java
@@ -102,7 +102,7 @@ public final class StaticInvocation implements AstNode, Typed {
      */
     public StaticInvocation(final XmlNode node, final List<AstNode> arguments) {
         this(
-            StaticInvocation.xattrs(node),
+            new Attributes(node),
             StaticInvocation.xowner(node),
             arguments
         );
@@ -177,19 +177,6 @@ public final class StaticInvocation implements AstNode, Typed {
     @Override
     public Type type() {
         return Type.getReturnType(this.attributes.descriptor());
-    }
-
-    /**
-     * Extracts attributes from the node.
-     * @param node XML node
-     * @return Attributes
-     */
-    private static Attributes xattrs(final XmlNode node) {
-        return node.attribute("scope").map(Attributes::new).orElseThrow(
-            () -> new IllegalArgumentException(
-                String.format("Can't retrieve static invocation attributes from the node %s", node)
-            )
-        );
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/This.java
+++ b/src/main/java/org/eolang/opeo/ast/This.java
@@ -62,7 +62,7 @@ public final class This implements AstNode, Typed {
      * @param node XML node.
      */
     public This(final XmlNode node) {
-        this(This.xattrs(node));
+        this(new Attributes(node));
     }
 
     /**
@@ -98,20 +98,5 @@ public final class This implements AstNode, Typed {
     @Override
     public Type type() {
         return Type.getObjectType(this.attributes.descriptor());
-    }
-
-    /**
-     * Extracts attributes from the XML node.
-     * @param node XML node.
-     * @return Attributes.
-     */
-    private static Attributes xattrs(final XmlNode node) {
-        return new Attributes(
-            node.attribute("scope").orElseThrow(
-                () -> new IllegalStateException(
-                    String.format("No scope attribute in this node %s", node)
-                )
-            )
-        );
     }
 }

--- a/src/main/java/org/eolang/opeo/compilation/Parser.java
+++ b/src/main/java/org/eolang/opeo/compilation/Parser.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.compilation;
+
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.ast.AstNode;
+
+/**
+ * Transforms XML nodes into AST nodes.
+ * @since 0.2
+ */
+public interface Parser {
+
+    /**
+     * Parses XML node into AST node.
+     * @param node XML node
+     * @return AST node
+     */
+    AstNode parse(final XmlNode node);
+}

--- a/src/main/java/org/eolang/opeo/compilation/Parser.java
+++ b/src/main/java/org/eolang/opeo/compilation/Parser.java
@@ -37,5 +37,5 @@ public interface Parser {
      * @param node XML node
      * @return AST node
      */
-    AstNode parse(final XmlNode node);
+    AstNode parse(XmlNode node);
 }

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -297,17 +297,7 @@ final class XmirParser implements Parser {
             final AstNode size = this.parse(children.get(1));
             result = new ArrayConstructor(size, type);
         } else if (!base.isEmpty() && base.charAt(0) == '.') {
-            final Attributes attributes = new Attributes(
-                node.attribute("scope")
-                    .orElseThrow(
-                        () -> new IllegalArgumentException(
-                            String.format(
-                                "Can't find attributes of '%s'",
-                                base
-                            )
-                        )
-                    )
-            );
+            final Attributes attributes = new Attributes(node);
             if ("static".equals(attributes.type())) {
                 result = new StaticInvocation(
                     node, this.args(node.children().collect(Collectors.toList()))

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -280,18 +280,7 @@ final class XmirParser implements Parser {
         } else if (base.contains("local")) {
             result = new LocalVariable(node);
         } else if (".new".equals(base)) {
-            final List<XmlNode> inner = node.children().collect(Collectors.toList());
-            final AstNode target = this.parse(inner.get(0));
-            final List<AstNode> args = new Arguments(node, this, 1).toList();
-            final String descriptor = node.attribute("scope")
-                .map(Attributes::new)
-                .map(Attributes::descriptor)
-                .map(descr -> new ConstructorDescriptor(descr, args))
-                .orElseGet(() -> new ConstructorDescriptor(args)).toString();
-            final Attributes attributes = new Attributes()
-                .descriptor(descriptor)
-                .interfaced(false);
-            result = new Constructor(target, attributes, args);
+            result = new Constructor(node, this);
         } else if (".array-node".equals(base)) {
             final List<XmlNode> children = node.children().collect(Collectors.toList());
             final String type = new HexString(children.get(0).text()).decode();

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -32,6 +32,7 @@ import org.eolang.jeo.representation.xmir.XmlInstruction;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.jeo.representation.xmir.XmlOperand;
 import org.eolang.opeo.ast.Add;
+import org.eolang.opeo.ast.Arguments;
 import org.eolang.opeo.ast.ArrayConstructor;
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.Attributes;
@@ -212,7 +213,7 @@ final class XmirParser implements Parser {
             final AstNode instance = this.parse(inner.get(0));
             result = new Super(
                 instance,
-                this.args(inner),
+                new Arguments(node, this, 1).toList(),
                 new Attributes(
                     node.attribute("scope").orElseThrow(
                         () -> new IllegalArgumentException(
@@ -281,7 +282,7 @@ final class XmirParser implements Parser {
         } else if (".new".equals(base)) {
             final List<XmlNode> inner = node.children().collect(Collectors.toList());
             final AstNode target = this.parse(inner.get(0));
-            final List<AstNode> args = this.args(inner);
+            final List<AstNode> args = new Arguments(node, this, 1).toList();
             final String descriptor = node.attribute("scope")
                 .map(Attributes::new)
                 .map(Attributes::descriptor)
@@ -300,14 +301,14 @@ final class XmirParser implements Parser {
             final Attributes attributes = new Attributes(node);
             if ("static".equals(attributes.type())) {
                 result = new StaticInvocation(
-                    node, this.args(node.children().collect(Collectors.toList()))
+                    node, new Arguments(node, this, 1).toList()
                 );
             } else if ("interface".equals(attributes.type())) {
                 result = new InterfaceInvocation(node, this::parse);
             } else {
                 final List<XmlNode> inner = node.children().collect(Collectors.toList());
                 final AstNode target = this.parse(inner.get(0));
-                result = new Invocation(target, attributes, this.args(inner));
+                result = new Invocation(target, attributes, new Arguments(node, this, 1).toList());
             }
         } else {
             throw new IllegalArgumentException(
@@ -315,24 +316,5 @@ final class XmirParser implements Parser {
             );
         }
         return result;
-    }
-
-    /**
-     * Convert XML nodes into a list of arguments.
-     *
-     * @param all XML nodes.
-     * @return List of arguments.
-     */
-    private List<AstNode> args(final List<XmlNode> all) {
-        final List<AstNode> arguments;
-        if (all.size() > 1) {
-            arguments = all.subList(1, all.size())
-                .stream()
-                .map(this::parse)
-                .collect(Collectors.toList());
-        } else {
-            arguments = Collections.emptyList();
-        }
-        return arguments;
     }
 }

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -24,7 +24,6 @@
 package org.eolang.opeo.compilation;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.eolang.jeo.representation.xmir.HexString;
@@ -41,7 +40,6 @@ import org.eolang.opeo.ast.ClassField;
 import org.eolang.opeo.ast.ClassName;
 import org.eolang.opeo.ast.Constant;
 import org.eolang.opeo.ast.Constructor;
-import org.eolang.opeo.ast.ConstructorDescriptor;
 import org.eolang.opeo.ast.Duplicate;
 import org.eolang.opeo.ast.Field;
 import org.eolang.opeo.ast.FieldAssignment;
@@ -106,34 +104,6 @@ final class XmirParser implements Parser {
     }
 
     /**
-     * Convert to XML nodes.
-     *
-     * @return XML nodes.
-     */
-    List<XmlNode> toJeoNodes() {
-        return this.nodes.stream()
-            .map(this::opcodes)
-            .flatMap(List::stream)
-            .collect(Collectors.toList());
-    }
-
-    /**
-     * Convert XmlNode into a list of opcodes.
-     *
-     * @param node XmlNode
-     * @return List of opcodes
-     */
-    private List<XmlNode> opcodes(final XmlNode node) {
-        return this.parse(node).opcodes()
-            .stream()
-            .map(AstNode::toXmir)
-            .map(Xembler::new)
-            .map(Xembler::xmlQuietly)
-            .map(XmlNode::new)
-            .collect(Collectors.toList());
-    }
-
-    /**
      * Convert XmlNode to AstNode.
      *
      * @param node XmlNode
@@ -153,6 +123,7 @@ final class XmirParser implements Parser {
      * @checkstyle JavaNCSSCheck (200 lines)
      * @checkstyle NestedIfDepthCheck (200 lines)
      * @checkstyle MethodLengthCheck (200 lines)     *
+     * @checkstyle NoJavadocForOverriddenMethodsCheck (200 lines)
      */
     @SuppressWarnings({"PMD.NcssCount", "PMD.ExcessiveMethodLength", "PMD.CognitiveComplexity"})
     @Override
@@ -305,5 +276,33 @@ final class XmirParser implements Parser {
             );
         }
         return result;
+    }
+
+    /**
+     * Convert to XML nodes.
+     *
+     * @return XML nodes.
+     */
+    List<XmlNode> toJeoNodes() {
+        return this.nodes.stream()
+            .map(this::opcodes)
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Convert XmlNode into a list of opcodes.
+     *
+     * @param node XmlNode
+     * @return List of opcodes
+     */
+    private List<XmlNode> opcodes(final XmlNode node) {
+        return this.parse(node).opcodes()
+            .stream()
+            .map(AstNode::toXmir)
+            .map(Xembler::new)
+            .map(Xembler::xmlQuietly)
+            .map(XmlNode::new)
+            .collect(Collectors.toList());
     }
 }

--- a/src/test/java/org/eolang/opeo/ast/ConstructorTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ConstructorTest.java
@@ -90,7 +90,6 @@ final class ConstructorTest {
 
 
     @Test
-    @Disabled
     void createsConstructorFromXmir() {
         final String xml = String.join(
             "\n",

--- a/src/test/java/org/eolang/opeo/ast/ConstructorTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ConstructorTest.java
@@ -24,7 +24,9 @@
 package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import org.eolang.jeo.representation.xmir.XmlNode;
 import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Transformers;
@@ -84,5 +86,28 @@ final class ConstructorTest {
                 "/o[@base='.new' and @scope='descriptor=(Ljava/lang/String;)V']"
             )
         );
+    }
+
+
+    @Test
+    @Disabled
+    void createsConstructorFromXmir() {
+        final String xml = String.join(
+            "\n",
+            "<o base='.new'>",
+            "  <o base='.new-type'><o base='string' data='bytes'>41</o></o>",
+            "  <o base='string' data='bytes'>66 69 72 73 74</o>",
+            "  <o base='string' data='bytes'>73 65 63 6F 6E 64</o>",
+            "  <o base='int' data='bytes'>00 00 00 00 00 00 00 03</o>",
+            "</o>"
+        );
+        final XmlNode node = new XmlNode(xml);
+        new Constructor(
+            node,
+            xmir -> {
+                return new Literal();
+            }
+        );
+
     }
 }

--- a/src/test/java/org/eolang/opeo/ast/ConstructorTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ConstructorTest.java
@@ -27,7 +27,6 @@ import com.jcabi.matchers.XhtmlMatchers;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Transformers;
@@ -101,23 +100,31 @@ final class ConstructorTest {
             new Constructor(
                 new XmlNode(ConstructorTest.CONSTRUCTOR),
                 node -> {
+                    final AstNode result;
                     if (node.equals(
-                        new XmlNode("<o base='string' data='bytes'>66 69 72 73 74</o>"))) {
-                        return new Literal("first");
+                        new XmlNode("<o base='string' data='bytes'>66 69 72 73 74</o>")
+                    )) {
+                        result = new Literal("first");
                     } else if (node.equals(
-                        new XmlNode("<o base='string' data='bytes'>73 65 63 6F 6E 64</o>"))) {
-                        return new Literal("second");
+                        new XmlNode("<o base='string' data='bytes'>73 65 63 6F 6E 64</o>")
+                    )) {
+                        result = new Literal("second");
                     } else if (node.equals(
-                        new XmlNode("<o base='int' data='bytes'>00 00 00 00 00 00 00 03</o>"))) {
-                        return new Literal(3);
-                    } else if (node.equals(new XmlNode(
-                        "<o base='.new-type'><o base='string' data='bytes'>41</o></o>"))) {
-                        return new NewAddress("A");
+                        new XmlNode("<o base='int' data='bytes'>00 00 00 00 00 00 00 03</o>")
+                    )) {
+                        result = new Literal(3);
+                    } else if (node.equals(
+                        new XmlNode(
+                            "<o base='.new-type'><o base='string' data='bytes'>41</o></o>"
+                        )
+                    )) {
+                        result = new NewAddress("A");
                     } else {
                         throw new IllegalArgumentException(
                             String.format("Can't parse constructor from node %s", node)
                         );
                     }
+                    return result;
                 }
             ),
             Matchers.equalTo(


### PR DESCRIPTION
In this PR I introduced `Arguments` class that encapsulates logic of parsing invocation arguments.
Removed duplicated parsing logic of `Attributes`.
Moved `Constructor` parsing logic into the corresponding class.
Add one more unit test related to constructors parsing.

Related to #316.
History:
- **feat(#316): parse attributes in a single place.**
- **feat(#316): simplify code in several places**
- **feat(#316): add Arguments class**
- **feat(#316): use Arguments class**
- **feat(#316): add one more puzzle**
- **feat(#316): add one more test for Constructor parsing**
- **feat(#316): fix all the code offences**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor attribute extraction methods and introduce a new `Parser` interface for XML to AST node transformation.

### Detailed summary
- Refactored attribute extraction methods in `Attributes` and `Constructor` classes
- Introduced a `Parser` interface for XML to AST node transformation
- Replaced attribute extraction methods with new `Attributes` constructor in `This`, `StaticInvocation`, and `LocalVariable` classes
- Updated constructor in `Constructor` class to use `Parser` for parsing subnodes
- Introduced `Arguments` class for handling invocation arguments in `Constructor` and `InterfaceInvocation` classes

> The following files were skipped due to too many changes: `src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java`, `src/test/java/org/eolang/opeo/ast/ConstructorTest.java`, `src/main/java/org/eolang/opeo/compilation/XmirParser.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->