### PR TITLE
feat(#317): Print PHI Expressions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>jeo-maven-plugin</artifactId>
-      <version>0.4.6</version>
+      <version>0.5.0</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/src/it/decompile-compile/README.md
+++ b/src/it/decompile-compile/README.md
@@ -8,5 +8,5 @@ representation using `compile` goal.
 To run only this test, use the following command:
 
 ```shell
-mvn clean integration-test invoker:run -Dinvoker.test=decompile-compile -DskipTests
+mvn clean integration-test -Dinvoker.test=decompile-compile -DskipTests
 ```

--- a/src/it/decompile-compile/pom.xml
+++ b/src/it/decompile-compile/pom.xml
@@ -77,6 +77,24 @@ SOFTWARE.
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>eo-maven-plugin</artifactId>
+        <version>0.38.4</version>
+        <executions>
+          <execution>
+            <id>convert-xmir-to-phi</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>xmir-to-phi</goal>
+            </goals>
+            <configuration>
+              <phiInputDir>${project.build.directory}/generated-sources/opeo-xmir-second-try</phiInputDir>
+              <phiOutputDir>${project.build.directory}/generated-sources/phi-expressions</phiOutputDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/it/decompile-compile/target/generated-sources/jeo-xmir/org/eolang/jeo/BeanMethod$NonOverridableMethodError.xmir
+++ b/src/it/decompile-compile/target/generated-sources/jeo-xmir/org/eolang/jeo/BeanMethod$NonOverridableMethodError.xmir
@@ -1,162 +1,164 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <program dob="2024-05-20T13:06:53.963872Z"
-         ms="1716210413963"
-         name="j$BeanMethod$NonOverridableMethodError"
-         revision="0.0.0"
-         time="2024-05-20T13:06:53.963872Z"
-         version="0.0.0">
-   <listing>yv66vgAAADQAMgkACQAZCAAaBwAbCgAcAB0LAB4AHwoAIAAhCgAcACIKAAoAIwcAJAcAJQEABnRoaXMkMAEAM0xvcmcvc3ByaW5nZnJhbWV3b3JrL2NvbnRleHQvYW5ub3RhdGlvbi9CZWFuTWV0aG9kOwEABjxpbml0PgEANihMb3JnL3NwcmluZ2ZyYW1ld29yay9jb250ZXh0L2Fubm90YXRpb24vQmVhbk1ldGhvZDspVgEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBABJMb2NhbFZhcmlhYmxlVGFibGUBAAR0aGlzAQAZTm9uT3ZlcnJpZGFibGVNZXRob2RFcnJvcgEADElubmVyQ2xhc3NlcwEATUxvcmcvc3ByaW5nZnJhbWV3b3JrL2NvbnRleHQvYW5ub3RhdGlvbi9CZWFuTWV0aG9kJE5vbk92ZXJyaWRhYmxlTWV0aG9kRXJyb3I7AQAQTWV0aG9kUGFyYW1ldGVycwEAClNvdXJjZUZpbGUBAA9CZWFuTWV0aG9kLmphdmEMAAsADAEAWUBCZWFuIG1ldGhvZCAnJXMnIG11c3Qgbm90IGJlIHByaXZhdGUgb3IgZmluYWw7IGNoYW5nZSB0aGUgbWV0aG9kJ3MgbW9kaWZpZXJzIHRvIGNvbnRpbnVlAQAQamF2YS9sYW5nL09iamVjdAcAJgwAJwAoBwApDAAqACsHACwMAC0ALgwALwAwDAANADEBAEtvcmcvc3ByaW5nZnJhbWV3b3JrL2NvbnRleHQvYW5ub3RhdGlvbi9CZWFuTWV0aG9kJE5vbk92ZXJyaWRhYmxlTWV0aG9kRXJyb3IBADFvcmcvc3ByaW5nZnJhbWV3b3JrL2JlYW5zL2ZhY3RvcnkvcGFyc2luZy9Qcm9ibGVtAQAxb3JnL3NwcmluZ2ZyYW1ld29yay9jb250ZXh0L2Fubm90YXRpb24vQmVhbk1ldGhvZAEAC2dldE1ldGFkYXRhAQAwKClMb3JnL3NwcmluZ2ZyYW1ld29yay9jb3JlL3R5cGUvTWV0aG9kTWV0YWRhdGE7AQAsb3JnL3NwcmluZ2ZyYW1ld29yay9jb3JlL3R5cGUvTWV0aG9kTWV0YWRhdGEBAA1nZXRNZXRob2ROYW1lAQAUKClMamF2YS9sYW5nL1N0cmluZzsBABBqYXZhL2xhbmcvU3RyaW5nAQAGZm9ybWF0AQA5KExqYXZhL2xhbmcvU3RyaW5nO1tMamF2YS9sYW5nL09iamVjdDspTGphdmEvbGFuZy9TdHJpbmc7AQATZ2V0UmVzb3VyY2VMb2NhdGlvbgEANigpTG9yZy9zcHJpbmdmcmFtZXdvcmsvYmVhbnMvZmFjdG9yeS9wYXJzaW5nL0xvY2F0aW9uOwEASShMamF2YS9sYW5nL1N0cmluZztMb3JnL3NwcmluZ2ZyYW1ld29yay9iZWFucy9mYWN0b3J5L3BhcnNpbmcvTG9jYXRpb247KVYAIAAJAAoAAAABEBAACwAMAAAAAQAAAA0ADgACAA8AAABlAAYAAgAAACMqK7UAASoSAgS9AANZAyu2AAS5AAUBAFO4AAYrtgAHtwAIsQAAAAIAEAAAAB4ABwAAAE0ABQBOAA8ATwAYAE4AHABPAB8ATgAiAFAAEQAAAAwAAQAAACMAEgAVAAAAFgAAAAUBAAsQEAACABcAAAACABgAFAAAAAoAAQAJABwAEwAC</listing>
-   <errors/>
-   <sheets/>
-   <license/>
-   <metas>
-      <meta>
-         <head>package</head>
-         <tail>org.springframework.context.annotation</tail>
-         <part>org.springframework.context.annotation</part>
-      </meta>
-      <meta>
-         <head>alias</head>
-         <tail>org.eolang.jeo.opcode</tail>
-         <part>org.eolang.jeo.opcode</part>
-      </meta>
-      <meta>
-         <head>alias</head>
-         <tail>org.eolang.jeo.label</tail>
-         <part>org.eolang.jeo.label</part>
-      </meta>
-   </metas>
-   <objects>
-      <o abstract="" name="j$BeanMethod$NonOverridableMethodError">
-         <o base="int" data="bytes" name="version">00 00 00 00 00 00 00 34</o>
-         <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 20</o>
-         <o base="string" data="bytes" name="supername">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 62 65 61 6E 73 2F 66 61 63 74 6F 72 79 2F 70 61 72 73 69 6E 67 2F 50 72 6F 62 6C 65 6D</o>
-         <o base="tuple" name="interfaces" star=""/>
-         <o base="field" name="j$this$0">
-            <o base="int" data="bytes" name="access-j$this$0">00 00 00 00 00 00 10 10</o>
-            <o base="string" data="bytes" name="descriptor-j$this$0">4C 6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 6E 74 65 78 74 2F 61 6E 6E 6F 74 61 74 69 6F 6E 2F 42 65 61 6E 4D 65 74 68 6F 64 3B</o>
-            <o base="string" data="bytes" name="signature-j$this$0"/>
-            <o base="class"
-               data="bytes"
-               name="value-j$this$0"
-               scope="nullable"/>
-         </o>
-         <o abstract="" name="new">
-            <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 00</o>
-            <o base="string" data="bytes" name="descriptor">28 4C 6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 6E 74 65 78 74 2F 61 6E 6E 6F 74 61 74 69 6F 6E 2F 42 65 61 6E 4D 65 74 68 6F 64 3B 29 56</o>
-            <o base="string" data="bytes" name="signature"/>
-            <o base="tuple" name="exceptions" star=""/>
-            <o name="maxs">
-               <o base="int" data="bytes" name="stack">00 00 00 00 00 00 00 06</o>
-               <o base="int" data="bytes" name="locals">00 00 00 00 00 00 00 02</o>
-            </o>
-            <o abstract=""
-               name="arg__Lorg/springframework/context/annotation/BeanMethod;__0"/>
-            <o base="seq" name="@">
-               <o base="tuple" star="">
-                  <o base="label" data="bytes">32 39 38 37 37 62 36 37 2D 36 64 63 33 2D 34 36 38 31 2D 61 39 64 36 2D 36 63 34 31 32 30 65 32 37 38 37 31</o>
-                  <o base="opcode" line="999" name="ALOAD-1FCAEF">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
-                  </o>
-                  <o base="opcode" line="999" name="ALOAD-1FCAF0">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 01</o>
-                  </o>
-                  <o base="opcode" line="999" name="PUTFIELD-1FCAF1">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 B5</o>
-                     <o base="string" data="bytes">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 6E 74 65 78 74 2F 61 6E 6E 6F 74 61 74 69 6F 6E 2F 42 65 61 6E 4D 65 74 68 6F 64 24 4E 6F 6E 4F 76 65 72 72 69 64 61 62 6C 65 4D 65 74 68 6F 64 45 72 72 6F 72</o>
-                     <o base="string" data="bytes">74 68 69 73 24 30</o>
-                     <o base="string" data="bytes">4C 6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 6E 74 65 78 74 2F 61 6E 6E 6F 74 61 74 69 6F 6E 2F 42 65 61 6E 4D 65 74 68 6F 64 3B</o>
-                  </o>
-                  <o base="label" data="bytes">38 61 30 38 35 34 65 39 2D 30 31 33 64 2D 34 37 38 32 2D 39 63 37 63 2D 32 35 62 33 37 31 37 64 36 35 61 33</o>
-                  <o base="opcode" line="999" name="ALOAD-1FCAF2">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
-                  </o>
-                  <o base="opcode" line="999" name="LDC-1FCAF3">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 12</o>
-                     <o base="string" data="bytes">40 42 65 61 6E 20 6D 65 74 68 6F 64 20 27 25 73 27 20 6D 75 73 74 20 6E 6F 74 20 62 65 20 70 72 69 76 61 74 65 20 6F 72 20 66 69 6E 61 6C 3B 20 63 68 61 6E 67 65 20 74 68 65 20 6D 65 74 68 6F 64 27 73 20 6D 6F 64 69 66 69 65 72 73 20 74 6F 20 63 6F 6E 74 69 6E 75 65</o>
-                  </o>
-                  <o base="opcode" line="999" name="ICONST_1-1FCAF4">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 04</o>
-                  </o>
-                  <o base="opcode" line="999" name="ANEWARRAY-1FCAF5">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 BD</o>
-                     <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
-                  </o>
-                  <o base="opcode" line="999" name="DUP-1FCAF6">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 59</o>
-                  </o>
-                  <o base="opcode" line="999" name="ICONST_0-1FCAF7">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 03</o>
-                  </o>
-                  <o base="opcode" line="999" name="ALOAD-1FCAF8">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 01</o>
-                  </o>
-                  <o base="label" data="bytes">37 36 62 32 66 63 37 37 2D 64 35 37 61 2D 34 61 38 64 2D 62 35 61 30 2D 64 66 65 37 33 62 66 62 62 65 33 39</o>
-                  <o base="opcode" line="999" name="INVOKEVIRTUAL-1FCAF9">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 B6</o>
-                     <o base="string" data="bytes">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 6E 74 65 78 74 2F 61 6E 6E 6F 74 61 74 69 6F 6E 2F 42 65 61 6E 4D 65 74 68 6F 64</o>
-                     <o base="string" data="bytes">67 65 74 4D 65 74 61 64 61 74 61</o>
-                     <o base="string" data="bytes">28 29 4C 6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 72 65 2F 74 79 70 65 2F 4D 65 74 68 6F 64 4D 65 74 61 64 61 74 61 3B</o>
-                     <o base="bool" data="bytes">00</o>
-                  </o>
-                  <o base="opcode" line="999" name="INVOKEINTERFACE-1FCAFA">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 B9</o>
-                     <o base="string" data="bytes">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 72 65 2F 74 79 70 65 2F 4D 65 74 68 6F 64 4D 65 74 61 64 61 74 61</o>
-                     <o base="string" data="bytes">67 65 74 4D 65 74 68 6F 64 4E 61 6D 65</o>
-                     <o base="string" data="bytes">28 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
-                     <o base="bool" data="bytes">01</o>
-                  </o>
-                  <o base="opcode" line="999" name="AASTORE-1FCAFB">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 53</o>
-                  </o>
-                  <o base="label" data="bytes">34 63 39 34 34 61 66 33 2D 32 34 37 64 2D 34 61 63 61 2D 61 62 63 64 2D 39 34 66 66 36 63 63 64 61 30 32 32</o>
-                  <o base="opcode" line="999" name="INVOKESTATIC-1FCAFC">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 B8</o>
-                     <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67</o>
-                     <o base="string" data="bytes">66 6F 72 6D 61 74</o>
-                     <o base="string" data="bytes">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
-                     <o base="bool" data="bytes">00</o>
-                  </o>
-                  <o base="opcode" line="999" name="ALOAD-1FCAFD">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 01</o>
-                  </o>
-                  <o base="label" data="bytes">30 63 38 32 61 34 38 66 2D 62 62 30 34 2D 34 64 36 31 2D 61 32 34 32 2D 64 34 65 61 35 37 30 35 38 38 30 39</o>
-                  <o base="opcode" line="999" name="INVOKEVIRTUAL-1FCAFE">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 B6</o>
-                     <o base="string" data="bytes">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 6E 74 65 78 74 2F 61 6E 6E 6F 74 61 74 69 6F 6E 2F 42 65 61 6E 4D 65 74 68 6F 64</o>
-                     <o base="string" data="bytes">67 65 74 52 65 73 6F 75 72 63 65 4C 6F 63 61 74 69 6F 6E</o>
-                     <o base="string" data="bytes">28 29 4C 6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 62 65 61 6E 73 2F 66 61 63 74 6F 72 79 2F 70 61 72 73 69 6E 67 2F 4C 6F 63 61 74 69 6F 6E 3B</o>
-                     <o base="bool" data="bytes">00</o>
-                  </o>
-                  <o base="label" data="bytes">37 39 38 63 32 64 63 66 2D 63 35 32 31 2D 34 31 33 36 2D 38 64 33 65 2D 66 39 33 37 33 64 35 39 38 66 61 62</o>
-                  <o base="opcode" line="999" name="INVOKESPECIAL-1FCAFF">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 B7</o>
-                     <o base="string" data="bytes">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 62 65 61 6E 73 2F 66 61 63 74 6F 72 79 2F 70 61 72 73 69 6E 67 2F 50 72 6F 62 6C 65 6D</o>
-                     <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
-                     <o base="string" data="bytes">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 62 65 61 6E 73 2F 66 61 63 74 6F 72 79 2F 70 61 72 73 69 6E 67 2F 4C 6F 63 61 74 69 6F 6E 3B 29 56</o>
-                     <o base="bool" data="bytes">00</o>
-                  </o>
-                  <o base="label" data="bytes">34 61 30 61 34 30 31 64 2D 65 33 34 36 2D 34 62 65 66 2D 38 39 35 30 2D 64 30 33 64 66 38 30 34 32 62 64 65</o>
-                  <o base="opcode" line="999" name="RETURN-1FCB00">
-                     <o base="int" data="bytes">00 00 00 00 00 00 00 B1</o>
-                  </o>
-                  <o base="label" data="bytes">66 35 38 61 61 39 34 61 2D 63 30 36 64 2D 34 37 63 36 2D 62 62 37 61 2D 34 66 39 35 63 33 39 66 30 62 32 61</o>
-               </o>
-            </o>
-         </o>
-         <o base="tuple" name="attributes" star="">
-            <o name="InnerClass">
-               <o base="string" data="bytes" name="name">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 6E 74 65 78 74 2F 61 6E 6E 6F 74 61 74 69 6F 6E 2F 42 65 61 6E 4D 65 74 68 6F 64 24 4E 6F 6E 4F 76 65 72 72 69 64 61 62 6C 65 4D 65 74 68 6F 64 45 72 72 6F 72</o>
-               <o base="string" data="bytes" name="outer">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 6E 74 65 78 74 2F 61 6E 6E 6F 74 61 74 69 6F 6E 2F 42 65 61 6E 4D 65 74 68 6F 64</o>
-               <o base="string" data="bytes" name="inner">4E 6F 6E 4F 76 65 72 72 69 64 61 62 6C 65 4D 65 74 68 6F 64 45 72 72 6F 72</o>
-               <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 02</o>
-            </o>
-         </o>
+  ms="1716210413963"
+  name="j$BeanMethod$NonOverridableMethodError"
+  revision="0.0.0"
+  time="2024-05-20T13:06:53.963872Z"
+  version="0.0.0">
+  <listing>yv66vgAAADQAMgkACQAZCAAaBwAbCgAcAB0LAB4AHwoAIAAhCgAcACIKAAoAIwcAJAcAJQEABnRoaXMkMAEAM0xvcmcvc3ByaW5nZnJhbWV3b3JrL2NvbnRleHQvYW5ub3RhdGlvbi9CZWFuTWV0aG9kOwEABjxpbml0PgEANihMb3JnL3NwcmluZ2ZyYW1ld29yay9jb250ZXh0L2Fubm90YXRpb24vQmVhbk1ldGhvZDspVgEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBABJMb2NhbFZhcmlhYmxlVGFibGUBAAR0aGlzAQAZTm9uT3ZlcnJpZGFibGVNZXRob2RFcnJvcgEADElubmVyQ2xhc3NlcwEATUxvcmcvc3ByaW5nZnJhbWV3b3JrL2NvbnRleHQvYW5ub3RhdGlvbi9CZWFuTWV0aG9kJE5vbk92ZXJyaWRhYmxlTWV0aG9kRXJyb3I7AQAQTWV0aG9kUGFyYW1ldGVycwEAClNvdXJjZUZpbGUBAA9CZWFuTWV0aG9kLmphdmEMAAsADAEAWUBCZWFuIG1ldGhvZCAnJXMnIG11c3Qgbm90IGJlIHByaXZhdGUgb3IgZmluYWw7IGNoYW5nZSB0aGUgbWV0aG9kJ3MgbW9kaWZpZXJzIHRvIGNvbnRpbnVlAQAQamF2YS9sYW5nL09iamVjdAcAJgwAJwAoBwApDAAqACsHACwMAC0ALgwALwAwDAANADEBAEtvcmcvc3ByaW5nZnJhbWV3b3JrL2NvbnRleHQvYW5ub3RhdGlvbi9CZWFuTWV0aG9kJE5vbk92ZXJyaWRhYmxlTWV0aG9kRXJyb3IBADFvcmcvc3ByaW5nZnJhbWV3b3JrL2JlYW5zL2ZhY3RvcnkvcGFyc2luZy9Qcm9ibGVtAQAxb3JnL3NwcmluZ2ZyYW1ld29yay9jb250ZXh0L2Fubm90YXRpb24vQmVhbk1ldGhvZAEAC2dldE1ldGFkYXRhAQAwKClMb3JnL3NwcmluZ2ZyYW1ld29yay9jb3JlL3R5cGUvTWV0aG9kTWV0YWRhdGE7AQAsb3JnL3NwcmluZ2ZyYW1ld29yay9jb3JlL3R5cGUvTWV0aG9kTWV0YWRhdGEBAA1nZXRNZXRob2ROYW1lAQAUKClMamF2YS9sYW5nL1N0cmluZzsBABBqYXZhL2xhbmcvU3RyaW5nAQAGZm9ybWF0AQA5KExqYXZhL2xhbmcvU3RyaW5nO1tMamF2YS9sYW5nL09iamVjdDspTGphdmEvbGFuZy9TdHJpbmc7AQATZ2V0UmVzb3VyY2VMb2NhdGlvbgEANigpTG9yZy9zcHJpbmdmcmFtZXdvcmsvYmVhbnMvZmFjdG9yeS9wYXJzaW5nL0xvY2F0aW9uOwEASShMamF2YS9sYW5nL1N0cmluZztMb3JnL3NwcmluZ2ZyYW1ld29yay9iZWFucy9mYWN0b3J5L3BhcnNpbmcvTG9jYXRpb247KVYAIAAJAAoAAAABEBAACwAMAAAAAQAAAA0ADgACAA8AAABlAAYAAgAAACMqK7UAASoSAgS9AANZAyu2AAS5AAUBAFO4AAYrtgAHtwAIsQAAAAIAEAAAAB4ABwAAAE0ABQBOAA8ATwAYAE4AHABPAB8ATgAiAFAAEQAAAAwAAQAAACMAEgAVAAAAFgAAAAUBAAsQEAACABcAAAACABgAFAAAAAoAAQAJABwAEwAC
+  </listing>
+  <errors/>
+  <sheets/>
+  <license/>
+  <metas>
+    <meta>
+      <head>package</head>
+      <tail>org.springframework.context.annotation</tail>
+      <part>org.springframework.context.annotation</part>
+    </meta>
+    <meta>
+      <head>alias</head>
+      <tail>org.eolang.jeo.opcode</tail>
+      <part>org.eolang.jeo.opcode</part>
+    </meta>
+    <meta>
+      <head>alias</head>
+      <tail>org.eolang.jeo.label</tail>
+      <part>org.eolang.jeo.label</part>
+    </meta>
+  </metas>
+  <objects>
+    <o abstract="" name="j$BeanMethod$NonOverridableMethodError">
+      <o base="int" data="bytes" name="version">00 00 00 00 00 00 00 34</o>
+      <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 20</o>
+      <o base="string" data="bytes" name="supername">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 62 65 61 6E 73 2F 66 61 63 74 6F 72 79 2F 70 61 72 73 69 6E 67 2F 50 72 6F 62 6C 65 6D</o>
+      <o base="tuple" name="interfaces" star=""/>
+      <o base="field" name="j$this$0">
+        <o base="int" data="bytes" line="999" name="access-j$this$0">00 00 00 00 00 00 10 10</o>
+        <o base="string" data="bytes" line="999" name="descriptor-j$this$0">4C 6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 6E 74 65 78 74 2F 61 6E 6E 6F 74 61 74 69 6F 6E 2F 42 65 61 6E 4D 65 74 68 6F 64 3B</o>
+        <o base="string" data="bytes" line="999" name="signature-j$this$0"/>
+        <o base="class"
+          line="999"
+          data="bytes"
+          name="value-j$this$0"
+          scope="nullable"/>
       </o>
-   </objects>
+      <o abstract="" name="new">
+        <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 00</o>
+        <o base="string" data="bytes" name="descriptor">28 4C 6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 6E 74 65 78 74 2F 61 6E 6E 6F 74 61 74 69 6F 6E 2F 42 65 61 6E 4D 65 74 68 6F 64 3B 29 56</o>
+        <o base="string" data="bytes" name="signature"/>
+        <o base="tuple" name="exceptions" star=""/>
+        <o base="maxs">
+          <o base="int" data="bytes">00 00 00 00 00 00 00 06</o>
+          <o base="int" data="bytes">00 00 00 00 00 00 00 02</o>
+        </o>
+        <o abstract=""
+          name="arg__Lorg/springframework/context/annotation/BeanMethod;__0"/>
+        <o base="seq" name="@">
+          <o base="tuple" star="">
+            <o base="label" data="bytes">32 39 38 37 37 62 36 37 2D 36 64 63 33 2D 34 36 38 31 2D 61 39 64 36 2D 36 63 34 31 32 30 65 32 37 38 37 31</o>
+            <o base="opcode" line="999" name="ALOAD-1FCAEF">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
+              <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
+            </o>
+            <o base="opcode" line="999" name="ALOAD-1FCAF0">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
+              <o base="int" data="bytes">00 00 00 00 00 00 00 01</o>
+            </o>
+            <o base="opcode" line="999" name="PUTFIELD-1FCAF1">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 B5</o>
+              <o base="string" data="bytes">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 6E 74 65 78 74 2F 61 6E 6E 6F 74 61 74 69 6F 6E 2F 42 65 61 6E 4D 65 74 68 6F 64 24 4E 6F 6E 4F 76 65 72 72 69 64 61 62 6C 65 4D 65 74 68 6F 64 45 72 72 6F 72</o>
+              <o base="string" data="bytes">74 68 69 73 24 30</o>
+              <o base="string" data="bytes">4C 6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 6E 74 65 78 74 2F 61 6E 6E 6F 74 61 74 69 6F 6E 2F 42 65 61 6E 4D 65 74 68 6F 64 3B</o>
+            </o>
+            <o base="label" data="bytes">38 61 30 38 35 34 65 39 2D 30 31 33 64 2D 34 37 38 32 2D 39 63 37 63 2D 32 35 62 33 37 31 37 64 36 35 61 33</o>
+            <o base="opcode" line="999" name="ALOAD-1FCAF2">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
+              <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
+            </o>
+            <o base="opcode" line="999" name="LDC-1FCAF3">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 12</o>
+              <o base="string" data="bytes">40 42 65 61 6E 20 6D 65 74 68 6F 64 20 27 25 73 27 20 6D 75 73 74 20 6E 6F 74 20 62 65 20 70 72 69 76 61 74 65 20 6F 72 20 66 69 6E 61 6C 3B 20 63 68 61 6E 67 65 20 74 68 65 20 6D 65 74 68 6F 64 27 73 20 6D 6F 64 69 66 69 65 72 73 20 74 6F 20 63 6F 6E 74 69 6E 75 65</o>
+            </o>
+            <o base="opcode" line="999" name="ICONST_1-1FCAF4">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 04</o>
+            </o>
+            <o base="opcode" line="999" name="ANEWARRAY-1FCAF5">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 BD</o>
+              <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
+            </o>
+            <o base="opcode" line="999" name="DUP-1FCAF6">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 59</o>
+            </o>
+            <o base="opcode" line="999" name="ICONST_0-1FCAF7">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 03</o>
+            </o>
+            <o base="opcode" line="999" name="ALOAD-1FCAF8">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
+              <o base="int" data="bytes">00 00 00 00 00 00 00 01</o>
+            </o>
+            <o base="label" data="bytes">37 36 62 32 66 63 37 37 2D 64 35 37 61 2D 34 61 38 64 2D 62 35 61 30 2D 64 66 65 37 33 62 66 62 62 65 33 39</o>
+            <o base="opcode" line="999" name="INVOKEVIRTUAL-1FCAF9">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 B6</o>
+              <o base="string" data="bytes">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 6E 74 65 78 74 2F 61 6E 6E 6F 74 61 74 69 6F 6E 2F 42 65 61 6E 4D 65 74 68 6F 64</o>
+              <o base="string" data="bytes">67 65 74 4D 65 74 61 64 61 74 61</o>
+              <o base="string" data="bytes">28 29 4C 6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 72 65 2F 74 79 70 65 2F 4D 65 74 68 6F 64 4D 65 74 61 64 61 74 61 3B</o>
+              <o base="bool" data="bytes">00</o>
+            </o>
+            <o base="opcode" line="999" name="INVOKEINTERFACE-1FCAFA">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 B9</o>
+              <o base="string" data="bytes">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 72 65 2F 74 79 70 65 2F 4D 65 74 68 6F 64 4D 65 74 61 64 61 74 61</o>
+              <o base="string" data="bytes">67 65 74 4D 65 74 68 6F 64 4E 61 6D 65</o>
+              <o base="string" data="bytes">28 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
+              <o base="bool" data="bytes">01</o>
+            </o>
+            <o base="opcode" line="999" name="AASTORE-1FCAFB">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 53</o>
+            </o>
+            <o base="label" data="bytes">34 63 39 34 34 61 66 33 2D 32 34 37 64 2D 34 61 63 61 2D 61 62 63 64 2D 39 34 66 66 36 63 63 64 61 30 32 32</o>
+            <o base="opcode" line="999" name="INVOKESTATIC-1FCAFC">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 B8</o>
+              <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67</o>
+              <o base="string" data="bytes">66 6F 72 6D 61 74</o>
+              <o base="string" data="bytes">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
+              <o base="bool" data="bytes">00</o>
+            </o>
+            <o base="opcode" line="999" name="ALOAD-1FCAFD">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
+              <o base="int" data="bytes">00 00 00 00 00 00 00 01</o>
+            </o>
+            <o base="label" data="bytes">30 63 38 32 61 34 38 66 2D 62 62 30 34 2D 34 64 36 31 2D 61 32 34 32 2D 64 34 65 61 35 37 30 35 38 38 30 39</o>
+            <o base="opcode" line="999" name="INVOKEVIRTUAL-1FCAFE">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 B6</o>
+              <o base="string" data="bytes">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 6E 74 65 78 74 2F 61 6E 6E 6F 74 61 74 69 6F 6E 2F 42 65 61 6E 4D 65 74 68 6F 64</o>
+              <o base="string" data="bytes">67 65 74 52 65 73 6F 75 72 63 65 4C 6F 63 61 74 69 6F 6E</o>
+              <o base="string" data="bytes">28 29 4C 6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 62 65 61 6E 73 2F 66 61 63 74 6F 72 79 2F 70 61 72 73 69 6E 67 2F 4C 6F 63 61 74 69 6F 6E 3B</o>
+              <o base="bool" data="bytes">00</o>
+            </o>
+            <o base="label" data="bytes">37 39 38 63 32 64 63 66 2D 63 35 32 31 2D 34 31 33 36 2D 38 64 33 65 2D 66 39 33 37 33 64 35 39 38 66 61 62</o>
+            <o base="opcode" line="999" name="INVOKESPECIAL-1FCAFF">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 B7</o>
+              <o base="string" data="bytes">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 62 65 61 6E 73 2F 66 61 63 74 6F 72 79 2F 70 61 72 73 69 6E 67 2F 50 72 6F 62 6C 65 6D</o>
+              <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
+              <o base="string" data="bytes">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 62 65 61 6E 73 2F 66 61 63 74 6F 72 79 2F 70 61 72 73 69 6E 67 2F 4C 6F 63 61 74 69 6F 6E 3B 29 56</o>
+              <o base="bool" data="bytes">00</o>
+            </o>
+            <o base="label" data="bytes">34 61 30 61 34 30 31 64 2D 65 33 34 36 2D 34 62 65 66 2D 38 39 35 30 2D 64 30 33 64 66 38 30 34 32 62 64 65</o>
+            <o base="opcode" line="999" name="RETURN-1FCB00">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 B1</o>
+            </o>
+            <o base="label" data="bytes">66 35 38 61 61 39 34 61 2D 63 30 36 64 2D 34 37 63 36 2D 62 62 37 61 2D 34 66 39 35 63 33 39 66 30 62 32 61</o>
+          </o>
+        </o>
+      </o>
+      <o base="tuple" name="attributes" star="">
+        <o base="InnerClass">
+          <o base="string" data="bytes" line="999">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 6E 74 65 78 74 2F 61 6E 6E 6F 74 61 74 69 6F 6E 2F 42 65 61 6E 4D 65 74 68 6F 64 24 4E 6F 6E 4F 76 65 72 72 69 64 61 62 6C 65 4D 65 74 68 6F 64 45 72 72 6F 72</o>
+          <o base="string" data="bytes" line="999">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 6E 74 65 78 74 2F 61 6E 6E 6F 74 61 74 69 6F 6E 2F 42 65 61 6E 4D 65 74 68 6F 64</o>
+          <o base="string" data="bytes" line="999">4E 6F 6E 4F 76 65 72 72 69 64 61 62 6C 65 4D 65 74 68 6F 64 45 72 72 6F 72</o>
+          <o base="int" data="bytes" line="999">00 00 00 00 00 00 00 02</o>
+        </o>
+      </o>
+    </o>
+  </objects>
 </program>

--- a/src/it/decompile-compile/target/generated-sources/jeo-xmir/org/eolang/jeo/TypeWriter$Default$ForInlining$WithFullProcessing$InitializationHandler$Appending$WithoutDrain.xmir
+++ b/src/it/decompile-compile/target/generated-sources/jeo-xmir/org/eolang/jeo/TypeWriter$Default$ForInlining$WithFullProcessing$InitializationHandler$Appending$WithoutDrain.xmir
@@ -34,13 +34,13 @@
          <o base="string" data="bytes" name="supername">6E 65 74 2F 62 79 74 65 62 75 64 64 79 2F 64 79 6E 61 6D 69 63 2F 73 63 61 66 66 6F 6C 64 2F 54 79 70 65 57 72 69 74 65 72 24 44 65 66 61 75 6C 74 24 46 6F 72 49 6E 6C 69 6E 69 6E 67 24 57 69 74 68 46 75 6C 6C 50 72 6F 63 65 73 73 69 6E 67 24 49 6E 69 74 69 61 6C 69 7A 61 74 69 6F 6E 48 61 6E 64 6C 65 72 24 41 70 70 65 6E 64 69 6E 67</o>
          <o base="tuple" name="interfaces" star=""/>
          <o abstract="" name="new">
-            <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 04</o>
-            <o base="string" data="bytes" name="descriptor">28 4C 6E 65 74 2F 62 79 74 65 62 75 64 64 79 2F 6A 61 72 2F 61 73 6D 2F 4D 65 74 68 6F 64 56 69 73 69 74 6F 72 3B 4C 6E 65 74 2F 62 79 74 65 62 75 64 64 79 2F 64 65 73 63 72 69 70 74 69 6F 6E 2F 74 79 70 65 2F 54 79 70 65 44 65 73 63 72 69 70 74 69 6F 6E 3B 4C 6E 65 74 2F 62 79 74 65 62 75 64 64 79 2F 64 79 6E 61 6D 69 63 2F 73 63 61 66 66 6F 6C 64 2F 54 79 70 65 57 72 69 74 65 72 24 4D 65 74 68 6F 64 50 6F 6F 6C 24 52 65 63 6F 72 64 3B 4C 6E 65 74 2F 62 79 74 65 62 75 64 64 79 2F 69 6D 70 6C 65 6D 65 6E 74 61 74 69 6F 6E 2F 61 74 74 72 69 62 75 74 65 2F 41 6E 6E 6F 74 61 74 69 6F 6E 56 61 6C 75 65 46 69 6C 74 65 72 24 46 61 63 74 6F 72 79 3B 5A 5A 29 56</o>
-            <o base="string" data="bytes" name="signature"/>
-            <o base="tuple" name="exceptions" star=""/>
-            <o name="maxs">
-               <o base="int" data="bytes" name="stack">00 00 00 00 00 00 00 07</o>
-               <o base="int" data="bytes" name="locals">00 00 00 00 00 00 00 07</o>
+            <o base="int" data="bytes">00 00 00 00 00 00 00 04</o>
+            <o base="string" data="bytes">28 4C 6E 65 74 2F 62 79 74 65 62 75 64 64 79 2F 6A 61 72 2F 61 73 6D 2F 4D 65 74 68 6F 64 56 69 73 69 74 6F 72 3B 4C 6E 65 74 2F 62 79 74 65 62 75 64 64 79 2F 64 65 73 63 72 69 70 74 69 6F 6E 2F 74 79 70 65 2F 54 79 70 65 44 65 73 63 72 69 70 74 69 6F 6E 3B 4C 6E 65 74 2F 62 79 74 65 62 75 64 64 79 2F 64 79 6E 61 6D 69 63 2F 73 63 61 66 66 6F 6C 64 2F 54 79 70 65 57 72 69 74 65 72 24 4D 65 74 68 6F 64 50 6F 6F 6C 24 52 65 63 6F 72 64 3B 4C 6E 65 74 2F 62 79 74 65 62 75 64 64 79 2F 69 6D 70 6C 65 6D 65 6E 74 61 74 69 6F 6E 2F 61 74 74 72 69 62 75 74 65 2F 41 6E 6E 6F 74 61 74 69 6F 6E 56 61 6C 75 65 46 69 6C 74 65 72 24 46 61 63 74 6F 72 79 3B 5A 5A 29 56</o>
+            <o base="string" data="bytes"/>
+            <o base="tuple" star=""/>
+            <o base="maxs">
+               <o base="int" data="bytes">00 00 00 00 00 00 00 07</o>
+               <o base="int" data="bytes">00 00 00 00 00 00 00 07</o>
             </o>
             <o abstract="" name="arg__Lnet/bytebuddy/jar/asm/MethodVisitor;__0"/>
             <o abstract=""

--- a/src/it/fuse/README.md
+++ b/src/it/fuse/README.md
@@ -9,5 +9,5 @@ test.
 To run only this test, use the following command:
 
 ```shell
-mvn clean integration-test invoker:run -Dinvoker.test=fuse -DskipTests
+mvn clean integration-test -Dinvoker.test=fuse -DskipTests
 ```

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -53,7 +53,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <jeo.version>0.4.6</jeo.version>
+    <jeo.version>0.5.0</jeo.version>
     <ineo.version>0.3.1</ineo.version>
     <jeo.disassemble.output>${project.build.directory}/generated-sources/jeo-disassemble-xmir</jeo.disassemble.output>
     <opeo.decompile.output>${project.build.directory}/generated-sources/opeo-decompile-xmir</opeo.decompile.output>
@@ -225,8 +225,6 @@ SOFTWARE.
                   <goal>xmir-to-phi</goal>
                 </goals>
                 <configuration>
-                  <phiSkipFailed>true</phiSkipFailed>
-                  <phiOptimize>false</phiOptimize>
                   <phiInputDir>${opeo.modified}</phiInputDir>
                   <phiOutputDir>${eo.phi.output}</phiOutputDir>
                 </configuration>

--- a/src/it/spring/README.md
+++ b/src/it/spring/README.md
@@ -23,7 +23,7 @@ In short, the test is organised as follows:
 To exclusively run this test, execute the command below:
 
 ```shell
-mvn clean integration-test invoker:run -Dinvoker.test=spring -DskipTests
+mvn clean integration-test -Dinvoker.test=spring -DskipTests
 ```
 
 ## PHI Expressions

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -126,8 +126,6 @@ SOFTWARE.
               <goal>xmir-to-phi</goal>
             </goals>
             <configuration>
-              <phiSkipFailed>true</phiSkipFailed>
-              <phiOptimize>false</phiOptimize>
               <phiInputDir>${project.build.directory}/generated-sources/opeo-decompile-modified-xmir</phiInputDir>
               <phiOutputDir>${project.build.directory}/generated-sources/phi-expressions</phiOutputDir>
             </configuration>

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -53,7 +53,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <jeo.version>0.4.6</jeo.version>
+    <jeo.version>0.5.0</jeo.version>
     <ineo.version>0.3.2</ineo.version>
   </properties>
   <dependencies>

--- a/src/it/spring/src/main/java/org/eolang/jeo/spring/Factorial.java
+++ b/src/it/spring/src/main/java/org/eolang/jeo/spring/Factorial.java
@@ -36,6 +36,14 @@ class Factorial {
 
     /**
      * Constructor.
+     */
+    Factorial() {
+        this(0);
+    }
+
+
+    /**
+     * Constructor.
      * @param d Value.
      */
     Factorial(int d) {

--- a/src/it/staticize/README.md
+++ b/src/it/staticize/README.md
@@ -6,7 +6,7 @@ optimizations. We utilize `staticize` optimization in this test.
 To run only this test, use the following command:
 
 ```shell
-mvn clean integration-test invoker:run -Dinvoker.test=staticize -DskipTests
+mvn clean integration-test -Dinvoker.test=staticize -DskipTests
 ```
 
 _____

--- a/src/it/staticize/pom.xml
+++ b/src/it/staticize/pom.xml
@@ -101,24 +101,24 @@ SOFTWARE.
           </execution>
         </executions>
       </plugin>
-        <plugin>
-                    <groupId>org.eolang</groupId>
-                    <artifactId>eo-maven-plugin</artifactId>
-                    <version>0.38.4</version>
-                    <executions>
-                      <execution>
-                        <id>convert-xmir-to-phi</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                          <goal>xmir-to-phi</goal>
-                        </goals>
-                        <configuration>
-                          <phiInputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</phiInputDir>
-                          <phiOutputDir>${project.build.directory}/generated-sources/phi-expressions</phiOutputDir>
-                        </configuration>
-                      </execution>
-                    </executions>
-                  </plugin>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>eo-maven-plugin</artifactId>
+        <version>0.38.4</version>
+        <executions>
+          <execution>
+            <id>convert-xmir-to-phi</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>xmir-to-phi</goal>
+            </goals>
+            <configuration>
+              <phiInputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</phiInputDir>
+              <phiOutputDir>${project.build.directory}/generated-sources/phi-expressions</phiOutputDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>ineo-maven-plugin</artifactId>

--- a/src/it/staticize/pom.xml
+++ b/src/it/staticize/pom.xml
@@ -50,7 +50,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
-    <jeo.version>0.4.6</jeo.version>
+    <jeo.version>0.5.0</jeo.version>
     <ineo.version>0.3.2</ineo.version>
     <opeo.version>@project.version@</opeo.version>
   </properties>
@@ -85,7 +85,7 @@ SOFTWARE.
             <configuration>
               <sourcesDir>${project.build.directory}/generated-sources/jeo-decompile-xmir</sourcesDir>
               <outputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</outputDir>
-              <modifiedDir>${project.build.directory}/generated-sources/opep-decompile-xmir-modified</modifiedDir>
+              <modifiedDir>${project.build.directory}/generated-sources/opeo-decompile-xmir-modified</modifiedDir>
             </configuration>
           </execution>
           <execution>
@@ -101,6 +101,24 @@ SOFTWARE.
           </execution>
         </executions>
       </plugin>
+        <plugin>
+                    <groupId>org.eolang</groupId>
+                    <artifactId>eo-maven-plugin</artifactId>
+                    <version>0.38.4</version>
+                    <executions>
+                      <execution>
+                        <id>convert-xmir-to-phi</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                          <goal>xmir-to-phi</goal>
+                        </goals>
+                        <configuration>
+                          <phiInputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</phiInputDir>
+                          <phiOutputDir>${project.build.directory}/generated-sources/phi-expressions</phiOutputDir>
+                        </configuration>
+                      </execution>
+                    </executions>
+                  </plugin>
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>ineo-maven-plugin</artifactId>

--- a/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
+++ b/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 import org.eolang.opeo.decompilation.Decompiler;
 import org.eolang.opeo.decompilation.handlers.RouterHandler;
 import org.eolang.opeo.jeo.JeoDecompiler;
-import org.eolang.opeo.storage.DummyStorage;
 import org.eolang.opeo.storage.FileStorage;
 import org.eolang.opeo.storage.Storage;
 import org.eolang.opeo.storage.XmirEntry;

--- a/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
+++ b/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
@@ -75,27 +75,6 @@ public final class SelectiveDecompiler implements Decompiler {
      * Constructor.
      * @param input Input folder with XMIRs.
      * @param output Output folder where to save the decompiled files.
-     */
-    public SelectiveDecompiler(final Path input, final Path output) {
-        this(input, output, new RouterHandler(false).supportedOpcodes());
-    }
-
-    /**
-     * Constructor.
-     * @param input Input folder with XMIRs.
-     * @param output Output folder where to save the decompiled files.
-     * @param supported Supported opcodes are used in selection.
-     */
-    public SelectiveDecompiler(
-        final Path input, final Path output, final String... supported
-    ) {
-        this(new FileStorage(input, output), supported);
-    }
-
-    /**
-     * Constructor.
-     * @param input Input folder with XMIRs.
-     * @param output Output folder where to save the decompiled files.
      * @param modified Folder where to save the modified XMIRs.
      * @param supported Supported opcodes are used in selection.
      * @checkstyle ParameterNumberCheck (5 lines)
@@ -107,15 +86,6 @@ public final class SelectiveDecompiler implements Decompiler {
         final String... supported
     ) {
         this(new FileStorage(input, output), new FileStorage(modified, modified), supported);
-    }
-
-    /**
-     * Constructor.
-     * @param storage Storage from which retrieve the XMIRs and where to save the modified ones.
-     * @param supported Supported opcodes are used in selection.
-     */
-    public SelectiveDecompiler(final Storage storage, final String... supported) {
-        this(storage, new DummyStorage(), supported);
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
+++ b/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
@@ -159,6 +159,6 @@ public final class SelectiveDecompiler implements Decompiler {
      *  Don't forget to add tests for the new functionality.
      */
     private static String trycatches() {
-        return "//o[@base='tuple' and @name='trycatchblocks']/@name";
+        return "//o[@base='tuple' and contains(@name,'trycatchblocks')]/@name";
     }
 }

--- a/src/main/java/org/eolang/opeo/jeo/JeoDecompiler.java
+++ b/src/main/java/org/eolang/opeo/jeo/JeoDecompiler.java
@@ -102,7 +102,7 @@ public final class JeoDecompiler {
                         new Xembler(
                             new DecompilerMachine(
                                 new LocalVariables(method.access(), method.descriptor(), clazz),
-                                Collections.singletonMap("counting", "false")
+                                Collections.singletonMap("counting", "true")
                             ).decompile(new JeoInstructions(method).instructions()),
                             new Transformers.Node()
                         ).xmlQuietly()

--- a/src/test/java/it/JeoAndOpeoTest.java
+++ b/src/test/java/it/JeoAndOpeoTest.java
@@ -33,6 +33,7 @@ import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.xmir.XmlBytecodeEntry;
 import org.eolang.jeo.representation.xmir.XmlLabel;
 import org.eolang.jeo.representation.xmir.XmlProgram;
+import org.eolang.opeo.SameXml;
 import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.compilation.JeoCompiler;
 import org.eolang.opeo.jeo.JeoDecompiler;
@@ -187,8 +188,8 @@ final class JeoAndOpeoTest {
         final XMLDocument original = new XMLDocument(new BytesOf(new ResourceOf(path)).asBytes());
         MatcherAssert.assertThat(
             "The original and decompiled/compiled content are not equal",
-            new JeoCompiler(new JeoDecompiler(original, pckg).decompile()).compile(),
-            Matchers.equalTo(original)
+            new JeoCompiler(new JeoDecompiler(original, pckg).decompile()).compile().toString(),
+            new SameXml(original)
         );
     }
 }

--- a/src/test/java/org/eolang/opeo/SameXml.java
+++ b/src/test/java/org/eolang/opeo/SameXml.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.xembly.Directives;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Matcher to check if the received XML document is the same as the expected one.
+ * Smart comparison of XML documents that ignores 'line' attributes.
+ * @since 0.5
+ */
+@SuppressWarnings({
+    "JTCOP.RuleAllTestsHaveProductionClass",
+    "JTCOP.RuleCorrectTestName",
+    "JTCOP.RuleInheritanceInTests"
+})
+public final class SameXml extends TypeSafeMatcher<String> {
+
+    /**
+     * Expected XML document.
+     */
+    private final String expected;
+
+    /**
+     * Constructor.
+     * @param xml Expected XML document.
+     */
+    public SameXml(final XML xml) {
+        this(xml.toString());
+    }
+
+    /**
+     * Constructor.
+     * @param expected Expected XML document.
+     */
+    public SameXml(final String expected) {
+        this.expected = expected;
+    }
+
+    @Override
+    public boolean matchesSafely(final String item) {
+        return SameXml.withoutLines(new XMLDocument(this.expected))
+            .equals(SameXml.withoutLines(new XMLDocument(item)));
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendText("XML documents is not the same.")
+            .appendText("Expected:\n")
+            .appendText(this.expected);
+    }
+
+    /**
+     * Remove 'line' attributes from the XML document.
+     * @param original Original XML document.
+     * @return XML document without 'line' attributes.
+     */
+    private static XML withoutLines(final XML original) {
+        try {
+            return new XMLDocument(
+                new Xembler(
+                    new Directives().xpath(".//o[@line]/@line").remove()
+                ).apply(original.node())
+            );
+        } catch (final ImpossibleModificationException exception) {
+            throw new IllegalStateException("Failed to remove 'line' attributes", exception);
+        }
+    }
+}

--- a/src/test/java/org/eolang/opeo/ast/ArrayConstructorTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ArrayConstructorTest.java
@@ -25,6 +25,7 @@ package org.eolang.opeo.ast;
 
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -118,8 +119,8 @@ final class ArrayConstructorTest {
                 "We expect that array constructor will be correctly transformed to XMIR, but it didn't. Result is: %n%s%n",
                 xmir
             ),
-            new XMLDocument(xmir),
-            Matchers.equalTo(new XMLDocument(ArrayConstructorTest.XMIR))
+            xmir,
+            new SameXml(ArrayConstructorTest.XMIR)
         );
     }
 }

--- a/src/test/java/org/eolang/opeo/ast/ArrayConstructorTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ArrayConstructorTest.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.opeo.ast;
 
-import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.SameXml;
 import org.eolang.opeo.compilation.HasInstructions;

--- a/src/test/java/org/eolang/opeo/ast/ClassFieldTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ClassFieldTest.java
@@ -25,6 +25,7 @@ package org.eolang.opeo.ast;
 
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -51,8 +52,8 @@ final class ClassFieldTest {
     void convertsToXmir() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "Can't convert class field to xmir representation",
-            new XMLDocument(new Xembler(new ClassField("java/lang/A", "x", "I").toXmir()).xml()),
-            Matchers.equalTo(new XMLDocument(ClassFieldTest.XMIR))
+            new Xembler(new ClassField("java/lang/A", "x", "I").toXmir()).xml(),
+            new SameXml(ClassFieldTest.XMIR)
         );
     }
 

--- a/src/test/java/org/eolang/opeo/ast/ClassFieldTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ClassFieldTest.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.opeo.ast;
 
-import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;

--- a/src/test/java/org/eolang/opeo/ast/ConstructorTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ConstructorTest.java
@@ -24,7 +24,6 @@
 package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;

--- a/src/test/java/org/eolang/opeo/ast/ConstructorTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ConstructorTest.java
@@ -26,6 +26,7 @@ package org.eolang.opeo.ast;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -82,25 +83,21 @@ final class ConstructorTest {
     void transformsConstructorToXmirWithAttributes() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "We expect that constructor will be transformed to XMIR with scope attribute",
-            new XMLDocument(
-                new Xembler(
-                    new Constructor(
-                        "A",
-                        new Attributes().descriptor("(Ljava/lang/String;)V"),
-                        new Literal("first")
-                    ).toXmir()
-                ).xml()
-            ),
-            Matchers.equalTo(
-                new XMLDocument(
-                    String.join(
-                        "\n",
-                        "<o base='.new'>",
-                        "  <o base='string' data='bytes'>64 65 73 63 72 69 70 74 6F 72 3D 28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 56</o>",
-                        "  <o base='.new-type'><o base='string' data='bytes'>41</o></o>",
-                        "  <o base='string' data='bytes'>66 69 72 73 74</o>",
-                        "</o>"
-                    )
+            new Xembler(
+                new Constructor(
+                    "A",
+                    new Attributes().descriptor("(Ljava/lang/String;)V"),
+                    new Literal("first")
+                ).toXmir()
+            ).xml(),
+            new SameXml(
+                String.join(
+                    "\n",
+                    "<o base='.new'>",
+                    "  <o base='string' data='bytes'>64 65 73 63 72 69 70 74 6F 72 3D 28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 56</o>",
+                    "  <o base='.new-type'><o base='string' data='bytes'>41</o></o>",
+                    "  <o base='string' data='bytes'>66 69 72 73 74</o>",
+                    "</o>"
                 )
             )
         );

--- a/src/test/java/org/eolang/opeo/ast/FieldAssignmentTest.java
+++ b/src/test/java/org/eolang/opeo/ast/FieldAssignmentTest.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.opeo.ast;
 
-import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.SameXml;
 import org.eolang.opeo.compilation.HasInstructions;

--- a/src/test/java/org/eolang/opeo/ast/FieldAssignmentTest.java
+++ b/src/test/java/org/eolang/opeo/ast/FieldAssignmentTest.java
@@ -25,6 +25,7 @@ package org.eolang.opeo.ast;
 
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -94,8 +95,8 @@ final class FieldAssignmentTest {
                 "Can't convert 'this.bar = 3' statement to the correct xmir, result is wrong: %n%s%n",
                 xmir
             ),
-            new XMLDocument(xmir),
-            Matchers.equalTo(new XMLDocument(FieldAssignmentTest.XMIR))
+            xmir,
+            new SameXml(FieldAssignmentTest.XMIR)
         );
     }
 

--- a/src/test/java/org/eolang/opeo/ast/FieldRetrievalTest.java
+++ b/src/test/java/org/eolang/opeo/ast/FieldRetrievalTest.java
@@ -23,8 +23,8 @@
  */
 package org.eolang.opeo.ast;
 
-import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -71,8 +71,8 @@ final class FieldRetrievalTest {
                 "Can't convert to a field access construct, actual result is : %n%s%n",
                 actual
             ),
-            new XMLDocument(actual),
-            Matchers.equalTo(new XMLDocument(FieldRetrievalTest.XMIR))
+            actual,
+            new SameXml(FieldRetrievalTest.XMIR)
         );
     }
 

