### PR TITLE
feat(#134): Refactor XmirParser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@ SOFTWARE.
                         <limit>
                           <counter>COMPLEXITY</counter>
                           <value>COVEREDRATIO</value>
-                          <minimum>0.58</minimum>
+                          <minimum>0.55</minimum>
                         </limit>
                         <limit>
                           <counter>METHOD</counter>

--- a/src/main/java/org/eolang/opeo/ast/Add.java
+++ b/src/main/java/org/eolang/opeo/ast/Add.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -37,6 +39,8 @@ import org.xembly.Directives;
  * Add output node.
  * @since 0.1
  */
+@EqualsAndHashCode
+@ToString
 public final class Add implements AstNode, Typed {
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/ArrayConstructor.java
+++ b/src/main/java/org/eolang/opeo/ast/ArrayConstructor.java
@@ -25,7 +25,13 @@ package org.eolang.opeo.ast;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.eolang.jeo.representation.directives.DirectivesData;
+import org.eolang.jeo.representation.xmir.HexString;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.compilation.Parser;
 import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
 import org.xembly.Directives;
@@ -34,6 +40,8 @@ import org.xembly.Directives;
  * Array constructor.
  * @since 0.1
  */
+@ToString
+@EqualsAndHashCode
 public final class ArrayConstructor implements AstNode {
 
     /**
@@ -45,6 +53,18 @@ public final class ArrayConstructor implements AstNode {
      * Array type.
      */
     private final String type;
+
+    /**
+     * Constructor.
+     * @param node Xmir representation of an array constructor.
+     * @param parser Parser that will be used to parse the child nodes of the array constructor.
+     */
+    public ArrayConstructor(final XmlNode node, final Parser parser) {
+        this(
+            parser.parse(node.children().collect(Collectors.toList()).get(1)),
+            new HexString(node.firstChild().text()).decode()
+        );
+    }
 
     /**
      * Constructor.

--- a/src/main/java/org/eolang/opeo/ast/FieldAssignment.java
+++ b/src/main/java/org/eolang/opeo/ast/FieldAssignment.java
@@ -53,10 +53,12 @@ public final class FieldAssignment implements AstNode {
      */
     private final AstNode value;
 
-    public FieldAssignment(
-        final XmlNode node,
-        final Parser parser
-    ) {
+    /**
+     * Constructor.
+     * @param node Root node is an XMIR representation of a field assignment.
+     * @param parser Parser that will be used to parse the child nodes of the field assignment.
+     */
+    public FieldAssignment(final XmlNode node, final Parser parser) {
         this(
             new Field(node.firstChild(), parser),
             parser.parse(node.children().collect(Collectors.toList()).get(1))
@@ -68,10 +70,7 @@ public final class FieldAssignment implements AstNode {
      * @param left The field to assign to
      * @param right The value to assign
      */
-    public FieldAssignment(
-        final Field left,
-        final AstNode right
-    ) {
+    public FieldAssignment(final Field left, final AstNode right) {
         this.field = left;
         this.value = right;
     }

--- a/src/main/java/org/eolang/opeo/ast/FieldAssignment.java
+++ b/src/main/java/org/eolang/opeo/ast/FieldAssignment.java
@@ -24,6 +24,11 @@
 package org.eolang.opeo.ast;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.compilation.Parser;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -34,6 +39,8 @@ import org.xembly.Directives;
  * }</p>
  * @since 0.2
  */
+@ToString
+@EqualsAndHashCode
 public final class FieldAssignment implements AstNode {
 
     /**
@@ -45,6 +52,16 @@ public final class FieldAssignment implements AstNode {
      * The value to assign.
      */
     private final AstNode value;
+
+    public FieldAssignment(
+        final XmlNode node,
+        final Parser parser
+    ) {
+        this(
+            new Field(node.firstChild(), parser),
+            parser.parse(node.children().collect(Collectors.toList()).get(1))
+        );
+    }
 
     /**
      * Constructor.

--- a/src/main/java/org/eolang/opeo/ast/FieldRetrieval.java
+++ b/src/main/java/org/eolang/opeo/ast/FieldRetrieval.java
@@ -24,6 +24,10 @@
 package org.eolang.opeo.ast;
 
 import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.compilation.Parser;
 import org.objectweb.asm.Type;
 import org.xembly.Directive;
 import org.xembly.Directives;
@@ -32,12 +36,23 @@ import org.xembly.Directives;
  * Field retrieval.
  * @since 0.2
  */
+@ToString
+@EqualsAndHashCode
 public final class FieldRetrieval implements AstNode, Typed {
 
     /**
      * The field to access.
      */
     private final Field field;
+
+    /**
+     * Constructor.
+     * @param node XML node
+     * @param parser Parser
+     */
+    public FieldRetrieval(final XmlNode node, final Parser parser) {
+        this(new Field(node.firstChild(), parser));
+    }
 
     /**
      * Constructor.

--- a/src/main/java/org/eolang/opeo/ast/Opcode.java
+++ b/src/main/java/org/eolang/opeo/ast/Opcode.java
@@ -28,9 +28,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.directives.DirectivesInstruction;
+import org.eolang.jeo.representation.xmir.XmlInstruction;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.jeo.representation.xmir.XmlOperand;
 import org.xembly.Directive;
 
 /**
@@ -91,6 +95,28 @@ public final class Opcode implements AstNode {
      */
     public Opcode(final int opcode, final List<Object> operands) {
         this(opcode, operands, Opcode.COUNTING.get());
+    }
+
+    /**
+     * Constructor.
+     * @param node XMIR node.
+     */
+    public Opcode(final XmlNode node) {
+        this(new XmlInstruction(node));
+    }
+
+    /**
+     * Constructor.
+     * @param instruction XMIR instruction.
+     */
+    public Opcode(final XmlInstruction instruction) {
+        this(
+            instruction.opcode(),
+            instruction.operands()
+                .stream()
+                .map(XmlOperand::asObject)
+                .collect(Collectors.toList())
+        );
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/StaticInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/StaticInvocation.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.compilation.Parser;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.xembly.Directive;
@@ -94,6 +95,15 @@ public final class StaticInvocation implements AstNode, Typed {
             new Owner(owner),
             arguments
         );
+    }
+
+    /**
+     * Constructor.
+     * @param node XML node
+     * @param parser Parser that will be used to parse the child nodes of the invocation.
+     */
+    public StaticInvocation(final XmlNode node, final Parser parser) {
+        this(node, new Arguments(node, parser, 2).toList());
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/StoreArray.java
+++ b/src/main/java/org/eolang/opeo/ast/StoreArray.java
@@ -25,6 +25,9 @@ package org.eolang.opeo.ast;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.compilation.Parser;
 import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
 import org.xembly.Directives;
@@ -49,6 +52,28 @@ public final class StoreArray implements AstNode {
      * Value to store.
      */
     private final AstNode value;
+
+    /**
+     * Constructor.
+     * @param root Xmir representation of a store array element.
+     * @param parser Parser that will be used to parse the nodes of the store array element.
+     */
+    public StoreArray(final XmlNode root, final Parser parser) {
+        this(root.children().collect(Collectors.toList()), parser);
+    }
+
+    /**
+     * Constructor.
+     * @param children Children nodes that represent an array, an index and a value.
+     * @param parser Parser that will be used to parse the children nodes.
+     */
+    public StoreArray(final List<XmlNode> children, final Parser parser) {
+        this(
+            parser.parse(children.get(0)),
+            parser.parse(children.get(1)),
+            parser.parse(children.get(2))
+        );
+    }
 
     /**
      * Constructor.

--- a/src/main/java/org/eolang/opeo/ast/VariableAssignment.java
+++ b/src/main/java/org/eolang/opeo/ast/VariableAssignment.java
@@ -25,6 +25,11 @@ package org.eolang.opeo.ast;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.compilation.Parser;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -35,6 +40,8 @@ import org.xembly.Directives;
  * }</p>
  * @since 0.2
  */
+@ToString
+@EqualsAndHashCode
 public final class VariableAssignment implements AstNode {
 
     /**
@@ -46,6 +53,24 @@ public final class VariableAssignment implements AstNode {
      * Right expression.
      */
     private final AstNode right;
+
+    /**
+     * Constructor.
+     * @param root Xmir representation of a variable assignment.
+     * @param parser Parser that will be used to parse the child nodes of the variable assignment.
+     */
+    public VariableAssignment(final XmlNode root, final Parser parser) {
+        this(root.children().collect(Collectors.toList()), parser);
+    }
+
+    /**
+     * Constructor.
+     * @param children Child nodes that represent the variable and the expression.
+     * @param parser Parser that will be used to parse the child nodes of the variable assignment.
+     */
+    public VariableAssignment(final List<XmlNode> children, final Parser parser) {
+        this((LocalVariable) parser.parse(children.get(0)), parser.parse(children.get(1)));
+    }
 
     /**
      * Constructor.

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -201,7 +201,7 @@ final class XmirParser implements Parser {
         } else if (!base.isEmpty() && base.charAt(0) == '.') {
             final Attributes attributes = new Attributes(node.firstChild());
             if ("static".equals(attributes.type())) {
-                result = new StaticInvocation(node, new Arguments(node, this, 2).toList());
+                result = new StaticInvocation(node, this);
             } else if ("interface".equals(attributes.type())) {
                 result = new InterfaceInvocation(node, this);
             } else {

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -27,9 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.eolang.jeo.representation.xmir.HexString;
-import org.eolang.jeo.representation.xmir.XmlInstruction;
 import org.eolang.jeo.representation.xmir.XmlNode;
-import org.eolang.jeo.representation.xmir.XmlOperand;
 import org.eolang.opeo.ast.Add;
 import org.eolang.opeo.ast.Arguments;
 import org.eolang.opeo.ast.ArrayConstructor;
@@ -160,15 +158,7 @@ final class XmirParser implements Parser {
         } else if ("frame".equals(base)) {
             result = new RawXml(node);
         } else if ("opcode".equals(base)) {
-            final XmlInstruction instruction = new XmlInstruction(node);
-            final int opcode = instruction.opcode();
-            result = new Opcode(
-                opcode,
-                instruction.operands()
-                    .stream()
-                    .map(XmlOperand::asObject)
-                    .collect(Collectors.toList())
-            );
+            result = new Opcode(node);
         } else if ("label".equals(base)) {
             result = new Label(node);
         } else if ("int".equals(base)) {

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -187,9 +187,7 @@ final class XmirParser implements Parser {
             final AstNode value = this.parse(inner.get(1));
             result = new VariableAssignment((LocalVariable) target, value);
         } else if (".get-field".equals(base)) {
-            final List<XmlNode> inner = node.children().collect(Collectors.toList());
-            final XmlNode field = inner.get(0);
-            result = new FieldRetrieval(new Field(field, this));
+            result = new FieldRetrieval(node, this);
         } else if (".write-field".equals(base)) {
             final List<XmlNode> inner = node.children().collect(Collectors.toList());
             final XmlNode field = inner.get(0);

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -194,10 +194,7 @@ final class XmirParser implements Parser {
         } else if (".new".equals(base)) {
             result = new Constructor(node, this);
         } else if (".array-node".equals(base)) {
-            final List<XmlNode> children = node.children().collect(Collectors.toList());
-            final String type = new HexString(children.get(0).text()).decode();
-            final AstNode size = this.parse(children.get(1));
-            result = new ArrayConstructor(size, type);
+            result = new ArrayConstructor(node, this);
         } else if (!base.isEmpty() && base.charAt(0) == '.') {
             final Attributes attributes = new Attributes(node.firstChild());
             if ("static".equals(attributes.type())) {

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -26,10 +26,8 @@ package org.eolang.opeo.compilation;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.eolang.jeo.representation.xmir.HexString;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.ast.Add;
-import org.eolang.opeo.ast.Arguments;
 import org.eolang.opeo.ast.ArrayConstructor;
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.Attributes;
@@ -67,7 +65,6 @@ import org.xembly.Xembler;
  * @since 0.1
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class XmirParser implements Parser {
 
     /**
@@ -105,25 +102,12 @@ final class XmirParser implements Parser {
      *
      * @param node XmlNode
      * @return Ast node
-     * @todo #77:90min Refactor this.node() method.
-     *  The parsing method this.node() looks overcomplicated and violates many
-     *  code quality standards. We should refactor the method and remove all
-     *  the checkstyle and PMD "suppressions" from the method.
-     * @todo #110:90min Remove ad-hoc solution for replacing descriptors and owners.
-     *  Currently we have an ad-hoc solution for replacing descriptors and owners.
-     *  It looks ugly and requires refactoring. To remove ad-hoc solution we need
-     *  to remove all the if statements that use concerete class names as:
-     *  - "org/eolang/benchmark/B"
-     *  - "org/eolang/benchmark/BA"
-     * @checkstyle CyclomaticComplexityCheck (200 lines)
-     * @checkstyle ExecutableStatementCountCheck (200 lines)
-     * @checkstyle JavaNCSSCheck (200 lines)
-     * @checkstyle NestedIfDepthCheck (200 lines)
-     * @checkstyle MethodLengthCheck (200 lines)     *
-     * @checkstyle NoJavadocForOverriddenMethodsCheck (200 lines)
+     * @checkstyle CyclomaticComplexityCheck (500 lines)
+     * @checkstyle JavaNCSSCheck (500 lines)
+     * @checkstyle NoJavadocForOverriddenMethodsCheck (500 lines)
      */
-    @SuppressWarnings({"PMD.NcssCount", "PMD.ExcessiveMethodLength", "PMD.CognitiveComplexity"})
     @Override
+    @SuppressWarnings("PMD.NcssCount")
     public AstNode parse(final XmlNode node) {
         final AstNode result;
         final String base = node.attribute("base").orElseThrow(

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -177,10 +177,7 @@ final class XmirParser implements Parser {
         } else if (".write-array".equals(base)) {
             result = new StoreArray(node, this);
         } else if (".write-local-var".equals(base)) {
-            final List<XmlNode> inner = node.children().collect(Collectors.toList());
-            final AstNode target = this.parse(inner.get(0));
-            final AstNode value = this.parse(inner.get(1));
-            result = new VariableAssignment((LocalVariable) target, value);
+            result = new VariableAssignment(node, this);
         } else if (".get-field".equals(base)) {
             result = new FieldRetrieval(node, this);
         } else if (".write-field".equals(base)) {

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -39,7 +39,6 @@ import org.eolang.opeo.ast.ClassName;
 import org.eolang.opeo.ast.Constant;
 import org.eolang.opeo.ast.Constructor;
 import org.eolang.opeo.ast.Duplicate;
-import org.eolang.opeo.ast.Field;
 import org.eolang.opeo.ast.FieldAssignment;
 import org.eolang.opeo.ast.FieldRetrieval;
 import org.eolang.opeo.ast.If;
@@ -189,10 +188,7 @@ final class XmirParser implements Parser {
         } else if (".get-field".equals(base)) {
             result = new FieldRetrieval(node, this);
         } else if (".write-field".equals(base)) {
-            final List<XmlNode> inner = node.children().collect(Collectors.toList());
-            final XmlNode field = inner.get(0);
-            final AstNode value = this.parse(inner.get(1));
-            result = new FieldAssignment(new Field(field, this), value);
+            result = new FieldAssignment(node, this);
         } else if (base.contains("local")) {
             result = new LocalVariable(node);
         } else if (".new".equals(base)) {

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -175,11 +175,7 @@ final class XmirParser implements Parser {
         } else if ("static-field".equals(base)) {
             result = new ClassField(node);
         } else if (".write-array".equals(base)) {
-            final List<XmlNode> inner = node.children().collect(Collectors.toList());
-            final AstNode array = this.parse(inner.get(0));
-            final AstNode index = this.parse(inner.get(1));
-            final AstNode value = this.parse(inner.get(2));
-            result = new StoreArray(array, index, value);
+            result = new StoreArray(node, this);
         } else if (".write-local-var".equals(base)) {
             final List<XmlNode> inner = node.children().collect(Collectors.toList());
             final AstNode target = this.parse(inner.get(0));

--- a/src/test/java/org/eolang/opeo/ast/ArrayConstructorTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ArrayConstructorTest.java
@@ -23,9 +23,11 @@
  */
 package org.eolang.opeo.ast;
 
-import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XMLDocument;
+import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 import org.xembly.ImpossibleModificationException;
@@ -36,6 +38,34 @@ import org.xembly.Xembler;
  * @since 0.1
  */
 final class ArrayConstructorTest {
+
+    /**
+     * XMIR representation of the array constructor.
+     */
+    private static final String XMIR = String.join(
+        "\n",
+        "<o base='.array-node'>",
+        "   <o base='string' data='bytes'>6A 61 76 61 2F 6C 61 6E 67 2F 49 6E 74 65 67 65 72</o>",
+        "   <o base='.plus'>",
+        "      <o base='int' data='bytes'>00 00 00 00 00 00 00 01</o>",
+        "      <o base='int' data='bytes'>00 00 00 00 00 00 00 02</o>",
+        "   </o>",
+        "</o>"
+    );
+
+    @Test
+    void createsArrayConstructorFromXmir() {
+        MatcherAssert.assertThat(
+            "Can't create array constructor from XMIR",
+            new ArrayConstructor(
+                new XmlNode(ArrayConstructorTest.XMIR),
+                node -> new Add(new Literal(1), new Literal(2))
+            ),
+            Matchers.equalTo(
+                new ArrayConstructor(new Add(new Literal(1), new Literal(2)), "java/lang/Integer")
+            )
+        );
+    }
 
     @Test
     void compilesSimpleArrayCreation() {
@@ -88,12 +118,8 @@ final class ArrayConstructorTest {
                 "We expect that array constructor will be correctly transformed to XMIR, but it didn't. Result is: %n%s%n",
                 xmir
             ),
-            xmir,
-            XhtmlMatchers.hasXPaths(
-                "./o[@base='.array-node']",
-                "./o[@base='.array-node']/o[@base='string' and @data='bytes']",
-                "./o[@base='.array-node']/o[@base='.plus']"
-            )
+            new XMLDocument(xmir),
+            Matchers.equalTo(new XMLDocument(ArrayConstructorTest.XMIR))
         );
     }
 }

--- a/src/test/java/org/eolang/opeo/ast/FieldAssignmentTest.java
+++ b/src/test/java/org/eolang/opeo/ast/FieldAssignmentTest.java
@@ -79,7 +79,6 @@ final class FieldAssignmentTest {
                 )
             )
         );
-
     }
 
     @Test

--- a/src/test/java/org/eolang/opeo/ast/FieldRetrievalTest.java
+++ b/src/test/java/org/eolang/opeo/ast/FieldRetrievalTest.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.opeo.ast;
 
-import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.compilation.HasInstructions;
@@ -31,7 +30,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
-import org.xembly.Directives;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
@@ -60,7 +58,7 @@ final class FieldRetrievalTest {
     void createsFromXmir() {
         MatcherAssert.assertThat(
             "The field retrieval should be successfully created from XMIR",
-            new FieldRetrieval(new XmlNode(FieldRetrievalTest.XMIR), (node) -> new This()),
+            new FieldRetrieval(new XmlNode(FieldRetrievalTest.XMIR), node -> new This()),
             Matchers.equalTo(new FieldRetrieval(new This(), "bar"))
         );
     }

--- a/src/test/java/org/eolang/opeo/ast/FieldRetrievalTest.java
+++ b/src/test/java/org/eolang/opeo/ast/FieldRetrievalTest.java
@@ -24,8 +24,11 @@
 package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XMLDocument;
+import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 import org.xembly.Directives;
@@ -38,26 +41,40 @@ import org.xembly.Xembler;
  */
 final class FieldRetrievalTest {
 
+    /**
+     * XMIR representation of the field retrieval.
+     */
+    private static final String XMIR = String.join(
+        "\n",
+        "   <o base='.get-field'>",
+        "      <o base='.bar'>",
+        "         <o base='string' data='bytes'>64 65 73 63 72 69 70 74 6F 72 3D 49 7C 6E 61 6D 65 3D 62 61 72 7C 74 79 70 65 3D 66 69 65 6C 64</o>",
+        "         <o base='$'>",
+        "            <o base='string' data='bytes'>64 65 73 63 72 69 70 74 6F 72 3D 6A 61 76 61 2E 6C 61 6E 67 2E 4F 62 6A 65 63 74</o>",
+        "         </o>",
+        "      </o>",
+        "</o>"
+    );
+
+    @Test
+    void createsFromXmir() {
+        MatcherAssert.assertThat(
+            "The field retrieval should be successfully created from XMIR",
+            new FieldRetrieval(new XmlNode(FieldRetrievalTest.XMIR), (node) -> new This()),
+            Matchers.equalTo(new FieldRetrieval(new This(), "bar"))
+        );
+    }
+
     @Test
     void convertsToXmir() throws ImpossibleModificationException {
-        final String actual = new Xembler(
-            new Directives()
-                .add("o")
-                .attr("name", "method")
-                .append(new FieldRetrieval(new This(), "bar").toXmir())
-                .up()
-        ).xml();
+        final String actual = new Xembler(new FieldRetrieval(new This(), "bar").toXmir()).xml();
         MatcherAssert.assertThat(
             String.format(
                 "Can't convert to a field access construct, actual result is : %n%s%n",
                 actual
             ),
-            actual,
-            XhtmlMatchers.hasXPaths(
-                "./o[@name='method']",
-                "./o[@name='method']/o[@base='.get-field']/o[@base='.bar']",
-                "./o[@name='method']/o[@base='.get-field']/o[@base='.bar']/o[@base='$']"
-            )
+            new XMLDocument(actual),
+            Matchers.equalTo(new XMLDocument(FieldRetrievalTest.XMIR))
         );
     }
 

--- a/src/test/java/org/eolang/opeo/ast/OpcodeTest.java
+++ b/src/test/java/org/eolang/opeo/ast/OpcodeTest.java
@@ -24,6 +24,8 @@
 package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XMLDocument;
+import org.eolang.jeo.representation.xmir.XmlNode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -37,21 +39,37 @@ import org.xembly.Xembler;
  */
 final class OpcodeTest {
 
+    /**
+     * XMIR representation of the opcode.
+     */
+    private static final String XMIR = String.join(
+        "\n",
+        "<o base='opcode' line='999' name='LDC'>",
+        "<o base='int' data='bytes'>00 00 00 00 00 00 00 12</o>",
+        "<o base='string' data='bytes'>68 65 6C 6C 6F</o>",
+        "</o>"
+    );
+
+    @Test
+    void createsFromXmir() {
+        MatcherAssert.assertThat(
+            "The LDC opcode should be created from XMIR",
+            new Opcode(new XmlNode(OpcodeTest.XMIR)),
+            Matchers.equalTo(
+                new Opcode(Opcodes.LDC, "hello")
+            )
+        );
+    }
+
     @Test
     void transformsToXml() {
+        Opcode.disableCounting();
         MatcherAssert.assertThat(
-            String.format(
-                "We expect the following XML to be generated: %s",
-                "<o base='opcode' name='LDC-1'><o base='int' data='bytes'>00 00 00 00 00 00 00 12</o><o base='string' data='bytes'>68 65 6C 6C 6F</o></o>"
+            String.format("We expect the following XML to be generated: %s", OpcodeTest.XMIR),
+            new XMLDocument(
+                new Xembler(new Opcode(Opcodes.LDC, "hello").toXmir()).xmlQuietly()
             ),
-            new Xembler(
-                new Opcode(Opcodes.LDC, "hello").toXmir(),
-                new Transformers.Node()
-            ).xmlQuietly(),
-            Matchers.allOf(
-                XhtmlMatchers.hasXPath("./o[@base='opcode']/o[@base='int']"),
-                XhtmlMatchers.hasXPath("./o[@base='opcode']/o[@base='string']")
-            )
+            Matchers.equalTo(new XMLDocument(OpcodeTest.XMIR))
         );
     }
 }

--- a/src/test/java/org/eolang/opeo/ast/OpcodeTest.java
+++ b/src/test/java/org/eolang/opeo/ast/OpcodeTest.java
@@ -23,14 +23,12 @@
  */
 package org.eolang.opeo.ast;
 
-import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
-import org.xembly.Transformers;
 import org.xembly.Xembler;
 
 /**

--- a/src/test/java/org/eolang/opeo/ast/VariableAssignmentTest.java
+++ b/src/test/java/org/eolang/opeo/ast/VariableAssignmentTest.java
@@ -59,11 +59,13 @@ final class VariableAssignmentTest {
             new VariableAssignment(
                 new XmlNode(VariableAssignmentTest.XMIR),
                 node -> {
+                    final AstNode result;
                     if (node.hasAttribute("base", "int")) {
-                        return new Literal(2);
+                        result = new Literal(2);
                     } else {
-                        return new LocalVariable(node);
+                        result = new LocalVariable(node);
                     }
+                    return result;
                 }
             ),
             Matchers.equalTo(
@@ -73,7 +75,6 @@ final class VariableAssignmentTest {
                 )
             )
         );
-
     }
 
     @Test


### PR DESCRIPTION
In this PR I significantly simplified the `XmirParser` class.
I moved all the logic related to parsing `XMIR` nodes directly to corresponding AST node classes.
Now each node knows how to parse itself from `XMIR`.

Closes: #134.
History:
- **feat(#134): Create Useful Opcode Constructor alongside with the unit test**
- **feat(#134): create useful constructor for FieldRetrieval alongside with the unit test**
- **feat(#134): create useful constructor for FieldAssignment alongside with the unit test**
- **feat(#134): add one more constructor for StaticInvocation**
- **feat(#134): create useful constructor for ArrayConstructor alongside with the unit test**
- **feat(#134): create useful constructor for StoreArray**
- **feat(#134): create useful constructor for VariableAssignment alongside with unit tests**
- **feat(#134): remove the puzzle for #134 issue**
- **feat(#134): decrease jacoco limits**
