### PR TITLE
feat(#327): Check Attributes Constructors

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/Attributes.java
+++ b/src/main/java/org/eolang/opeo/ast/Attributes.java
@@ -273,6 +273,7 @@ public final class Attributes implements Xmir {
     private static Map<String, String> parse(final String raw) {
         try {
             return Arrays.stream(raw.split("\\|")).map(entry -> entry.split("="))
+                .filter(arr -> arr.length > 1)
                 .peek(Attributes::entrySize)
                 .map(entry -> new MapEntry<>(entry[0], entry[1]))
                 .collect(Collectors.toMap(MapEntry::getKey, MapEntry::getValue));

--- a/src/test/java/org/eolang/opeo/ast/AttributesTest.java
+++ b/src/test/java/org/eolang/opeo/ast/AttributesTest.java
@@ -90,6 +90,7 @@ final class AttributesTest {
      * Xmir representation of attribute objects.
      * @return Stream of arguments for {@link #parsesXmir(String, String)} test.
      */
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static Stream<Arguments> xmirAttributes() {
         return Stream.of(
             Arguments.of(

--- a/src/test/java/org/eolang/opeo/ast/AttributesTest.java
+++ b/src/test/java/org/eolang/opeo/ast/AttributesTest.java
@@ -23,11 +23,15 @@
  */
 package org.eolang.opeo.ast;
 
+import java.util.stream.Stream;
+import org.eolang.jeo.representation.xmir.XmlNode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test case for {@link Attributes}.
@@ -68,6 +72,42 @@ final class AttributesTest {
             "Can't parse owner from raw string",
             actual.owner(),
             Matchers.equalTo("Lorg/eolang/opeo/ast/Invocation;")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("xmirAttributes")
+    void parsesXmir(final String xmir, final String expected) {
+        final XmlNode node = new XmlNode(xmir);
+        MatcherAssert.assertThat(
+            String.format("Can't create correct attributes from node '%s'", node),
+            new Attributes(node).toString(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    /**
+     * Xmir representation of attribute objects.
+     * @return Stream of arguments for {@link #parsesXmir(String, String)} test.
+     */
+    private static Stream<Arguments> xmirAttributes() {
+        return Stream.of(
+            Arguments.of(
+                "<o base='string' data='bytes' line='999'>64 65 73 63 72 69 70 74 6F 72 3D 49 7C 74 79 70 65 3D 6C 6F 63 61 6C</o>",
+                "descriptor=I|type=local"
+            ),
+            Arguments.of(
+                "<o base='string' data='bytes' line='999'>64 65 73 63 72 69 70 74 6F 72 3D 49 7C 74 79 70 65 3D 6C 6F 63 61 6C   </o>",
+                "descriptor=I|type=local"
+            ),
+            Arguments.of(
+                "<o base='string' data='bytes' line='999'>64 65 73 63 72 69 70 74 6F 72 3D 49 7C 74 79 70 65 3D 6C 6F 63 61 6C\n\n\n</o>",
+                "descriptor=I|type=local"
+            ),
+            Arguments.of("<o base='string' data='bytes' line='999'></o>", ""),
+            Arguments.of("<o base='string' data='bytes' line='999'>\n\n\n</o>", ""),
+            Arguments.of("<o base='string' data='bytes' line='999'> \n \n </o>", ""),
+            Arguments.of("<o base='string' data='bytes' line='999'>\n</o>", "")
         );
     }
 }


### PR DESCRIPTION
In this PR we check how `Attributes` class might be created from XMIR representation.
I added several unit tests for this and refactored the parsing code.
Closes: #327
History:
- **feat(#327): add more unit tests for Attributes objects creation**
- **feat(#327): solve the problem with empty attributes**
- **feat(#327): fix the problem with redundant trims and replacing places**
- **feat(#327): fix all the linter complaints**


<!-- start pr-codex -->

---

## PR-Codex overview
The PR introduces parameterized tests in `AttributesTest` and refactors the `fromXmir` method in `Attributes` to simplify hex string processing.

### Detailed summary
- Added parameterized tests in `AttributesTest`
- Refactored `fromXmir` method in `Attributes` to simplify hex string processing
- Added a new line pattern for replacing redundant symbols from hex strings

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->