--- a/src/test/java/org/eolang/opeo/ast/FieldTest.java
+++ b/src/test/java/org/eolang/opeo/ast/FieldTest.java
@@ -25,6 +25,7 @@ package org.eolang.opeo.ast;
 
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -53,18 +54,19 @@ final class FieldTest {
 
     @Test
     void convertsToXmir() throws ImpossibleModificationException {
-        final XMLDocument actual = new XMLDocument(
-            new Xembler(
-                new Field(
-                    new This(),
-                    new Attributes("name", "foo")
-                ).toXmir()
-            ).xml()
-        );
+        final String actual = new Xembler(
+            new Field(
+                new This(),
+                new Attributes("name", "foo")
+            ).toXmir()
+        ).xml();
         MatcherAssert.assertThat(
-            String.format("Can't convert to correct XMIR, actual result is : %n%s%n", actual),
+            String.format(
+                "Can't convert to correct XMIR, actual result is : %n%s%n",
+                new XMLDocument(actual)
+            ),
             actual,
-            Matchers.equalTo(new XMLDocument(FieldTest.XMIR))
+            new SameXml(FieldTest.XMIR)
         );
     }
 

--- a/src/test/java/org/eolang/opeo/ast/IfTest.java
+++ b/src/test/java/org/eolang/opeo/ast/IfTest.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.opeo.ast;
 
-import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;

--- a/src/test/java/org/eolang/opeo/ast/IfTest.java
+++ b/src/test/java/org/eolang/opeo/ast/IfTest.java
@@ -25,6 +25,7 @@ package org.eolang.opeo.ast;
 
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -59,14 +60,12 @@ final class IfTest {
     void convertsIfStatementToXmir() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "Can convert 'if' statement to correct XMIR",
-            new XMLDocument(
-                new Xembler(
-                    new If(
-                        new Literal(1), new Literal(2), new Label("FF")
-                    ).toXmir()
-                ).xml()
-            ),
-            Matchers.equalTo(new XMLDocument(IfTest.XMIR))
+            new Xembler(
+                new If(
+                    new Literal(1), new Literal(2), new Label("FF")
+                ).toXmir()
+            ).xml(),
+            new SameXml(IfTest.XMIR)
         );
     }
 

