### PR TITLE
feat(#305): Enable 'spring' and 'staticize' Integration Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,15 +215,6 @@ SOFTWARE.
                We should either update the representation generated or just remove the test.
             -->
             <exclude>fuse/pom.xml</exclude>
-            <!--
-              @todo #290:30min Enable the 'staticize' and 'spring' integration tests.
-               The 'staticize' and 'spring' integration test are disabled in the default profile.
-               They are disabled because they depend on 'ineo-maven-plugin' wich supports only Java 11.
-               We need to add support for Java 8 to the 'ineo-maven-plugin' and enable these tests.
-               Check the progress here: https://github.com/objectionary/ineo-maven-plugin/pull/72
-            -->
-            <exclude>staticize/pom.xml</exclude>
-            <exclude>spring/pom.xml</exclude>
           </pomExcludes>
         </configuration>
         <dependencies>

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -54,7 +54,7 @@ SOFTWARE.
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <jeo.version>0.4.6</jeo.version>
-    <ineo.version>0.3.1</ineo.version>
+    <ineo.version>0.3.2</ineo.version>
   </properties>
   <dependencies>
     <dependency>

--- a/src/it/staticize/pom.xml
+++ b/src/it/staticize/pom.xml
@@ -51,7 +51,7 @@ SOFTWARE.
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
     <jeo.version>0.4.6</jeo.version>
-    <ineo.version>0.3.1</ineo.version>
+    <ineo.version>0.3.2</ineo.version>
     <opeo.version>@project.version@</opeo.version>
   </properties>
   <build>


### PR DESCRIPTION
In this PR I upgraded `ineo-maven-plugin` up to `0.3.2` version.
This allowed to enable `spring` and `staticize` integration tests.

Closes: #305.
History:
- **feat(#305): enable 'staticize' and 'spring' integration tests**
- **feat(#305): enable ineo version 0.3.2**
- **feat(#305): upgrade ineo version 0.3.2 for 'spring' integration test**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `ineo.version` from `0.3.1` to `0.3.2` in the `pom.xml` files for integration test enablement.

### Detailed summary
- Updated `ineo.version` from `0.3.1` to `0.3.2` in `src/it/spring/pom.xml` and `src/it/staticize/pom.xml`
- Removed exclusions for `staticize/pom.xml` and `spring/pom.xml` in the root `pom.xml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->