### PR TITLE
feat(#208): Remove `appendIntefaced()` Method

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/Opcode.java
+++ b/src/main/java/org/eolang/opeo/ast/Opcode.java
@@ -113,16 +113,16 @@ public final class Opcode implements AstNode {
 
     @Override
     public List<AstNode> opcodes() {
-        switch (this.bytecode) {
-            case Opcodes.INVOKEVIRTUAL:
-            case Opcodes.INVOKEINTERFACE:
-            case Opcodes.INVOKESPECIAL:
-            case Opcodes.INVOKESTATIC:
-                this.appendInterfaced();
-                break;
-            default:
-                break;
-        }
+//        switch (this.bytecode) {
+//            case Opcodes.INVOKEVIRTUAL:
+//            case Opcodes.INVOKEINTERFACE:
+//            case Opcodes.INVOKESPECIAL:
+//            case Opcodes.INVOKESTATIC:
+//                this.appendInterfaced();
+//                break;
+//            default:
+//                break;
+//        }
         return Arrays.asList(this);
     }
 

--- a/src/main/java/org/eolang/opeo/ast/Opcode.java
+++ b/src/main/java/org/eolang/opeo/ast/Opcode.java
@@ -31,7 +31,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.directives.DirectivesInstruction;
-import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
 
 /**
@@ -113,16 +112,6 @@ public final class Opcode implements AstNode {
 
     @Override
     public List<AstNode> opcodes() {
-//        switch (this.bytecode) {
-//            case Opcodes.INVOKEVIRTUAL:
-//            case Opcodes.INVOKEINTERFACE:
-//            case Opcodes.INVOKESPECIAL:
-//            case Opcodes.INVOKESTATIC:
-//                this.appendInterfaced();
-//                break;
-//            default:
-//                break;
-//        }
         return Arrays.asList(this);
     }
 
@@ -137,19 +126,5 @@ public final class Opcode implements AstNode {
     @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
     public static void disableCounting() {
         Opcode.COUNTING.set(false);
-    }
-
-    /**
-     * Append 'interfaced' attribute.
-     * @todo #201:90 Remove the 'appendInterfaced' method from Opcode.
-     *  This method was added to hide problems in 'ineo-maven-plugin' optimizations implementation.
-     *  Also in 'opeo-maven-plugin' we also have some gaps related to 'interfaced' attribute.
-     *  We definitely should remove this method. Moreover, we shouldn't forget to clean
-     *  {@link #opcodes} method after.
-     */
-    private void appendInterfaced() {
-        if (!(this.operands.get(this.operands.size() - 1) instanceof Boolean)) {
-            this.operands.add(false);
-        }
     }
 }


### PR DESCRIPTION
In this PR I remove the outdated `appendIntefaced()` method.
We used it to hide the problem with method invocation transformation on `jeo` side.
Now `jeo-maven-plugin` knows how to transfom this invocations and we can easily remove this crutch.

Closes: #208.
History:
- **feat(#208): don't use appendInterfaced() method**
- **feat(#208): remove outdated code and the puzzle for #208 issue**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes unused opcode cases and a method `appendInterfaced` in `Opcode.java`.

### Detailed summary
- Removed unused opcode cases: `INVOKEVIRTUAL`, `INVOKEINTERFACE`, `INVOKESPECIAL`, `INVOKESTATIC`.
- Removed `appendInterfaced` method as it was no longer needed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->