--- a/src/test/java/org/eolang/opeo/ast/InterfaceInvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InterfaceInvocationTest.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.opeo.ast;
 
-import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;

--- a/src/test/java/org/eolang/opeo/ast/InterfaceInvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InterfaceInvocationTest.java
@@ -25,6 +25,7 @@ package org.eolang.opeo.ast;
 
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -60,8 +61,8 @@ final class InterfaceInvocationTest {
         ).xml();
         MatcherAssert.assertThat(
             String.format("Can't transform to correct XMIR, what we got is '%s'", xml),
-            new XMLDocument(InterfaceInvocationTest.XMIR),
-            Matchers.equalTo(new XMLDocument(xml))
+            InterfaceInvocationTest.XMIR,
+            new SameXml(xml)
         );
     }
 

--- a/src/test/java/org/eolang/opeo/ast/InvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InvocationTest.java
@@ -24,8 +24,8 @@
 package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -90,17 +90,15 @@ final class InvocationTest {
     void transformsToXmir() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "Can't transform 'invocation' to XMIR",
-            new XMLDocument(
-                new Xembler(
-                    new Invocation(
-                        new Constructor("foo"),
-                        "bar",
-                        new Literal("baz")
-                    ).toXmir(),
-                    new Transformers.Node()
-                ).xml()
-            ),
-            Matchers.equalTo(new XMLDocument(InvocationTest.XMIR))
+            new Xembler(
+                new Invocation(
+                    new Constructor("foo"),
+                    "bar",
+                    new Literal("baz")
+                ).toXmir(),
+                new Transformers.Node()
+            ).xml(),
+            new SameXml(InvocationTest.XMIR)
         );
     }
 

--- a/src/test/java/org/eolang/opeo/ast/LabelTest.java
+++ b/src/test/java/org/eolang/opeo/ast/LabelTest.java
@@ -24,6 +24,7 @@
 package org.eolang.opeo.ast;
 
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -42,17 +43,17 @@ final class LabelTest {
         MatcherAssert.assertThat(
             "The label should be converted to XMIR",
             new Xembler(new Label("66 6F 6F").toXmir(), new Transformers.Node()).xml(),
-            Matchers.equalTo("<o base=\"label\" data=\"bytes\">66 6F 6F</o>")
+            new SameXml("<o base='label' data='bytes'>66 6F 6F</o>")
         );
     }
 
     @Test
     void parsesXml() throws ImpossibleModificationException {
-        final String initial = "<o base=\"label\" data=\"bytes\">66 6F 6F</o>";
+        final String initial = "<o base='label' data='bytes'>66 6F 6F 6F</o>";
         MatcherAssert.assertThat(
             "The label should be able parse itself from XMIR and convert back to the same XMIR",
             new Xembler(new Label(new XmlNode(initial)).toXmir(), new Transformers.Node()).xml(),
-            Matchers.equalTo(initial)
+            new SameXml(initial)
         );
     }
 }

--- a/src/test/java/org/eolang/opeo/ast/LabelTest.java
+++ b/src/test/java/org/eolang/opeo/ast/LabelTest.java
@@ -26,7 +26,6 @@ package org.eolang.opeo.ast;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Transformers;

--- a/src/test/java/org/eolang/opeo/ast/LabeledTest.java
+++ b/src/test/java/org/eolang/opeo/ast/LabeledTest.java
@@ -25,6 +25,7 @@ package org.eolang.opeo.ast;
 
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -48,12 +49,10 @@ final class LabeledTest {
     void convertsToXmir() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "Wrong XMIR is generated for labeled constant",
-            new XMLDocument(
-                new Xembler(
-                    new Labeled(new Constant(1), new Label("1")).toXmir()
-                ).xml()
-            ),
-            Matchers.equalTo(new XMLDocument(LabeledTest.XMIR))
+            new Xembler(
+                new Labeled(new Constant(1), new Label("1")).toXmir()
+            ).xml(),
+            new SameXml(new XMLDocument(LabeledTest.XMIR))
         );
     }
 

--- a/src/test/java/org/eolang/opeo/ast/NewAddressTest.java
+++ b/src/test/java/org/eolang/opeo/ast/NewAddressTest.java
@@ -24,6 +24,7 @@
 package org.eolang.opeo.ast;
 
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -59,7 +60,7 @@ final class NewAddressTest {
         MatcherAssert.assertThat(
             "We expect, that new address will be successfully converted to XMIR",
             new Xembler(new NewAddress(NewAddressTest.TYPE).toXmir()).xml(),
-            Matchers.equalTo(NewAddressTest.XML)
+            new SameXml(NewAddressTest.XML)
         );
     }
 

--- a/src/test/java/org/eolang/opeo/ast/OpcodeTest.java
+++ b/src/test/java/org/eolang/opeo/ast/OpcodeTest.java
@@ -23,8 +23,8 @@
  */
 package org.eolang.opeo.ast;
 
-import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -64,10 +64,8 @@ final class OpcodeTest {
         Opcode.disableCounting();
         MatcherAssert.assertThat(
             String.format("We expect the following XML to be generated: %s", OpcodeTest.XMIR),
-            new XMLDocument(
-                new Xembler(new Opcode(Opcodes.LDC, "hello").toXmir()).xmlQuietly()
-            ),
-            Matchers.equalTo(new XMLDocument(OpcodeTest.XMIR))
+            new Xembler(new Opcode(Opcodes.LDC, "hello").toXmir()).xmlQuietly(),
+            new SameXml(OpcodeTest.XMIR)
         );
     }
 }

--- a/src/test/java/org/eolang/opeo/ast/SuperTest.java
+++ b/src/test/java/org/eolang/opeo/ast/SuperTest.java
@@ -26,6 +26,7 @@ package org.eolang.opeo.ast;
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.HexData;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -71,8 +72,8 @@ final class SuperTest {
                 "Can't convert 'super' statement to XMIR, result is wrong: %n%s%n",
                 xmir
             ),
-            new XMLDocument(xmir),
-            Matchers.equalTo(new XMLDocument(SuperTest.XMIR))
+            xmir,
+            new SameXml(SuperTest.XMIR)
         );
     }
 

--- a/src/test/java/org/eolang/opeo/ast/SuperTest.java
+++ b/src/test/java/org/eolang/opeo/ast/SuperTest.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.opeo.ast;
 
-import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.HexData;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.SameXml;

--- a/src/test/java/org/eolang/opeo/ast/ThisTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ThisTest.java
@@ -23,8 +23,8 @@
  */
 package org.eolang.opeo.ast;
 
-import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -52,8 +52,8 @@ final class ThisTest {
         final String xml = new Xembler(new This().toXmir()).xml();
         MatcherAssert.assertThat(
             String.format("Can't convert to correct XMIR, actual result is : %n%s%n", xml),
-            new XMLDocument(xml),
-            Matchers.equalTo(new XMLDocument(ThisTest.XMIR))
+            xml,
+            new SameXml(ThisTest.XMIR)
         );
     }
 

--- a/src/test/java/org/eolang/opeo/ast/VariableAssignmentTest.java
+++ b/src/test/java/org/eolang/opeo/ast/VariableAssignmentTest.java
@@ -25,6 +25,7 @@ package org.eolang.opeo.ast;
 
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -91,8 +92,8 @@ final class VariableAssignmentTest {
                 "We expect the XMIR to be correct, but it's not:%n%s%n",
                 xml
             ),
-            new XMLDocument(xml),
-            Matchers.equalTo(new XMLDocument(VariableAssignmentTest.XMIR))
+            xml,
+            new SameXml(VariableAssignmentTest.XMIR)
         );
     }
 }

--- a/src/test/java/org/eolang/opeo/ast/VariableAssignmentTest.java
+++ b/src/test/java/org/eolang/opeo/ast/VariableAssignmentTest.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.opeo.ast;
 
-import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.SameXml;
 import org.hamcrest.MatcherAssert;

--- a/src/test/java/org/eolang/opeo/compilation/DefaultCompilerTest.java
+++ b/src/test/java/org/eolang/opeo/compilation/DefaultCompilerTest.java
@@ -23,11 +23,13 @@
  */
 package org.eolang.opeo.compilation;
 
+import com.jcabi.xml.XMLDocument;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.io.ResourceOf;
+import org.eolang.opeo.SameXml;
 import org.eolang.opeo.ast.Opcode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -78,8 +80,8 @@ final class DefaultCompilerTest {
         );
         MatcherAssert.assertThat(
             "The compiled file is not equal to the original, but should. This is because Bar.xmir is already a low-level xmir",
-            new BytesOf(output).asBytes(),
-            Matchers.equalTo(before)
+            new XMLDocument(output).toString(),
+            new SameXml(new XMLDocument(before))
         );
     }
 

--- a/src/test/java/org/eolang/opeo/compilation/HasInstructions.java
+++ b/src/test/java/org/eolang/opeo/compilation/HasInstructions.java
@@ -32,6 +32,7 @@ import java.util.stream.IntStream;
 import org.eolang.jeo.representation.directives.DirectivesData;
 import org.eolang.jeo.representation.xmir.HexString;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.eolang.opeo.ast.OpcodeName;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
@@ -164,7 +165,7 @@ public final class HasInstructions extends TypeSafeMatcher<List<XmlNode>> {
                         new DirectivesData(instruction.operands.get(operindex))
                     ).xmlQuietly()
                 );
-                if (!operand.equals(expected)) {
+                if (!new SameXml(expected.toString()).matchesSafely(operand.toString())) {
                     this.warnings.add(
                         String.format(
                             "Bytecode instruction at %d index should have opcode with operands %s but got %s instead, ('%s' != '%s')",

--- a/src/test/java/org/eolang/opeo/compilation/JeoCompilerTest.java
+++ b/src/test/java/org/eolang/opeo/compilation/JeoCompilerTest.java
@@ -30,7 +30,6 @@ import org.cactoos.text.TextOf;
 import org.eolang.opeo.SameXml;
 import org.eolang.opeo.ast.Opcode;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/src/test/java/org/eolang/opeo/compilation/JeoCompilerTest.java
+++ b/src/test/java/org/eolang/opeo/compilation/JeoCompilerTest.java
@@ -27,6 +27,7 @@ import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.text.TextOf;
+import org.eolang.opeo.SameXml;
 import org.eolang.opeo.ast.Opcode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -47,8 +48,8 @@ final class JeoCompilerTest {
         );
         MatcherAssert.assertThat(
             "The compiled program is not equal to the expected one, but should since we provided already compiled program",
-            new JeoCompiler(expected).compile(),
-            Matchers.equalTo(expected)
+            new JeoCompiler(expected).compile().toString(),
+            new SameXml(expected)
         );
     }
 }

--- a/src/test/java/org/eolang/opeo/compilation/XmirParserTest.java
+++ b/src/test/java/org/eolang/opeo/compilation/XmirParserTest.java
@@ -26,6 +26,7 @@ package org.eolang.opeo.compilation;
 import java.util.Collections;
 import java.util.List;
 import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
 import org.eolang.opeo.ast.Add;
 import org.eolang.opeo.ast.Attributes;
 import org.eolang.opeo.ast.Field;
@@ -174,8 +175,8 @@ final class XmirParserTest {
         );
         MatcherAssert.assertThat(
             "We expect to retrieve exactly 1 opcode INVOKEDYNAMIC (without changes), but got something else instead",
-            new XmirParser(Collections.singletonList(node)).toJeoNodes().get(0),
-            Matchers.equalTo(node)
+            new XmirParser(Collections.singletonList(node)).toJeoNodes().get(0).toString(),
+            new SameXml(node.toString())
         );
     }
 }

--- a/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.eolang.jeo.representation.xmir.AllLabels;
 import org.eolang.opeo.LabelInstruction;
 import org.eolang.opeo.OpcodeInstruction;
+import org.eolang.opeo.SameXml;
 import org.eolang.opeo.ast.Add;
 import org.eolang.opeo.ast.ArrayConstructor;
 import org.eolang.opeo.ast.AstNode;
@@ -254,7 +255,7 @@ final class DecompilerMachineTest {
                         new OpcodeInstruction(Opcodes.ANEWARRAY, type)
                     )
             ).xml(),
-            Matchers.equalTo(
+            new SameXml(
                 new Xembler(
                     new Root(
                         new ArrayConstructor(
@@ -283,7 +284,7 @@ final class DecompilerMachineTest {
                         new OpcodeInstruction(Opcodes.AASTORE)
                     )
             ).xml(),
-            Matchers.equalTo(
+            new SameXml(
                 new Xembler(
                     new Root(
                         new StoreArray(
@@ -470,7 +471,7 @@ final class DecompilerMachineTest {
                 final String xpected = new Xembler(this.expected.toXmir()).xml();
                 this.actual.set(xactual);
                 this.exp.set(xpected);
-                return xactual.equals(xpected);
+                return new SameXml(xpected).matchesSafely(xactual);
             } catch (final ImpossibleModificationException exception) {
                 throw new IllegalStateException(
                     String.format(

--- a/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
@@ -50,7 +50,6 @@ import org.eolang.opeo.ast.This;
 import org.eolang.opeo.ast.VariableAssignment;
 import org.hamcrest.Description;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/src/test/resources/xmir/compiled/AgentBuilder$RedefinitionStrategy$Collector.xmir
+++ b/src/test/resources/xmir/compiled/AgentBuilder$RedefinitionStrategy$Collector.xmir
@@ -718,21 +718,25 @@
                   <o base="label" data="bytes" name="start">63 63 30 31 38 32 34 61 2D 30 39 39 65 2D 34 33 36 34 2D 39 31 64 39 2D 30 66 36 36 65 35 35 37 36 30 33 36</o>
                   <o base="label" data="bytes" name="end">65 30 32 35 39 39 31 36 2D 36 64 36 31 2D 34 37 36 61 2D 38 61 32 66 2D 36 33 61 65 30 66 65 66 34 30 66 33</o>
                   <o base="label" data="bytes" name="handler">62 30 34 62 36 39 33 65 2D 32 37 64 61 2D 34 37 66 36 2D 38 36 30 63 2D 64 31 38 35 33 63 30 34 30 64 31 32</o>
+                  <o base="nop"/>
                </o>
                <o base="trycatch">
                   <o base="label" data="bytes" name="start">62 30 34 62 36 39 33 65 2D 32 37 64 61 2D 34 37 66 36 2D 38 36 30 63 2D 64 31 38 35 33 63 30 34 30 64 31 32</o>
                   <o base="label" data="bytes" name="end">31 39 35 61 65 66 61 39 2D 64 63 62 31 2D 34 64 36 36 2D 62 39 36 34 2D 31 36 63 36 66 36 35 33 34 64 35 66</o>
                   <o base="label" data="bytes" name="handler">62 30 34 62 36 39 33 65 2D 32 37 64 61 2D 34 37 66 36 2D 38 36 30 63 2D 64 31 38 35 33 63 30 34 30 64 31 32</o>
+                  <o base="nop"/>
                </o>
                <o base="trycatch">
                   <o base="label" data="bytes" name="start">36 30 39 61 33 34 35 38 2D 61 32 35 35 2D 34 31 62 34 2D 38 33 62 31 2D 34 62 66 64 39 36 38 37 31 30 66 65</o>
                   <o base="label" data="bytes" name="end">35 61 33 65 36 37 65 37 2D 39 34 39 31 2D 34 36 64 38 2D 38 63 33 34 2D 39 30 35 61 32 65 32 32 32 66 35 62</o>
                   <o base="label" data="bytes" name="handler">39 35 30 65 63 61 62 61 2D 37 33 63 38 2D 34 33 36 61 2D 38 33 39 65 2D 31 39 61 38 34 30 66 64 62 30 34 38</o>
+                  <o base="nop"/>
                </o>
                <o base="trycatch">
                   <o base="label" data="bytes" name="start">39 35 30 65 63 61 62 61 2D 37 33 63 38 2D 34 33 36 61 2D 38 33 39 65 2D 31 39 61 38 34 30 66 64 62 30 34 38</o>
                   <o base="label" data="bytes" name="end">30 33 37 31 64 66 39 35 2D 34 64 61 33 2D 34 32 32 31 2D 62 30 61 62 2D 33 39 66 31 39 30 32 30 66 32 31 62</o>
                   <o base="label" data="bytes" name="handler">39 35 30 65 63 61 62 61 2D 37 33 63 38 2D 34 33 36 61 2D 38 33 39 65 2D 31 39 61 38 34 30 66 64 62 30 34 38</o>
+                  <o base="nop"/>
                </o>
                <o base="trycatch">
                   <o base="label" data="bytes" name="start">63 63 30 31 38 32 34 61 2D 30 39 39 65 2D 34 33 36 34 2D 39 31 64 39 2D 30 66 36 36 65 35 35 37 36 30 33 36</o>


### PR DESCRIPTION
In this PR I added printing PHI expressions for all integration tests except the `spring-fat` integration test.

This changes also revealed the problem with XMIR comparision. I copied `SameXml` class from `jeo-maven-plugin` to compare different XML files smartly.
It would be better to move this class into a separate repository or library which we can use across all the projects.

Closes: #317

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update versions, improve constructor in `Factorial.java`, and replace XMLDocument with SameXml for XMIR comparisons.

### Detailed summary
- Updated `jeo-maven-plugin` version to `0.5.0`
- Improved constructor in `Factorial.java`
- Replaced `XMLDocument` with `SameXml` for XMIR comparisons

> The following files were skipped due to too many changes: `src/test/java/org/eolang/opeo/ast/LabeledTest.java`, `src/test/java/org/eolang/opeo/ast/ClassFieldTest.java`, `src/test/java/org/eolang/opeo/ast/IfTest.java`, `src/test/java/it/JeoAndOpeoTest.java`, `src/test/java/org/eolang/opeo/compilation/DefaultCompilerTest.java`, `src/test/java/org/eolang/opeo/ast/InvocationTest.java`, `src/test/java/org/eolang/opeo/ast/FieldTest.java`, `src/test/java/org/eolang/opeo/ast/LabelTest.java`, `src/it/staticize/pom.xml`, `src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java`, `src/test/java/org/eolang/opeo/ast/ConstructorTest.java`, `src/main/java/org/eolang/opeo/SelectiveDecompiler.java`, `src/test/resources/xmir/compiled/AgentBuilder$RedefinitionStrategy$Collector.xmir`, `src/it/decompile-compile/target/generated-sources/jeo-xmir/org/eolang/jeo/TypeWriter$Default$ForInlining$WithFullProcessing$InitializationHandler$Appending$WithoutDrain.xmir`, `src/test/java/org/eolang/opeo/SameXml.java`, `src/it/decompile-compile/target/generated-sources/jeo-xmir/org/eolang/jeo/BeanMethod$NonOverridableMethodError.xmir`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->