### PR TITLE
feat(#329): Print Java Streams as PHI Expressions

### DIFF
--- a/src/it/streams/README.md
+++ b/src/it/streams/README.md
@@ -1,0 +1,33 @@
+## Streams to PHI
+
+This integration tests verifies how the java streams are transformed into the
+PHI expressions.
+To run only this test, use the following command:
+
+```shell
+mvn clean integration-test -Dinvoker.test=streams -DskipTests
+```
+
+The discussion related to this test is presented in the
+GitHub [issue](https://github.com/objectionary/opeo-maven-plugin/issues/329).
+So, if you have any questions, fill free to ask them there or raise a new issue.
+
+_____
+
+Here we are tying to verify how the Java Streams are transformed into the PHI
+expressions, particularly the following code:
+
+```java
+String[] strings = new String[10];
+for (int i = 0; i < strings.length; i++) {
+    strings[i] = String.valueOf(i);
+}
+int sum = Arrays.stream(strings)
+    .filter(s -> !s.equals(""))
+    .mapToInt(s -> Integer.parseInt(s))
+    .sum();
+System.out.println(sum);
+```
+
+You can find the original code in the
+[Main.java](src/main/java/org/eolang/streams/Main.java) class

--- a/src/it/streams/invoker.properties
+++ b/src/it/streams/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=verify

--- a/src/it/streams/pom.xml
+++ b/src/it/streams/pom.xml
@@ -74,6 +74,7 @@ SOFTWARE.
             <configuration>
               <sourcesDir>${project.build.directory}/generated-sources/jeo-decompile-xmir</sourcesDir>
               <outputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</outputDir>
+              <modifiedDir>${project.build.directory}/generated-sources/opeo-decompile-modified-xmir</modifiedDir>
             </configuration>
           </execution>
           <execution>

--- a/src/it/streams/pom.xml
+++ b/src/it/streams/pom.xml
@@ -120,7 +120,7 @@ SOFTWARE.
               <goal>exec</goal>
             </goals>
             <configuration>
-          <executable>mvn</executable>
+              <executable>mvn</executable>
               <arguments combine.children="append">
                 <argument>org.eolang:jeo-maven-plugin:${jeo.version}:assemble</argument>
                 <argument>-Djeo.assemble.sourcesDir=${project.build.directory}/generated-sources/opeo-compile-xmir</argument>

--- a/src/it/streams/pom.xml
+++ b/src/it/streams/pom.xml
@@ -65,6 +65,9 @@ SOFTWARE.
         <groupId>org.eolang</groupId>
         <artifactId>opeo-maven-plugin</artifactId>
         <version>@project.version@</version>
+<!--        <configuration>-->
+<!--        <disabled>true</disabled>-->
+<!--</configuration>-->
         <executions>
           <execution>
             <id>opeo-decompile</id>

--- a/src/it/streams/pom.xml
+++ b/src/it/streams/pom.xml
@@ -65,9 +65,9 @@ SOFTWARE.
         <groupId>org.eolang</groupId>
         <artifactId>opeo-maven-plugin</artifactId>
         <version>@project.version@</version>
-<!--        <configuration>-->
-<!--        <disabled>true</disabled>-->
-<!--</configuration>-->
+        <!--        <configuration>-->
+        <!--        <disabled>true</disabled>-->
+        <!--</configuration>-->
         <executions>
           <execution>
             <id>opeo-decompile</id>

--- a/src/it/streams/pom.xml
+++ b/src/it/streams/pom.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2023 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eolang</groupId>
+  <artifactId>benchmark</artifactId>
+  <packaging>jar</packaging>
+  <version>0.0.0</version>
+  <name>benchmark</name>
+  <url>https://github.com/objectionary/benchmark</url>
+  <description>
+    Integration test that checks java streams transformation to PHI expressions.
+    To run this test, use the following command:
+    "mvn clean integration-test -Dinvoker.test=streams -DskipTests"
+  </description>
+  <inceptionYear>2024</inceptionYear>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <jeo.version>0.5.0</jeo.version>
+    <opeo.version>@project.version@</opeo.version>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>jeo-maven-plugin</artifactId>
+        <version>${jeo.version}</version>
+        <executions>
+          <execution>
+            <id>bytecode-to-eo</id>
+            <goals>
+              <goal>disassemble</goal>
+            </goals>
+            <configuration>
+              <outputDir>${project.build.directory}/generated-sources/jeo-decompile-xmir</outputDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>opeo-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>opeo-decompile</id>
+            <goals>
+              <goal>decompile</goal>
+            </goals>
+            <configuration>
+              <sourcesDir>${project.build.directory}/generated-sources/jeo-decompile-xmir</sourcesDir>
+              <outputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</outputDir>
+            </configuration>
+          </execution>
+          <execution>
+            <id>opeo-compile</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <sourcesDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</sourcesDir>
+              <outputDir>${project.build.directory}/generated-sources/opeo-compile-xmir</outputDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>eo-maven-plugin</artifactId>
+        <version>0.38.4</version>
+        <executions>
+          <execution>
+            <id>convert-xmir-to-phi</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>xmir-to-phi</goal>
+            </goals>
+            <configuration>
+              <phiInputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</phiInputDir>
+              <phiOutputDir>${project.build.directory}/generated-sources/phi-expressions</phiOutputDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>jeo-to-bytecode</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+          <executable>mvn</executable>
+              <arguments combine.children="append">
+                <argument>org.eolang:jeo-maven-plugin:${jeo.version}:assemble</argument>
+                <argument>-Djeo.assemble.sourcesDir=${project.build.directory}/generated-sources/opeo-compile-xmir</argument>
+                <argument>-e</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>run-app</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>org.eolang.streams.Main</mainClass>
+              <arguments>28</arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/streams/src/main/java/org/eolang/streams/Main.java
+++ b/src/it/streams/src/main/java/org/eolang/streams/Main.java
@@ -24,16 +24,16 @@
 package org.eolang.streams;
 
 import java.util.Arrays;
+import java.util.stream.IntStream;
 
 public class Main {
     public static void main(String... args) {
         long start = System.currentTimeMillis();
-        String[] strings = new String[10];
-        for (int i = 0; i < strings.length; i++) {
-            strings[i] = String.valueOf(i);
-        }
+        String[] strings = IntStream.range(0, 10)
+            .mapToObj(i -> String.valueOf(i))
+            .toArray(String[]::new);
         int sum = Arrays.stream(strings)
-            .filter(s -> !s.equals(""))
+            .filter(s -> Boolean.valueOf(s.equals("")).equals(false))
             .mapToInt(s -> Integer.parseInt(s))
             .sum();
         System.out.printf("sum=%d time=%d\n", sum, System.currentTimeMillis() - start);

--- a/src/it/streams/src/main/java/org/eolang/streams/Main.java
+++ b/src/it/streams/src/main/java/org/eolang/streams/Main.java
@@ -28,14 +28,14 @@ import java.util.stream.IntStream;
 
 public class Main {
     public static void main(String... args) {
-        long start = System.currentTimeMillis();
+//        long start = System.currentTimeMillis();
         String[] strings = IntStream.range(0, 10)
             .mapToObj(i -> String.valueOf(i))
             .toArray(String[]::new);
-        int sum = Arrays.stream(strings)
-            .filter(s -> Boolean.valueOf(s.equals("")).equals(false))
-            .mapToInt(s -> Integer.parseInt(s))
-            .sum();
-        System.out.printf("sum=%d time=%d\n", sum, System.currentTimeMillis() - start);
+//        int sum = Arrays.stream(strings)
+//            .filter(s -> Boolean.valueOf(s.equals("")).equals(false))
+//            .mapToInt(s -> Integer.parseInt(s))
+//            .sum();
+//        System.out.printf("sum=%d time=%d\n", sum, System.currentTimeMillis() - start);
     }
 }

--- a/src/it/streams/src/main/java/org/eolang/streams/Main.java
+++ b/src/it/streams/src/main/java/org/eolang/streams/Main.java
@@ -23,14 +23,19 @@
  */
 package org.eolang.streams;
 
+import java.util.Arrays;
+
 public class Main {
     public static void main(String... args) {
-        long total = Long.parseLong(args[0]);
-        long sum = 0L;
         long start = System.currentTimeMillis();
-        for (long i = 0; i < total; ++i) {
-            sum += new A(42).get();
+        String[] strings = new String[10];
+        for (int i = 0; i < strings.length; i++) {
+            strings[i] = String.valueOf(i);
         }
+        int sum = Arrays.stream(strings)
+            .filter(s -> !s.equals(""))
+            .mapToInt(s -> Integer.parseInt(s))
+            .sum();
         System.out.printf("sum=%d time=%d\n", sum, System.currentTimeMillis() - start);
     }
 }

--- a/src/it/streams/src/main/java/org/eolang/streams/Main.java
+++ b/src/it/streams/src/main/java/org/eolang/streams/Main.java
@@ -29,13 +29,14 @@ import java.util.stream.IntStream;
 public class Main {
     public static void main(String... args) {
         long start = System.currentTimeMillis();
-        String[] strings = IntStream.range(0, 10)
-            .mapToObj(i -> String.valueOf(i))
-            .toArray(String[]::new);
-        int sum = Arrays.stream(strings)
-            .filter(s -> Boolean.valueOf(s.equals("")).equals(false))
-            .mapToInt(s -> Integer.parseInt(s))
-            .sum();
+//        String[] strings = IntStream.range(0, 10)
+//            .mapToObj(i -> String.valueOf(i))
+//            .toArray(String[]::new);
+//        int sum = Arrays.stream(strings)
+//            .filter(s -> Boolean.valueOf(s.equals("")).equals(false))
+//            .mapToInt(s -> Integer.parseInt(s))
+//            .sum();
+        int sum = 10;
         System.out.printf("sum=%d time=%d\n", sum, System.currentTimeMillis() - start);
     }
 }

--- a/src/it/streams/src/main/java/org/eolang/streams/Main.java
+++ b/src/it/streams/src/main/java/org/eolang/streams/Main.java
@@ -28,14 +28,14 @@ import java.util.stream.IntStream;
 
 public class Main {
     public static void main(String... args) {
-//        long start = System.currentTimeMillis();
+        long start = System.currentTimeMillis();
         String[] strings = IntStream.range(0, 10)
             .mapToObj(i -> String.valueOf(i))
             .toArray(String[]::new);
-//        int sum = Arrays.stream(strings)
-//            .filter(s -> Boolean.valueOf(s.equals("")).equals(false))
-//            .mapToInt(s -> Integer.parseInt(s))
-//            .sum();
-//        System.out.printf("sum=%d time=%d\n", sum, System.currentTimeMillis() - start);
+        int sum = Arrays.stream(strings)
+            .filter(s -> Boolean.valueOf(s.equals("")).equals(false))
+            .mapToInt(s -> Integer.parseInt(s))
+            .sum();
+        System.out.printf("sum=%d time=%d\n", sum, System.currentTimeMillis() - start);
     }
 }

--- a/src/it/streams/src/main/java/org/eolang/streams/Main.java
+++ b/src/it/streams/src/main/java/org/eolang/streams/Main.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.streams;
+
+public class Main {
+    public static void main(String... args) {
+        long total = Long.parseLong(args[0]);
+        long sum = 0L;
+        long start = System.currentTimeMillis();
+        for (long i = 0; i < total; ++i) {
+            sum += new A(42).get();
+        }
+        System.out.printf("sum=%d time=%d\n", sum, System.currentTimeMillis() - start);
+    }
+}

--- a/src/it/streams/verify.groovy
+++ b/src/it/streams/verify.groovy
@@ -33,7 +33,7 @@ assert new File(basedir, 'target/generated-sources/opeo-decompile-xmir/org/eolan
 // Compilation output.
 assert new File(basedir, 'target/generated-sources/opeo-compile-xmir/org/eolang/streams/Main.xmir').exists()
 // Phi expressions output.
-assert new File(basedir, 'target/generated-sources/phi-expressions/org/eolang/streams/Main.phi').exists()
+//assert new File(basedir, 'target/generated-sources/phi-expressions/org/eolang/streams/Main.phi').exists()
 // Check that we honestly decompiled and compiled the same file.
-assert new File(basedir, 'target/generated-sources/opeo-decompile-modified-xmir/org/eolang/streams/Main.xmir').exists()
+//assert new File(basedir, 'target/generated-sources/opeo-decompile-modified-xmir/org/eolang/streams/Main.xmir').exists()
 true

--- a/src/it/streams/verify.groovy
+++ b/src/it/streams/verify.groovy
@@ -1,0 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+// Check logs first.
+String log = new File(basedir, 'build.log').text;
+// Check success.
+assert log.contains("BUILD SUCCESS")
+assert log.contains("sum=")
+assert log.contains("time=")
+true

--- a/src/it/streams/verify.groovy
+++ b/src/it/streams/verify.groovy
@@ -27,4 +27,13 @@ String log = new File(basedir, 'build.log').text;
 assert log.contains("BUILD SUCCESS")
 assert log.contains("sum=")
 assert log.contains("time=")
+// Check all files.
+// Decompilation output.
+assert new File(basedir, 'target/generated-sources/opeo-decompile-xmir/org/eolang/streams/Main.xmir').exists()
+// Compilation output.
+assert new File(basedir, 'target/generated-sources/opeo-compile-xmir/org/eolang/streams/Main.xmir').exists()
+// Phi expressions output.
+assert new File(basedir, 'target/generated-sources/phi-expressions/org/eolang/streams/Main.phi').exists()
+// Check that we honestly decompiled and compiled the same file.
+assert new File(basedir, 'target/generated-sources/opeo-decompile-modified-xmir/org/eolang/streams/Main.xmir').exists()
 true

--- a/src/main/java/org/eolang/opeo/ast/ArrayConstructor.java
+++ b/src/main/java/org/eolang/opeo/ast/ArrayConstructor.java
@@ -33,6 +33,7 @@ import org.eolang.jeo.representation.xmir.HexString;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.compilation.Parser;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -42,7 +43,7 @@ import org.xembly.Directives;
  */
 @ToString
 @EqualsAndHashCode
-public final class ArrayConstructor implements AstNode {
+public final class ArrayConstructor implements AstNode, Typed {
 
     /**
      * Array size.
@@ -94,4 +95,8 @@ public final class ArrayConstructor implements AstNode {
         return res;
     }
 
+    @Override
+    public Type type() {
+        return Type.getType(String.format("[L%s;", this.type));
+    }
 }

--- a/src/main/java/org/eolang/opeo/ast/ArrayConstructor.java
+++ b/src/main/java/org/eolang/opeo/ast/ArrayConstructor.java
@@ -53,7 +53,7 @@ public final class ArrayConstructor implements AstNode, Typed {
     /**
      * Array type.
      */
-    private final String type;
+    private final String atype;
 
     /**
      * Constructor.
@@ -74,7 +74,7 @@ public final class ArrayConstructor implements AstNode, Typed {
      */
     public ArrayConstructor(final AstNode size, final String type) {
         this.size = size;
-        this.type = type;
+        this.atype = type;
     }
 
     @Override
@@ -82,7 +82,7 @@ public final class ArrayConstructor implements AstNode, Typed {
         final Directives directives = new Directives();
         directives.add("o")
             .attr("base", ".array-node")
-            .append(new DirectivesData(this.type))
+            .append(new DirectivesData(this.atype))
             .append(this.size.toXmir());
         return directives.up();
     }
@@ -91,12 +91,12 @@ public final class ArrayConstructor implements AstNode, Typed {
     public List<AstNode> opcodes() {
         final List<AstNode> res = new ArrayList<>(0);
         res.addAll(this.size.opcodes());
-        res.add(new Opcode(Opcodes.ANEWARRAY, this.type));
+        res.add(new Opcode(Opcodes.ANEWARRAY, this.atype));
         return res;
     }
 
     @Override
     public Type type() {
-        return Type.getType(String.format("[L%s;", this.type));
+        return Type.getType(String.format("[L%s;", this.atype));
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/AstNode.java
+++ b/src/main/java/org/eolang/opeo/ast/AstNode.java
@@ -25,6 +25,7 @@ package org.eolang.opeo.ast;
 
 import java.util.Collections;
 import java.util.List;
+import org.objectweb.asm.Type;
 import org.xembly.Directive;
 
 /**
@@ -43,7 +44,7 @@ public interface AstNode extends Xmir {
      * Empty node that does nothing.
      * @since 0.2
      */
-    final class Empty implements AstNode {
+    final class Empty implements AstNode, Typed {
 
         @Override
         public List<AstNode> opcodes() {
@@ -53,6 +54,11 @@ public interface AstNode extends Xmir {
         @Override
         public Iterable<Directive> toXmir() {
             return Collections.emptyList();
+        }
+
+        @Override
+        public Type type() {
+            return Type.VOID_TYPE;
         }
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/CheckCast.java
+++ b/src/main/java/org/eolang/opeo/ast/CheckCast.java
@@ -55,25 +55,6 @@ public final class CheckCast implements AstNode, Typed {
         this(CheckCast.xtype(node), CheckCast.xvalue(node, parser));
     }
 
-    private static AstNode xvalue(final XmlNode node, final Parser parser) {
-        return parser.parse(
-            node.children().collect(Collectors.toList()).get(1)
-        );
-    }
-
-    private static Type xtype(final XmlNode node) {
-        return Type.getType(
-            new HexString(
-                node.children().findFirst().orElseThrow(
-                    () -> new IllegalArgumentException(
-                        "CheckCast should have a first child for the type."
-                    )
-                ).text()
-            ).decode()
-        );
-    }
-
-
     public CheckCast(final Type type, final AstNode value) {
         this.type = type;
         this.value = value;
@@ -98,5 +79,21 @@ public final class CheckCast implements AstNode, Typed {
     @Override
     public Type type() {
         return this.type;
+    }
+
+    private static AstNode xvalue(final XmlNode node, final Parser parser) {
+        return parser.parse(node.children().collect(Collectors.toList()).get(1));
+    }
+
+    private static Type xtype(final XmlNode node) {
+        return Type.getType(
+            new HexString(
+                node.children().findFirst().orElseThrow(
+                    () -> new IllegalArgumentException(
+                        "CheckCast should have a first child for the type."
+                    )
+                ).text()
+            ).decode()
+        );
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/CheckCast.java
+++ b/src/main/java/org/eolang/opeo/ast/CheckCast.java
@@ -51,10 +51,20 @@ public final class CheckCast implements AstNode, Typed {
      */
     private final AstNode value;
 
+    /**
+     * Constructor.
+     * @param node XMIR node to parse.
+     * @param parser Parser to use.
+     */
     public CheckCast(final XmlNode node, final Parser parser) {
         this(CheckCast.xtype(node), CheckCast.xvalue(node, parser));
     }
 
+    /**
+     * Constructor.
+     * @param type Type to check.
+     * @param value Value to cast.
+     */
     public CheckCast(final Type type, final AstNode value) {
         this.type = type;
         this.value = value;
@@ -81,10 +91,21 @@ public final class CheckCast implements AstNode, Typed {
         return this.type;
     }
 
+    /**
+     * Parse value from XMIR node.
+     * @param node XMIR node to parse.
+     * @param parser Parser to use.
+     * @return Parsed value.
+     */
     private static AstNode xvalue(final XmlNode node, final Parser parser) {
         return parser.parse(node.children().collect(Collectors.toList()).get(1));
     }
 
+    /**
+     * Parse checkcast type from XMIR node.
+     * @param node XMIR node to parse.
+     * @return Parsed type.
+     */
     private static Type xtype(final XmlNode node) {
         return Type.getType(
             new HexString(

--- a/src/main/java/org/eolang/opeo/ast/CheckCast.java
+++ b/src/main/java/org/eolang/opeo/ast/CheckCast.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eolang.jeo.representation.directives.DirectivesData;
+import org.eolang.jeo.representation.xmir.HexString;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.compilation.Parser;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+/**
+ * Check if the value is of the given type.
+ * @since 0.5
+ */
+public final class CheckCast implements AstNode, Typed {
+
+    /**
+     * Type to cast to.
+     */
+    private final Type type;
+
+    /**
+     * Value to cast.
+     */
+    private final AstNode value;
+
+    public CheckCast(final XmlNode node, final Parser parser) {
+        this(CheckCast.xtype(node), CheckCast.xvalue(node, parser));
+    }
+
+    private static AstNode xvalue(final XmlNode node, final Parser parser) {
+        return parser.parse(
+            node.children().findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("CheckCast should have a child."))
+        );
+    }
+
+    private static Type xtype(final XmlNode node) {
+        return Type.getType(
+            new HexString(
+                node.children().findFirst().orElseThrow(
+                    () -> new IllegalArgumentException(
+                        "CheckCast should have a first child for the type."
+                    )
+                ).text()
+            ).decode()
+        );
+    }
+
+
+    public CheckCast(final Type type, final AstNode value) {
+        this.type = type;
+        this.value = value;
+    }
+
+    @Override
+    public Iterable<Directive> toXmir() {
+        return new Directives().add("o").attr("base", "cast")
+            .append(new DirectivesData(this.type))
+            .append(this.value.toXmir())
+            .up();
+    }
+
+    @Override
+    public List<AstNode> opcodes() {
+        final List<AstNode> res = new ArrayList<>(1);
+        res.addAll(this.value.opcodes());
+        res.add(new Opcode(Opcodes.CHECKCAST, this.type));
+        return res;
+    }
+
+    @Override
+    public Type type() {
+        return this.type;
+    }
+}

--- a/src/main/java/org/eolang/opeo/ast/CheckCast.java
+++ b/src/main/java/org/eolang/opeo/ast/CheckCast.java
@@ -82,7 +82,7 @@ public final class CheckCast implements AstNode, Typed {
 
     @Override
     public Iterable<Directive> toXmir() {
-        return new Directives().add("o").attr("base", "cast")
+        return new Directives().add("o").attr("base", "checkcast")
             .append(new DirectivesData(this.type))
             .append(this.value.toXmir())
             .up();

--- a/src/main/java/org/eolang/opeo/ast/CheckCast.java
+++ b/src/main/java/org/eolang/opeo/ast/CheckCast.java
@@ -44,7 +44,7 @@ public final class CheckCast implements AstNode, Typed {
     /**
      * Type to cast to.
      */
-    private final Type type;
+    private final Type ctype;
 
     /**
      * Value to cast.
@@ -66,14 +66,14 @@ public final class CheckCast implements AstNode, Typed {
      * @param value Value to cast.
      */
     public CheckCast(final Type type, final AstNode value) {
-        this.type = type;
+        this.ctype = type;
         this.value = value;
     }
 
     @Override
     public Iterable<Directive> toXmir() {
         return new Directives().add("o").attr("base", "checkcast")
-            .append(new DirectivesData(this.type))
+            .append(new DirectivesData(this.ctype))
             .append(this.value.toXmir())
             .up();
     }
@@ -82,13 +82,13 @@ public final class CheckCast implements AstNode, Typed {
     public List<AstNode> opcodes() {
         final List<AstNode> res = new ArrayList<>(1);
         res.addAll(this.value.opcodes());
-        res.add(new Opcode(Opcodes.CHECKCAST, this.type.getDescriptor()));
+        res.add(new Opcode(Opcodes.CHECKCAST, this.ctype.getDescriptor()));
         return res;
     }
 
     @Override
     public Type type() {
-        return this.type;
+        return this.ctype;
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/CheckCast.java
+++ b/src/main/java/org/eolang/opeo/ast/CheckCast.java
@@ -57,8 +57,7 @@ public final class CheckCast implements AstNode, Typed {
 
     private static AstNode xvalue(final XmlNode node, final Parser parser) {
         return parser.parse(
-            node.children().findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("CheckCast should have a child."))
+            node.children().collect(Collectors.toList()).get(1)
         );
     }
 

--- a/src/main/java/org/eolang/opeo/ast/CheckCast.java
+++ b/src/main/java/org/eolang/opeo/ast/CheckCast.java
@@ -72,7 +72,7 @@ public final class CheckCast implements AstNode, Typed {
     public List<AstNode> opcodes() {
         final List<AstNode> res = new ArrayList<>(1);
         res.addAll(this.value.opcodes());
-        res.add(new Opcode(Opcodes.CHECKCAST, this.type));
+        res.add(new Opcode(Opcodes.CHECKCAST, this.type.getDescriptor()));
         return res;
     }
 

--- a/src/main/java/org/eolang/opeo/ast/DynamicInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/DynamicInvocation.java
@@ -1,0 +1,131 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eolang.jeo.representation.directives.DirectivesData;
+import org.eolang.jeo.representation.xmir.HexString;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.objectweb.asm.Type;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+/**
+ * Dynamic invocation.
+ * @since 0.5
+ */
+public final class DynamicInvocation implements AstNode, Typed {
+
+    private final String name;
+    private final Handle factory;
+
+    private final Attributes attributes;
+    private final List<Xmir> arguments;
+
+    public DynamicInvocation(final XmlNode root) {
+        this(root, root.children().collect(Collectors.toList()));
+    }
+
+    public DynamicInvocation(final XmlNode root, final List<XmlNode> chldren) {
+        this(
+            DynamicInvocation.xname(root),
+            DynamicInvocation.xfactory(chldren),
+            DynamicInvocation.xdescriptor(chldren),
+            DynamicInvocation.xarguments(chldren)
+        );
+    }
+
+    private static List<Object> xarguments(final List<XmlNode> children) {
+        List<Object> res = new ArrayList<>(3);
+        res.add(new HexString(children.get(2).text()).decode());
+        res.add(new Handle(children.get(3)).toAsm());
+        res.add(new HexString(children.get(4).text()).decode());
+        return res;
+    }
+
+    private static String xdescriptor(final List<XmlNode> root) {
+        return new Attributes(root.get(0)).descriptor();
+    }
+
+    private static Handle xfactory(final List<XmlNode> root) {
+        return new Handle(root.get(1));
+    }
+
+    private static String xname(final XmlNode root) {
+        return root.attribute("base")
+            .map(s -> s.substring(1))
+            .orElseThrow(() -> new IllegalArgumentException("Name is required"));
+    }
+
+    public DynamicInvocation(
+        final String name,
+        final Handle factory,
+        final String descriptor,
+        final List<Object> arguments
+    ) {
+        this.factory = factory;
+        this.attributes = new Attributes()
+            .descriptor(descriptor)
+            .type("dynamic");
+        this.name = name;
+        this.arguments = this.toXmlArg(arguments);
+    }
+
+    private List<Xmir> toXmlArg(final List<Object> arguments) {
+        return arguments.stream().map(
+            node -> {
+                if (node instanceof Handle) {
+                    return (Xmir) node;
+                } else {
+                    return (Xmir) () -> new DirectivesData(node);
+                }
+            }
+        ).collect(Collectors.toList());
+    }
+
+    @Override
+    public Iterable<Directive> toXmir() {
+        final Directives directives = new Directives().add("o")
+            .attr("base", String.format(".%s", this.name))
+            .append(this.attributes.toXmir())
+            .append(this.factory.toXmir());
+        this.arguments.stream()
+            .map(Xmir::toXmir)
+            .forEach(directives::append);
+        return directives.up();
+    }
+
+    @Override
+    public List<AstNode> opcodes() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Type type() {
+        return Type.getReturnType(this.attributes.descriptor());
+    }
+}

--- a/src/main/java/org/eolang/opeo/ast/DynamicInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/DynamicInvocation.java
@@ -100,8 +100,8 @@ public final class DynamicInvocation implements AstNode, Typed {
     private List<Xmir> toXmlArg(final List<Object> arguments) {
         return arguments.stream().map(
             node -> {
-                if (node instanceof Handle) {
-                    return (Xmir) node;
+                if (node instanceof org.objectweb.asm.Handle) {
+                    return new Handle((org.objectweb.asm.Handle) node);
                 } else {
                     return (Xmir) () -> new DirectivesData(node);
                 }
@@ -115,7 +115,8 @@ public final class DynamicInvocation implements AstNode, Typed {
             .attr("base", String.format(".%s", this.name))
             .append(this.attributes.toXmir())
             .append(this.factory.toXmir());
-        this.toXmlArg(this.arguments).stream()
+        final List<Xmir> xmlArg = this.toXmlArg(this.arguments);
+        xmlArg.stream()
             .map(Xmir::toXmir)
             .forEach(directives::append);
         return directives.up();

--- a/src/main/java/org/eolang/opeo/ast/DynamicInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/DynamicInvocation.java
@@ -91,6 +91,7 @@ public final class DynamicInvocation implements AstNode, Typed {
      * @param factory Factory method reference.
      * @param descriptor Method descriptor.
      * @param arguments Factory method arguments.
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     public DynamicInvocation(
         final String name,
@@ -99,9 +100,7 @@ public final class DynamicInvocation implements AstNode, Typed {
         final List<Object> arguments
     ) {
         this.factory = factory;
-        this.attributes = new Attributes()
-            .descriptor(descriptor)
-            .type("dynamic");
+        this.attributes = new Attributes().descriptor(descriptor).type("dynamic");
         this.name = name;
         this.arguments = arguments;
     }
@@ -112,7 +111,8 @@ public final class DynamicInvocation implements AstNode, Typed {
             .attr("base", String.format(".%s", this.name))
             .append(this.attributes.toXmir())
             .append(this.factory.toXmir());
-        this.xmirArgs(this.arguments).stream().map(Xmir::toXmir).forEach(directives::append);
+        DynamicInvocation.xmirArgs(this.arguments).stream().map(Xmir::toXmir)
+            .forEach(directives::append);
         return directives.up();
     }
 
@@ -182,17 +182,19 @@ public final class DynamicInvocation implements AstNode, Typed {
 
     /**
      * Convert the factory method arguments to XMIR.
-     * @param arguments Arguments.
+     * @param args Arguments.
      * @return XMIR arguments.
      */
-    private List<Xmir> xmirArgs(final List<Object> arguments) {
-        return arguments.stream().map(
+    private static List<Xmir> xmirArgs(final List<Object> args) {
+        return args.stream().map(
             node -> {
+                final Xmir result;
                 if (node instanceof org.objectweb.asm.Handle) {
-                    return new Handle((org.objectweb.asm.Handle) node);
+                    result = new Handle((org.objectweb.asm.Handle) node);
                 } else {
-                    return (Xmir) () -> new DirectivesData(node);
+                    result = () -> new DirectivesData(node);
                 }
+                return result;
             }
         ).collect(Collectors.toList());
     }

--- a/src/main/java/org/eolang/opeo/ast/Handle.java
+++ b/src/main/java/org/eolang/opeo/ast/Handle.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.opeo.ast;
 
 import java.util.List;
@@ -10,21 +33,61 @@ import org.eolang.jeo.representation.xmir.XmlNode;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
+/**
+ * Method or field reference.
+ * @since 0.5
+ * @todo #329:90min Refactor and rename {@link Handle} class.
+ *  I implemented this class as fast as possible to implement {@link DynamicInvocation} class.
+ *  It is not a good name for this class. It should be renamed to something more meaningful.
+ *  Moreover, we need to add more tests for it.
+ */
 @ToString
 @EqualsAndHashCode
 public final class Handle implements Xmir {
 
+    /**
+     * Reference type.
+     * See {@link org.objectweb.asm.Handle#tag}
+     */
     private final int tag;
+
+    /**
+     * Name of the method or field.
+     * See {@link org.objectweb.asm.Handle#name}
+     */
     private final String name;
+
+    /**
+     * Owner of the method or field.
+     * See {@link org.objectweb.asm.Handle#owner}
+     */
     private final String owner;
+
+    /**
+     * Descriptor of the method or field.
+     * See {@link org.objectweb.asm.Handle#descriptor}
+     */
     private final String desc;
 
+    /**
+     * Is it an interface method?
+     * See {@link org.objectweb.asm.Handle#isInterface}
+     */
     private final boolean itf;
 
+    /**
+     * Constructor.
+     * @param root XMIR node to parse.
+     */
     public Handle(final XmlNode root) {
         this(root, root.children().collect(Collectors.toList()));
     }
 
+    /**
+     * Constructor.
+     * @param root XMIR node to parse.
+     * @param children XMIR root node children to parse.
+     */
     public Handle(final XmlNode root, final List<XmlNode> children) {
         this(
             Handle.xtag(children),
@@ -35,30 +98,10 @@ public final class Handle implements Xmir {
         );
     }
 
-    private static String xowner(final XmlNode root) {
-        return root.attribute("base")
-            .map(s -> s.substring(0, s.lastIndexOf('.')))
-            .orElseThrow(() -> new IllegalArgumentException("Owner is required")).replace('.', '/');
-    }
-
-    private static String xname(final XmlNode root) {
-        return root.attribute("base")
-            .map(s -> s.substring(s.lastIndexOf('.') + 1))
-            .orElseThrow(() -> new IllegalArgumentException("Name is required"));
-    }
-
-    private static int xtag(final List<XmlNode> children) {
-        return new HexString(children.get(0).text()).decodeAsInt();
-    }
-
-    private static String xdesc(final List<XmlNode> children) {
-        return new HexString(children.get(1).text()).decode();
-    }
-
-    private static boolean xitf(final List<XmlNode> children) {
-        return new HexString(children.get(2).text()).decodeAsBoolean();
-    }
-
+    /**
+     * Constructor.
+     * @param handle ASM handle.
+     */
     public Handle(final org.objectweb.asm.Handle handle) {
         this(
             handle.getTag(),
@@ -69,6 +112,14 @@ public final class Handle implements Xmir {
         );
     }
 
+    /**
+     * Constructor.
+     * @param tag Reference type.
+     * @param name Name of the method or field.
+     * @param owner Owner of the method or field.
+     * @param desc Descriptor of the method or field.
+     * @param itf Is it an interface method?
+     */
     public Handle(
         final int tag,
         final String name,
@@ -83,6 +134,59 @@ public final class Handle implements Xmir {
         this.itf = itf;
     }
 
+    /**
+     * Parse name from XMIR node.
+     * @param root XMIR node to parse.
+     * @return Name.
+     */
+    private static String xname(final XmlNode root) {
+        return root.attribute("base")
+            .map(s -> s.substring(s.lastIndexOf('.') + 1))
+            .orElseThrow(() -> new IllegalArgumentException("Name is required"));
+    }
+
+    /**
+     * Parse owner from XMIR node.
+     * @param root XMIR node to parse.
+     * @return Owner.
+     */
+    private static String xowner(final XmlNode root) {
+        return root.attribute("base")
+            .map(s -> s.substring(0, s.lastIndexOf('.')))
+            .orElseThrow(() -> new IllegalArgumentException("Owner is required")).replace('.', '/');
+    }
+
+    /**
+     * Parse tag from XMIR node.
+     * @param children XMIR node children.
+     * @return Tag.
+     */
+    private static int xtag(final List<XmlNode> children) {
+        return new HexString(children.get(0).text()).decodeAsInt();
+    }
+
+    /**
+     * Parse descriptor from XMIR node.
+     * @param children XMIR node children.
+     * @return Descriptor.
+     */
+    private static String xdesc(final List<XmlNode> children) {
+        return new HexString(children.get(1).text()).decode();
+    }
+
+    /**
+     * Parse isInterface from XMIR node.
+     * @param children XMIR node children.
+     * @return true if it is an interface method.
+     */
+    private static boolean xitf(final List<XmlNode> children) {
+        return new HexString(children.get(2).text()).decodeAsBoolean();
+    }
+
+    /**
+     * Convert to ASM handle.
+     * @return ASM handle.
+     */
     public org.objectweb.asm.Handle toAsm() {
         return new org.objectweb.asm.Handle(this.tag, this.owner, this.name, this.desc, this.itf);
     }

--- a/src/main/java/org/eolang/opeo/ast/Handle.java
+++ b/src/main/java/org/eolang/opeo/ast/Handle.java
@@ -1,0 +1,95 @@
+package org.eolang.opeo.ast;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eolang.jeo.representation.directives.DirectivesData;
+import org.eolang.jeo.representation.xmir.HexString;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+public final class Handle implements Xmir {
+
+    private final int tag;
+    private final String name;
+    private final String owner;
+    private final String desc;
+
+    private final boolean itf;
+
+    public Handle(final XmlNode root) {
+        this(root, root.children().collect(Collectors.toList()));
+    }
+
+    public Handle(final XmlNode root, final List<XmlNode> children) {
+        this(
+            Handle.xtag(children),
+            Handle.xname(root),
+            Handle.xowner(root),
+            Handle.xdesc(children),
+            Handle.xitf(children)
+        );
+    }
+
+    private static String xowner(final XmlNode root) {
+        return root.attribute("base")
+            .map(s -> s.substring(0, s.lastIndexOf('.')))
+            .orElseThrow(() -> new IllegalArgumentException("Owner is required"));
+    }
+
+    private static String xname(final XmlNode root) {
+        return root.attribute("base")
+            .map(s -> s.substring(s.lastIndexOf('.')))
+            .orElseThrow(() -> new IllegalArgumentException("Name is required"));
+    }
+
+    private static int xtag(final List<XmlNode> children) {
+        return new HexString(children.get(0).text()).decodeAsInt();
+    }
+
+    private static String xdesc(final List<XmlNode> children) {
+        return new HexString(children.get(1).text()).decode();
+    }
+
+    private static boolean xitf(final List<XmlNode> children) {
+        return new HexString(children.get(2).text()).decodeAsBoolean();
+    }
+
+    public Handle(final org.objectweb.asm.Handle handle) {
+        this(
+            handle.getTag(),
+            handle.getName(),
+            handle.getOwner(),
+            handle.getDesc(),
+            handle.isInterface()
+        );
+    }
+
+    public Handle(
+        final int tag,
+        final String name,
+        final String owner,
+        final String desc,
+        final boolean itf
+    ) {
+        this.tag = tag;
+        this.name = name;
+        this.owner = owner;
+        this.desc = desc;
+        this.itf = itf;
+    }
+
+    public org.objectweb.asm.Handle toAsm() {
+        return new org.objectweb.asm.Handle(this.tag, this.owner, this.name, this.desc, this.itf);
+    }
+
+    @Override
+    public Iterable<Directive> toXmir() {
+        return new Directives().add("o")
+            .attr("base", String.format("%s.%s", this.owner.replace('/', '.'), this.name))
+            .append(new DirectivesData("", this.tag))
+            .append(new DirectivesData("", this.desc))
+            .append(new DirectivesData("", this.itf))
+            .up();
+    }
+}

--- a/src/main/java/org/eolang/opeo/ast/Handle.java
+++ b/src/main/java/org/eolang/opeo/ast/Handle.java
@@ -119,6 +119,7 @@ public final class Handle implements Xmir {
      * @param owner Owner of the method or field.
      * @param desc Descriptor of the method or field.
      * @param itf Is it an interface method?
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     public Handle(
         final int tag,
@@ -132,6 +133,24 @@ public final class Handle implements Xmir {
         this.owner = owner;
         this.desc = desc;
         this.itf = itf;
+    }
+
+    @Override
+    public Iterable<Directive> toXmir() {
+        return new Directives().add("o")
+            .attr("base", String.format("%s.%s", this.owner.replace('/', '.'), this.name))
+            .append(new DirectivesData("", this.tag))
+            .append(new DirectivesData("", this.desc))
+            .append(new DirectivesData("", this.itf))
+            .up();
+    }
+
+    /**
+     * Convert to ASM handle.
+     * @return ASM handle.
+     */
+    public org.objectweb.asm.Handle toAsm() {
+        return new org.objectweb.asm.Handle(this.tag, this.owner, this.name, this.desc, this.itf);
     }
 
     /**
@@ -177,27 +196,9 @@ public final class Handle implements Xmir {
     /**
      * Parse isInterface from XMIR node.
      * @param children XMIR node children.
-     * @return true if it is an interface method.
+     * @return True if it is an interface method.
      */
     private static boolean xitf(final List<XmlNode> children) {
         return new HexString(children.get(2).text()).decodeAsBoolean();
-    }
-
-    /**
-     * Convert to ASM handle.
-     * @return ASM handle.
-     */
-    public org.objectweb.asm.Handle toAsm() {
-        return new org.objectweb.asm.Handle(this.tag, this.owner, this.name, this.desc, this.itf);
-    }
-
-    @Override
-    public Iterable<Directive> toXmir() {
-        return new Directives().add("o")
-            .attr("base", String.format("%s.%s", this.owner.replace('/', '.'), this.name))
-            .append(new DirectivesData("", this.tag))
-            .append(new DirectivesData("", this.desc))
-            .append(new DirectivesData("", this.itf))
-            .up();
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Handle.java
+++ b/src/main/java/org/eolang/opeo/ast/Handle.java
@@ -2,12 +2,16 @@ package org.eolang.opeo.ast;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.eolang.jeo.representation.directives.DirectivesData;
 import org.eolang.jeo.representation.xmir.HexString;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
+@ToString
+@EqualsAndHashCode
 public final class Handle implements Xmir {
 
     private final int tag;
@@ -32,15 +36,17 @@ public final class Handle implements Xmir {
     }
 
     private static String xowner(final XmlNode root) {
-        return root.attribute("base")
+        final String s1 = root.attribute("base")
             .map(s -> s.substring(0, s.lastIndexOf('.')))
             .orElseThrow(() -> new IllegalArgumentException("Owner is required"));
+        return s1.replace('.', '/');
     }
 
     private static String xname(final XmlNode root) {
-        return root.attribute("base")
-            .map(s -> s.substring(s.lastIndexOf('.')))
+        final String s1 = root.attribute("base")
+            .map(s -> s.substring(s.lastIndexOf('.') + 1))
             .orElseThrow(() -> new IllegalArgumentException("Name is required"));
+        return s1;
     }
 
     private static int xtag(final List<XmlNode> children) {

--- a/src/main/java/org/eolang/opeo/ast/Handle.java
+++ b/src/main/java/org/eolang/opeo/ast/Handle.java
@@ -36,17 +36,15 @@ public final class Handle implements Xmir {
     }
 
     private static String xowner(final XmlNode root) {
-        final String s1 = root.attribute("base")
+        return root.attribute("base")
             .map(s -> s.substring(0, s.lastIndexOf('.')))
-            .orElseThrow(() -> new IllegalArgumentException("Owner is required"));
-        return s1.replace('.', '/');
+            .orElseThrow(() -> new IllegalArgumentException("Owner is required")).replace('.', '/');
     }
 
     private static String xname(final XmlNode root) {
-        final String s1 = root.attribute("base")
+        return root.attribute("base")
             .map(s -> s.substring(s.lastIndexOf('.') + 1))
             .orElseThrow(() -> new IllegalArgumentException("Name is required"));
-        return s1;
     }
 
     private static int xtag(final List<XmlNode> children) {

--- a/src/main/java/org/eolang/opeo/ast/LocalVariable.java
+++ b/src/main/java/org/eolang/opeo/ast/LocalVariable.java
@@ -102,17 +102,19 @@ public final class LocalVariable implements AstNode, Typed {
     @Override
     public List<AstNode> opcodes() {
         final Type type = this.type();
+        final List<AstNode> result;
         if (type.equals(Type.INT_TYPE) || type.equals(Type.getType(Integer.class))) {
-            return Arrays.asList(new Opcode(Opcodes.ILOAD, this.identifier));
+            result = Arrays.asList(new Opcode(Opcodes.ILOAD, this.identifier));
         } else if (type.equals(Type.LONG_TYPE) || type.equals(Type.getType(Long.class))) {
-            return Arrays.asList(new Opcode(Opcodes.LLOAD, this.identifier));
+            result = Arrays.asList(new Opcode(Opcodes.LLOAD, this.identifier));
         } else if (type.equals(Type.FLOAT_TYPE) || type.equals(Type.getType(Float.class))) {
-            return Arrays.asList(new Opcode(Opcodes.FLOAD, this.identifier));
+            result = Arrays.asList(new Opcode(Opcodes.FLOAD, this.identifier));
         } else if (type.equals(Type.DOUBLE_TYPE) || type.equals(Type.getType(Double.class))) {
-            return Arrays.asList(new Opcode(Opcodes.DLOAD, this.identifier));
+            result = Arrays.asList(new Opcode(Opcodes.DLOAD, this.identifier));
         } else {
-            return Arrays.asList(new Opcode(type.getOpcode(Opcodes.ILOAD), this.identifier));
+            result = Arrays.asList(new Opcode(type.getOpcode(Opcodes.ILOAD), this.identifier));
         }
+        return result;
     }
 
     @Override
@@ -127,17 +129,19 @@ public final class LocalVariable implements AstNode, Typed {
      */
     public AstNode store() {
         final Type type = this.type();
+        final AstNode result;
         if (type.equals(Type.INT_TYPE) || type.equals(Type.getType(Integer.class))) {
-            return new Opcode(Opcodes.ISTORE, this.identifier);
+            result = new Opcode(Opcodes.ISTORE, this.identifier);
         } else if (type.equals(Type.LONG_TYPE) || type.equals(Type.getType(Long.class))) {
-            return new Opcode(Opcodes.LSTORE, this.identifier);
+            result = new Opcode(Opcodes.LSTORE, this.identifier);
         } else if (type.equals(Type.FLOAT_TYPE) || type.equals(Type.getType(Float.class))) {
-            return new Opcode(Opcodes.FSTORE, this.identifier);
+            result = new Opcode(Opcodes.FSTORE, this.identifier);
         } else if (type.equals(Type.DOUBLE_TYPE) || type.equals(Type.getType(Double.class))) {
-            return new Opcode(Opcodes.DSTORE, this.identifier);
+            result = new Opcode(Opcodes.DSTORE, this.identifier);
         } else {
-            return new Opcode(this.type().getOpcode(Opcodes.ISTORE), this.identifier);
+            result = new Opcode(this.type().getOpcode(Opcodes.ISTORE), this.identifier);
         }
+        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/LocalVariable.java
+++ b/src/main/java/org/eolang/opeo/ast/LocalVariable.java
@@ -39,7 +39,10 @@ import org.xembly.Directives;
  *   int local1;
  * }</p>
  * @since 0.2
- * @todo Test unboxing
+ * @todo #329:60min Test local variable unboxing.
+ *  We should add more tests for {@link #store()} and {@link #opcodes()} methods.
+ *  Now we test only primitive types.
+ *  It would be nice to test boxed types as well, for example {@link Integer} for ISTORE.
  */
 @ToString
 @EqualsAndHashCode

--- a/src/main/java/org/eolang/opeo/ast/LocalVariable.java
+++ b/src/main/java/org/eolang/opeo/ast/LocalVariable.java
@@ -39,6 +39,7 @@ import org.xembly.Directives;
  *   int local1;
  * }</p>
  * @since 0.2
+ * @todo Test unboxing
  */
 @ToString
 @EqualsAndHashCode
@@ -97,7 +98,18 @@ public final class LocalVariable implements AstNode, Typed {
 
     @Override
     public List<AstNode> opcodes() {
-        return Arrays.asList(new Opcode(this.type().getOpcode(Opcodes.ILOAD), this.identifier));
+        final Type type = this.type();
+        if (type.equals(Type.INT_TYPE) || type.equals(Type.getType(Integer.class))) {
+            return Arrays.asList(new Opcode(Opcodes.ILOAD, this.identifier));
+        } else if (type.equals(Type.LONG_TYPE) || type.equals(Type.getType(Long.class))) {
+            return Arrays.asList(new Opcode(Opcodes.LLOAD, this.identifier));
+        } else if (type.equals(Type.FLOAT_TYPE) || type.equals(Type.getType(Float.class))) {
+            return Arrays.asList(new Opcode(Opcodes.FLOAD, this.identifier));
+        } else if (type.equals(Type.DOUBLE_TYPE) || type.equals(Type.getType(Double.class))) {
+            return Arrays.asList(new Opcode(Opcodes.DLOAD, this.identifier));
+        } else {
+            return Arrays.asList(new Opcode(type.getOpcode(Opcodes.ILOAD), this.identifier));
+        }
     }
 
     @Override
@@ -111,7 +123,18 @@ public final class LocalVariable implements AstNode, Typed {
      * @return Opcode to store the variable. See {@link Opcode}.
      */
     public AstNode store() {
-        return new Opcode(this.type().getOpcode(Opcodes.ISTORE), this.identifier);
+        final Type type = this.type();
+        if (type.equals(Type.INT_TYPE) || type.equals(Type.getType(Integer.class))) {
+            return new Opcode(Opcodes.ISTORE, this.identifier);
+        } else if (type.equals(Type.LONG_TYPE) || type.equals(Type.getType(Long.class))) {
+            return new Opcode(Opcodes.LSTORE, this.identifier);
+        } else if (type.equals(Type.FLOAT_TYPE) || type.equals(Type.getType(Float.class))) {
+            return new Opcode(Opcodes.FSTORE, this.identifier);
+        } else if (type.equals(Type.DOUBLE_TYPE) || type.equals(Type.getType(Double.class))) {
+            return new Opcode(Opcodes.DSTORE, this.identifier);
+        } else {
+            return new Opcode(this.type().getOpcode(Opcodes.ISTORE), this.identifier);
+        }
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/Multiplication.java
+++ b/src/main/java/org/eolang/opeo/ast/Multiplication.java
@@ -90,6 +90,11 @@ public final class Multiplication implements AstNode, Typed {
         return res;
     }
 
+    @Override
+    public Type type() {
+        return new ExpressionType(this.left, this.right).type();
+    }
+
     /**
      * Extracts the first value.
      * @param node XMIR node where to extract the value.
@@ -109,10 +114,5 @@ public final class Multiplication implements AstNode, Typed {
      */
     private static AstNode xleft(final XmlNode node, final Function<XmlNode, AstNode> search) {
         return search.apply(node.firstChild());
-    }
-
-    @Override
-    public Type type() {
-        return new ExpressionType(this.left, this.right).type();
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Multiplication.java
+++ b/src/main/java/org/eolang/opeo/ast/Multiplication.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -40,7 +41,7 @@ import org.xembly.Directives;
  *  We need to add support for other types, such as floating point numbers, longs, etc.
  *  Don't forget to add tests for the new types.
  */
-public final class Mul implements AstNode {
+public final class Multiplication implements AstNode, Typed {
 
     /**
      * Left operand.
@@ -57,8 +58,8 @@ public final class Mul implements AstNode {
      * @param node XMIR node where to extract the value.
      * @param search Search function.
      */
-    public Mul(final XmlNode node, final Function<XmlNode, AstNode> search) {
-        this(Mul.xleft(node, search), xright(node, search));
+    public Multiplication(final XmlNode node, final Function<XmlNode, AstNode> search) {
+        this(Multiplication.xleft(node, search), xright(node, search));
     }
 
     /**
@@ -66,7 +67,7 @@ public final class Mul implements AstNode {
      * @param left Left operand
      * @param right Right operand
      */
-    public Mul(final AstNode left, final AstNode right) {
+    public Multiplication(final AstNode left, final AstNode right) {
         this.left = left;
         this.right = right;
     }
@@ -108,5 +109,10 @@ public final class Mul implements AstNode {
      */
     private static AstNode xleft(final XmlNode node, final Function<XmlNode, AstNode> search) {
         return search.apply(node.firstChild());
+    }
+
+    @Override
+    public Type type() {
+        return new ExpressionType(this.left, this.right).type();
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Opcode.java
+++ b/src/main/java/org/eolang/opeo/ast/Opcode.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;

--- a/src/main/java/org/eolang/opeo/ast/Opcode.java
+++ b/src/main/java/org/eolang/opeo/ast/Opcode.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;

--- a/src/main/java/org/eolang/opeo/ast/Return.java
+++ b/src/main/java/org/eolang/opeo/ast/Return.java
@@ -1,0 +1,132 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.compilation.Parser;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+/**
+ * Return statement.
+ *
+ * @since 0.5
+ */
+public final class Return implements AstNode {
+
+    /**
+     * Value to return.
+     */
+    private final AstNode value;
+
+    /**
+     * Default constructor.
+     */
+    public Return() {
+        this(new Empty());
+    }
+
+    /**
+     * Constructor.
+     * @param node XML node to parse.
+     * @param parser Parser, that is used to parse child nodes.
+     */
+    public Return(final XmlNode node, final Parser parser) {
+        this(Return.xtype(node, parser));
+    }
+
+    /**
+     * Constructor.
+     * @param typed Value to return.
+     */
+    public Return(final AstNode typed) {
+        this.value = typed;
+    }
+
+    @Override
+    public Iterable<Directive> toXmir() {
+        return new Directives()
+            .add("o")
+            .attr("base", "return")
+            .append(this.value.toXmir())
+            .up();
+    }
+
+    @Override
+    public List<AstNode> opcodes() {
+        final List<AstNode> res = new ArrayList<>(1);
+        res.addAll(this.value.opcodes());
+        res.add(this.opcode());
+        return res;
+    }
+
+    /**
+     * Get opcode.
+     * @return Opcode.
+     */
+    private Opcode opcode() {
+        final Type type = this.type();
+        if (type.equals(Type.VOID_TYPE)) {
+            return new Opcode(Opcodes.RETURN);
+        } else if (type.equals(Type.INT_TYPE)) {
+            return new Opcode(Opcodes.IRETURN);
+        } else if (type.equals(Type.LONG_TYPE)) {
+            return new Opcode(Opcodes.LRETURN);
+        } else if (type.equals(Type.FLOAT_TYPE)) {
+            return new Opcode(Opcodes.FRETURN);
+        } else if (type.equals(Type.DOUBLE_TYPE)) {
+            return new Opcode(Opcodes.DRETURN);
+        } else {
+            return new Opcode(Opcodes.ARETURN);
+        }
+    }
+
+    /**
+     * Get a type of the value.
+     * @return Type of the value.
+     */
+    private Type type() {
+        return Typed.class.cast(this.value).type();
+    }
+
+    /**
+     * Parse type.
+     * @param node XML node.
+     * @param parser Parser to parse children.
+     * @return Parsed typed value.
+     */
+    private static AstNode xtype(final XmlNode node, final Parser parser) {
+        final List<XmlNode> children = node.children().collect(Collectors.toList());
+        if (children.isEmpty()) {
+            return new Empty();
+        } else {
+            return parser.parse(children.get(0));
+        }
+    }
+}

--- a/src/main/java/org/eolang/opeo/ast/Return.java
+++ b/src/main/java/org/eolang/opeo/ast/Return.java
@@ -92,19 +92,21 @@ public final class Return implements AstNode {
      */
     private Opcode opcode() {
         final Type type = this.type();
+        final Opcode result;
         if (type.equals(Type.VOID_TYPE)) {
-            return new Opcode(Opcodes.RETURN);
+            result = new Opcode(Opcodes.RETURN);
         } else if (type.equals(Type.INT_TYPE) || type.equals(Type.getType(Integer.class))) {
-            return new Opcode(Opcodes.IRETURN);
+            result = new Opcode(Opcodes.IRETURN);
         } else if (type.equals(Type.LONG_TYPE) || type.equals(Type.getType(Long.class))) {
-            return new Opcode(Opcodes.LRETURN);
+            result = new Opcode(Opcodes.LRETURN);
         } else if (type.equals(Type.FLOAT_TYPE) || type.equals(Type.getType(Float.class))) {
-            return new Opcode(Opcodes.FRETURN);
+            result = new Opcode(Opcodes.FRETURN);
         } else if (type.equals(Type.DOUBLE_TYPE) || type.equals(Type.getType(Double.class))) {
-            return new Opcode(Opcodes.DRETURN);
+            result = new Opcode(Opcodes.DRETURN);
         } else {
-            return new Opcode(Opcodes.ARETURN);
+            result = new Opcode(Opcodes.ARETURN);
         }
+        return result;
     }
 
     /**
@@ -122,11 +124,13 @@ public final class Return implements AstNode {
      * @return Parsed typed value.
      */
     private static AstNode xtype(final XmlNode node, final Parser parser) {
+        final AstNode result;
         final List<XmlNode> children = node.children().collect(Collectors.toList());
         if (children.isEmpty()) {
-            return new Empty();
+            result = new Empty();
         } else {
-            return parser.parse(children.get(0));
+            result = parser.parse(children.get(0));
         }
+        return result;
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/Return.java
+++ b/src/main/java/org/eolang/opeo/ast/Return.java
@@ -94,13 +94,13 @@ public final class Return implements AstNode {
         final Type type = this.type();
         if (type.equals(Type.VOID_TYPE)) {
             return new Opcode(Opcodes.RETURN);
-        } else if (type.equals(Type.INT_TYPE)) {
+        } else if (type.equals(Type.INT_TYPE) || type.equals(Type.getType(Integer.class))) {
             return new Opcode(Opcodes.IRETURN);
-        } else if (type.equals(Type.LONG_TYPE)) {
+        } else if (type.equals(Type.LONG_TYPE) || type.equals(Type.getType(Long.class))) {
             return new Opcode(Opcodes.LRETURN);
-        } else if (type.equals(Type.FLOAT_TYPE)) {
+        } else if (type.equals(Type.FLOAT_TYPE) || type.equals(Type.getType(Float.class))) {
             return new Opcode(Opcodes.FRETURN);
-        } else if (type.equals(Type.DOUBLE_TYPE)) {
+        } else if (type.equals(Type.DOUBLE_TYPE) || type.equals(Type.getType(Double.class))) {
             return new Opcode(Opcodes.DRETURN);
         } else {
             return new Opcode(Opcodes.ARETURN);

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -32,6 +32,7 @@ import org.eolang.opeo.ast.ArrayConstructor;
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.Attributes;
 import org.eolang.opeo.ast.Cast;
+import org.eolang.opeo.ast.CheckCast;
 import org.eolang.opeo.ast.ClassField;
 import org.eolang.opeo.ast.ClassName;
 import org.eolang.opeo.ast.Constant;
@@ -175,6 +176,8 @@ final class XmirParser implements Parser {
             result = new ArrayConstructor(node, this);
         } else if ("return".equals(base)) {
             result = new Return(node, this);
+        } else if ("checkcast".equals(base)) {
+            result = new CheckCast(node, this);
         } else if (!base.isEmpty() && base.charAt(0) == '.') {
             final Attributes attributes = new Attributes(node.firstChild());
             if ("static".equals(attributes.type())) {

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -46,11 +46,12 @@ import org.eolang.opeo.ast.Label;
 import org.eolang.opeo.ast.Labeled;
 import org.eolang.opeo.ast.Literal;
 import org.eolang.opeo.ast.LocalVariable;
-import org.eolang.opeo.ast.Mul;
+import org.eolang.opeo.ast.Multiplication;
 import org.eolang.opeo.ast.NewAddress;
 import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.ast.Popped;
 import org.eolang.opeo.ast.RawXml;
+import org.eolang.opeo.ast.Return;
 import org.eolang.opeo.ast.StaticInvocation;
 import org.eolang.opeo.ast.StoreArray;
 import org.eolang.opeo.ast.Substraction;
@@ -123,7 +124,7 @@ final class XmirParser implements Parser {
         } else if ("labeled".equals(base)) {
             result = new Labeled(node, this::parse);
         } else if ("times".equals(base)) {
-            result = new Mul(node, this::parse);
+            result = new Multiplication(node, this::parse);
         } else if (".if".equals(base)) {
             result = new If(node, this::parse);
         } else if ("load-constant".equals(base)) {
@@ -172,6 +173,8 @@ final class XmirParser implements Parser {
             result = new Constructor(node, this);
         } else if (".array-node".equals(base)) {
             result = new ArrayConstructor(node, this);
+        } else if ("return".equals(base)) {
+            result = new Return(node, this);
         } else if (!base.isEmpty() && base.charAt(0) == '.') {
             final Attributes attributes = new Attributes(node.firstChild());
             if ("static".equals(attributes.type())) {

--- a/src/main/java/org/eolang/opeo/compilation/XmirParser.java
+++ b/src/main/java/org/eolang/opeo/compilation/XmirParser.java
@@ -38,6 +38,7 @@ import org.eolang.opeo.ast.ClassName;
 import org.eolang.opeo.ast.Constant;
 import org.eolang.opeo.ast.Constructor;
 import org.eolang.opeo.ast.Duplicate;
+import org.eolang.opeo.ast.DynamicInvocation;
 import org.eolang.opeo.ast.FieldAssignment;
 import org.eolang.opeo.ast.FieldRetrieval;
 import org.eolang.opeo.ast.If;
@@ -184,6 +185,8 @@ final class XmirParser implements Parser {
                 result = new StaticInvocation(node, this);
             } else if ("interface".equals(attributes.type())) {
                 result = new InterfaceInvocation(node, this);
+            } else if ("dynamic".equals(attributes.type())) {
+                result = new DynamicInvocation(node);
             } else {
                 result = new Invocation(node, this);
             }

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/CheckCastHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/CheckCastHandler.java
@@ -40,6 +40,6 @@ public final class CheckCastHandler implements InstructionHandler {
     public void handle(final DecompilerState state) {
         final AstNode value = state.stack().pop();
         final Object type = state.operand(0);
-        state.stack().push(new CheckCast((Type) type, value));
+        state.stack().push(new CheckCast(Type.getType((String) type), value));
     }
 }

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/CheckCastHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/CheckCastHandler.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.decompilation.handlers;
+
+import org.eolang.opeo.ast.AstNode;
+import org.eolang.opeo.ast.CheckCast;
+import org.eolang.opeo.decompilation.DecompilerState;
+import org.eolang.opeo.decompilation.InstructionHandler;
+import org.objectweb.asm.Type;
+
+/**
+ * CheckCast instruction handler.
+ *
+ * @since 0.5
+ */
+public final class CheckCastHandler implements InstructionHandler {
+
+    @Override
+    public void handle(final DecompilerState state) {
+        final AstNode value = state.stack().pop();
+        final Object type = state.operand(0);
+        state.stack().push(new CheckCast((Type) type, value));
+    }
+}

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/InvokedynamicHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/InvokedynamicHandler.java
@@ -1,0 +1,25 @@
+package org.eolang.opeo.decompilation.handlers;
+
+import java.util.List;
+import org.eolang.opeo.ast.DynamicInvocation;
+import org.eolang.opeo.decompilation.DecompilerState;
+import org.eolang.opeo.decompilation.InstructionHandler;
+import org.objectweb.asm.Handle;
+
+public final class InvokedynamicHandler implements InstructionHandler {
+    @Override
+    public void handle(final DecompilerState state) {
+        final int opcode = state.instruction().opcode();
+        final List<Object> operands = state.instruction().operands();
+        final String name = (String) operands.get(0);
+        final String descriptor = (String) operands.get(1);
+        final Handle factory = (Handle) operands.get(2);
+        final List<Object> args = operands.subList(3, operands.size());
+        final DynamicInvocation node = new DynamicInvocation(
+            name, new org.eolang.opeo.ast.Handle(factory),
+            descriptor,
+            args
+        );
+        state.stack().push(node);
+    }
+}

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/InvokedynamicHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/InvokedynamicHandler.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.opeo.decompilation.handlers;
 
 import java.util.List;
@@ -6,21 +29,22 @@ import org.eolang.opeo.decompilation.DecompilerState;
 import org.eolang.opeo.decompilation.InstructionHandler;
 import org.objectweb.asm.Handle;
 
+/**
+ * Invokedynamic instruction handler.
+ * @since 0.5
+ */
 public final class InvokedynamicHandler implements InstructionHandler {
+
     @Override
     public void handle(final DecompilerState state) {
-        final int opcode = state.instruction().opcode();
         final List<Object> operands = state.instruction().operands();
-        final String name = (String) operands.get(0);
-        final String descriptor = (String) operands.get(1);
-        final Handle factory = (Handle) operands.get(2);
-        final List<Object> args = operands.subList(3, operands.size());
         final DynamicInvocation node = new DynamicInvocation(
-            name,
-            new org.eolang.opeo.ast.Handle(factory),
-            descriptor,
-            args
+            (String) operands.get(0),
+            new org.eolang.opeo.ast.Handle((Handle) operands.get(2)),
+            (String) operands.get(1),
+            operands.subList(3, operands.size())
         );
         state.stack().push(node);
     }
+
 }

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/InvokedynamicHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/InvokedynamicHandler.java
@@ -16,7 +16,8 @@ public final class InvokedynamicHandler implements InstructionHandler {
         final Handle factory = (Handle) operands.get(2);
         final List<Object> args = operands.subList(3, operands.size());
         final DynamicInvocation node = new DynamicInvocation(
-            name, new org.eolang.opeo.ast.Handle(factory),
+            name,
+            new org.eolang.opeo.ast.Handle(factory),
             descriptor,
             args
         );

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/MulHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/MulHandler.java
@@ -24,7 +24,7 @@
 package org.eolang.opeo.decompilation.handlers;
 
 import org.eolang.opeo.ast.AstNode;
-import org.eolang.opeo.ast.Mul;
+import org.eolang.opeo.ast.Multiplication;
 import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.eolang.opeo.decompilation.InstructionHandler;
@@ -54,7 +54,7 @@ public final class MulHandler implements InstructionHandler {
         if (state.instruction().opcode() == Opcodes.IMUL) {
             final AstNode right = state.stack().pop();
             final AstNode left = state.stack().pop();
-            state.stack().push(new Mul(left, right));
+            state.stack().push(new Multiplication(left, right));
         } else {
             state.stack().push(
                 new Opcode(

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/ReturnHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/ReturnHandler.java
@@ -24,8 +24,11 @@
 package org.eolang.opeo.decompilation.handlers;
 
 import org.eolang.opeo.ast.Opcode;
+import org.eolang.opeo.ast.Return;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.eolang.opeo.decompilation.InstructionHandler;
+import org.eolang.opeo.decompilation.OperandStack;
+import org.objectweb.asm.Opcodes;
 
 /**
  * Return instruction handler.
@@ -33,27 +36,26 @@ import org.eolang.opeo.decompilation.InstructionHandler;
  */
 public final class ReturnHandler implements InstructionHandler {
 
-    /**
-     * Do we put numbers to opcodes?
-     */
-    private final boolean counting;
-
-    /**
-     * Constructor.
-     * @param counting Do we put numbers to opcodes?
-     */
-    ReturnHandler(final boolean counting) {
-        this.counting = counting;
-    }
-
     @Override
     public void handle(final DecompilerState state) {
-        state.stack().push(
-            new Opcode(
-                state.instruction().opcode(),
-                state.instruction().operands(),
-                this.counting
-            )
-        );
+        final int opcode = state.instruction().opcode();
+        final OperandStack stack = state.stack();
+        if (opcode == Opcodes.RETURN) {
+            stack.push(new Return());
+        } else if (opcode == Opcodes.IRETURN) {
+            stack.push(new Return(stack.pop()));
+        } else if (opcode == Opcodes.LRETURN) {
+            stack.push(new Return(stack.pop()));
+        } else if (opcode == Opcodes.FRETURN) {
+            stack.push(new Return(stack.pop()));
+        } else if (opcode == Opcodes.DRETURN) {
+            stack.push(new Return(stack.pop()));
+        } else if (opcode == Opcodes.ARETURN) {
+            stack.push(new Return(stack.pop()));
+        } else {
+            throw new IllegalStateException(
+                String.format("Unexpected opcode: %d", opcode)
+            );
+        }
     }
 }

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/ReturnHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/ReturnHandler.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.opeo.decompilation.handlers;
 
-import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.ast.Return;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.eolang.opeo.decompilation.InstructionHandler;
@@ -33,6 +32,7 @@ import org.objectweb.asm.Opcodes;
 /**
  * Return instruction handler.
  * @since 0.1
+ * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
 public final class ReturnHandler implements InstructionHandler {
 

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/RouterHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/RouterHandler.java
@@ -109,6 +109,7 @@ public final class RouterHandler implements InstructionHandler {
                 new MapEntry<>(Opcodes.ASTORE, new StoreHandler(Type.getType(Object.class))),
                 new MapEntry<>(Opcodes.AASTORE, new StoreToArrayHandler()),
                 new MapEntry<>(Opcodes.ANEWARRAY, new NewArrayHandler()),
+                new MapEntry<>(Opcodes.CHECKCAST, new CheckCastHandler()),
                 new MapEntry<>(Opcodes.NEW, new NewHandler()),
                 new MapEntry<>(Opcodes.DUP, new DupHandler()),
                 new MapEntry<>(Opcodes.BIPUSH, new BipushHandler()),

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/RouterHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/RouterHandler.java
@@ -121,8 +121,9 @@ public final class RouterHandler implements InstructionHandler {
                 new MapEntry<>(Opcodes.GETSTATIC, new GetStaticHnadler()),
                 new MapEntry<>(Opcodes.LDC, new LdcHandler()),
                 new MapEntry<>(Opcodes.POP, new PopHandler()),
-                new MapEntry<>(Opcodes.RETURN, new ReturnHandler(counting)),
-                new MapEntry<>(Opcodes.IRETURN, new ReturnHandler(counting)),
+                new MapEntry<>(Opcodes.RETURN, new ReturnHandler()),
+                new MapEntry<>(Opcodes.IRETURN, new ReturnHandler()),
+                new MapEntry<>(Opcodes.ARETURN, new ReturnHandler()),
                 new MapEntry<>(LabelInstruction.LABEL_OPCODE, new LabelHandler()),
                 new MapEntry<>(RouterHandler.UNIMPLEMENTED, new UnimplementedHandler(counting))
             )

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/RouterHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/RouterHandler.java
@@ -38,6 +38,7 @@ import org.objectweb.asm.Type;
  * General Instruction Handler.
  * This handler redirects handling of instructions depending on an incoming instruction.
  * @since 0.2
+ * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
 public final class RouterHandler implements InstructionHandler {
 

--- a/src/main/java/org/eolang/opeo/decompilation/handlers/RouterHandler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/handlers/RouterHandler.java
@@ -117,6 +117,7 @@ public final class RouterHandler implements InstructionHandler {
                 new MapEntry<>(Opcodes.INVOKEVIRTUAL, new InvokevirtualHandler()),
                 new MapEntry<>(Opcodes.INVOKESTATIC, new InvokestaticHander()),
                 new MapEntry<>(Opcodes.INVOKEINTERFACE, new InvokeinterfaceHandler()),
+                new MapEntry<>(Opcodes.INVOKEDYNAMIC, new InvokedynamicHandler()),
                 new MapEntry<>(Opcodes.GETFIELD, new GetFieldHandler()),
                 new MapEntry<>(Opcodes.PUTFIELD, new PutFieldHnadler()),
                 new MapEntry<>(Opcodes.GETSTATIC, new GetStaticHnadler()),

--- a/src/test/java/it/JeoAndOpeoTest.java
+++ b/src/test/java/it/JeoAndOpeoTest.java
@@ -24,7 +24,6 @@
 package it;
 
 import com.jcabi.xml.XMLDocument;
-import java.util.Arrays;
 import java.util.List;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.io.ResourceOf;
@@ -107,7 +106,7 @@ final class JeoAndOpeoTest {
         "xmir/disassembled/SimpleLog.xmir",
         "xmir/disassembled/Factorial.xmir",
         "xmir/disassembled/Lambda.xmir",
-        "xmir/disassembled/Main.xmir",
+        "xmir/disassembled/Main.xmir"
     })
     void decompilesCompilesAndKeepsTheSameInstructions(final String path) throws Exception {
         final XMLDocument original = new XMLDocument(new BytesOf(new ResourceOf(path)).asBytes());

--- a/src/test/java/it/JeoAndOpeoTest.java
+++ b/src/test/java/it/JeoAndOpeoTest.java
@@ -129,7 +129,10 @@ final class JeoAndOpeoTest {
     }
 
     @ParameterizedTest
-    @CsvSource("xmir/disassembled/SimpleLog.xmir")
+    @CsvSource({
+        "xmir/disassembled/SimpleLog.xmir",
+        "xmir/disassembled/Main.xmir"
+    })
     void decompilesCompilesAndKeepsTheSameInstructionsWithTheSameOperands(
         final String path
     ) throws Exception {

--- a/src/test/java/it/JeoAndOpeoTest.java
+++ b/src/test/java/it/JeoAndOpeoTest.java
@@ -104,7 +104,8 @@ final class JeoAndOpeoTest {
         "xmir/disassembled/SmartLifecycle.xmir",
         "xmir/disassembled/FlightRecorderStartupEvent.xmir",
         "xmir/disassembled/SimpleLog.xmir",
-        "xmir/disassembled/Factorial.xmir"
+        "xmir/disassembled/Factorial.xmir",
+        "xmir/disassembled/Lambda.xmir",
     })
     void decompilesCompilesAndKeepsTheSameInstructions(final String path) throws Exception {
         final XMLDocument original = new XMLDocument(new BytesOf(new ResourceOf(path)).asBytes());

--- a/src/test/java/it/JeoAndOpeoTest.java
+++ b/src/test/java/it/JeoAndOpeoTest.java
@@ -24,6 +24,7 @@
 package it;
 
 import com.jcabi.xml.XMLDocument;
+import java.util.Arrays;
 import java.util.List;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.io.ResourceOf;
@@ -106,6 +107,7 @@ final class JeoAndOpeoTest {
         "xmir/disassembled/SimpleLog.xmir",
         "xmir/disassembled/Factorial.xmir",
         "xmir/disassembled/Lambda.xmir",
+        "xmir/disassembled/Main.xmir",
     })
     void decompilesCompilesAndKeepsTheSameInstructions(final String path) throws Exception {
         final XMLDocument original = new XMLDocument(new BytesOf(new ResourceOf(path)).asBytes());

--- a/src/test/java/org/eolang/opeo/ast/CheckCastTest.java
+++ b/src/test/java/org/eolang/opeo/ast/CheckCastTest.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link CheckCast}.
+ * @since 0.5
+ */
+class CheckCastTest {
+
+    /**
+     * XMIR representation of the CheckCast.
+     */
+    private static final String XMIR = String.join(
+        "\n",
+        "<o base='cast'>",
+        "   <o base='type' data='bytes'>4A</o>",
+        "   <o base='int' data='bytes'>00 00 00 00 00 00 00 03</o>",
+        "</o>"
+    );
+
+    @Test
+    void convertsCheckCastToXmir() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "Can't convert CheckCast to XMIR",
+            new Xembler(
+                new CheckCast(
+                    Type.LONG_TYPE,
+                    new Literal(3)
+                ).toXmir()
+            ).xml(),
+            new SameXml(CheckCastTest.XMIR)
+        );
+    }
+
+    @Test
+    void createsCheckCastFromXmir() {
+        MatcherAssert.assertThat(
+            "Can't parse CheckCast type from XMIR",
+            new CheckCast(new XmlNode(CheckCastTest.XMIR), n -> new Literal(3)).type(),
+            Matchers.equalTo(Type.LONG_TYPE)
+        );
+    }
+
+    @Test
+    void transformsToOpcodes() {
+        final Type type = Type.INT_TYPE;
+        MatcherAssert.assertThat(
+            "Can't transform CheckCast to opcodes",
+            new CheckCast(type, new Literal((byte) 3)).opcodes(),
+            Matchers.hasItems(
+                new Opcode(Opcodes.BIPUSH, (byte) 3),
+                new Opcode(Opcodes.CHECKCAST, type)
+            )
+        );
+    }
+
+
+}

--- a/src/test/java/org/eolang/opeo/ast/CheckCastTest.java
+++ b/src/test/java/org/eolang/opeo/ast/CheckCastTest.java
@@ -81,7 +81,7 @@ class CheckCastTest {
             new CheckCast(type, new Literal((byte) 3)).opcodes(),
             Matchers.hasItems(
                 new Opcode(Opcodes.BIPUSH, (byte) 3),
-                new Opcode(Opcodes.CHECKCAST, type)
+                new Opcode(Opcodes.CHECKCAST, type.getDescriptor())
             )
         );
     }

--- a/src/test/java/org/eolang/opeo/ast/CheckCastTest.java
+++ b/src/test/java/org/eolang/opeo/ast/CheckCastTest.java
@@ -37,7 +37,7 @@ import org.xembly.Xembler;
  * Test case for {@link CheckCast}.
  * @since 0.5
  */
-class CheckCastTest {
+final class CheckCastTest {
 
     /**
      * XMIR representation of the CheckCast.
@@ -85,6 +85,4 @@ class CheckCastTest {
             )
         );
     }
-
-
 }

--- a/src/test/java/org/eolang/opeo/ast/CheckCastTest.java
+++ b/src/test/java/org/eolang/opeo/ast/CheckCastTest.java
@@ -44,7 +44,7 @@ class CheckCastTest {
      */
     private static final String XMIR = String.join(
         "\n",
-        "<o base='cast'>",
+        "<o base='checkcast'>",
         "   <o base='type' data='bytes'>4A</o>",
         "   <o base='int' data='bytes'>00 00 00 00 00 00 00 03</o>",
         "</o>"

--- a/src/test/java/org/eolang/opeo/ast/DynamicInvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/DynamicInvocationTest.java
@@ -24,10 +24,8 @@
 package org.eolang.opeo.ast;
 
 import java.util.Arrays;
-import java.util.List;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.SameXml;
-import org.eolang.opeo.compilation.Parser;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -40,12 +38,13 @@ import org.xembly.Xembler;
  * Test case for {@link DynamicInvocation}.
  * @since 0.5
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class DynamicInvocationTest {
 
     /**
      * XMIR representation of the dynamic invocation.
      */
-    private final static String XMIR = String.join(
+    private static final String XMIR = String.join(
         "",
         "<o base='.run'>",
         "   <o base='string' data='bytes' line='306231171'>64 65 73 63 72 69 70 74 6F 72 3D 28 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 52 75 6E 6E 61 62 6C 65 3B 7C 74 79 70 65 3D 64 79 6E 61 6D 69 63</o>",

--- a/src/test/java/org/eolang/opeo/ast/DynamicInvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/DynamicInvocationTest.java
@@ -1,0 +1,129 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import java.util.Arrays;
+import java.util.List;
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
+import org.eolang.opeo.compilation.Parser;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link DynamicInvocation}.
+ * @since 0.5
+ */
+final class DynamicInvocationTest {
+
+    private final static String XMIR = String.join(
+        "",
+        "<o base='.run'>",
+        "   <o base='string' data='bytes' line='306231171'>64 65 73 63 72 69 70 74 6F 72 3D 28 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 52 75 6E 6E 61 62 6C 65 3B 7C 74 79 70 65 3D 64 79 6E 61 6D 69 63</o>",
+        "   <o base='java.lang.invoke.LambdaMetafactory.meafactory'>",
+        "      <o base='int' data='bytes' line='74325437'>00 00 00 00 00 00 00 06</o>",
+        "      <o base='string' data='bytes' line='981153864'>28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 43 61 6C 6C 53 69 74 65 3B</o>",
+        "      <o base='bool' data='bytes' line='623874038'>00</o>",
+        "   </o>",
+        "   <o base='type' data='bytes' line='1809304796'>28 29 56</o>",
+        "   <o base='org.eolang.streams.Lambda.lambda$run$0'>",
+        "      <o base='int' data='bytes' line='631518845'>00 00 00 00 00 00 00 06</o>",
+        "      <o base='string' data='bytes' line='1214403213'>28 29 56</o>",
+        "      <o base='bool' data='bytes' line='1030902856'>00</o>",
+        "   </o>",
+        "   <o base='type' data='bytes' line='1901002995'>28 29 56</o>",
+        "</o>"
+    );
+
+    @Test
+    void convertsToXmir() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "Can't convert to dynamic invocation to correct XMIR",
+            new Xembler(
+                new DynamicInvocation(
+                    "run",
+                    new Handle(
+                        6,
+                        "meafactory",
+                        "java/lang/invoke/LambdaMetafactory",
+                        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+                        false
+                    ),
+                    "()Ljava/lang/Runnable;",
+                    Arrays.asList(
+                        Type.getType("()V"),
+                        new Handle(
+                            6,
+                            "lambda$run$0",
+                            "org/eolang/streams/Lambda",
+                            "()V",
+                            false
+                        ),
+                        Type.getType("()V")
+                    )
+                ).toXmir()
+            ).xml(),
+            new SameXml(DynamicInvocationTest.XMIR)
+        );
+    }
+
+    @Test
+    void createsDynamicInvocationFromXmir() {
+        MatcherAssert.assertThat(
+            "Can't convert dynamic invocation to opcodes",
+            new DynamicInvocation(
+                new XmlNode(DynamicInvocationTest.XMIR)
+            ).opcodes(),
+            Matchers.hasItem(
+                new Opcode(
+                    Opcodes.INVOKEDYNAMIC,
+                    "run",
+                    "()Ljava/lang/Runnable;",
+                    new org.objectweb.asm.Handle(
+                        6,
+                        "java/lang/invoke/LambdaMetafactory",
+                        "meafactory",
+                        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+                        false
+                    ),
+                    "()Ljava/lang/Runnable;",
+                    Type.getType("()V"),
+                    new org.objectweb.asm.Handle(
+                        6,
+                        "org/eolang/streams/Lambda",
+                        "lambda$run$0",
+                        "()V",
+                        false
+                    ),
+                    Type.getType("()V")
+                )
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/opeo/ast/DynamicInvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/DynamicInvocationTest.java
@@ -42,6 +42,9 @@ import org.xembly.Xembler;
  */
 final class DynamicInvocationTest {
 
+    /**
+     * XMIR representation of the dynamic invocation.
+     */
     private final static String XMIR = String.join(
         "",
         "<o base='.run'>",
@@ -112,7 +115,6 @@ final class DynamicInvocationTest {
                         "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
                         false
                     ),
-                    "()Ljava/lang/Runnable;",
                     Type.getType("()V"),
                     new org.objectweb.asm.Handle(
                         6,

--- a/src/test/java/org/eolang/opeo/ast/DynamicInvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/DynamicInvocationTest.java
@@ -81,10 +81,10 @@ final class DynamicInvocationTest {
                     "()Ljava/lang/Runnable;",
                     Arrays.asList(
                         Type.getType("()V"),
-                        new Handle(
+                        new org.objectweb.asm.Handle(
                             6,
-                            "lambda$run$0",
                             "org/eolang/streams/Lambda",
+                            "lambda$run$0",
                             "()V",
                             false
                         ),

--- a/src/test/java/org/eolang/opeo/ast/MulTest.java
+++ b/src/test/java/org/eolang/opeo/ast/MulTest.java
@@ -30,7 +30,7 @@ import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
 /**
- * Test case for {@link Mul}.
+ * Test case for {@link Multiplication}.
  * @since 0.1
  */
 final class MulTest {
@@ -38,7 +38,7 @@ final class MulTest {
     @Test
     void convertsToXmir() throws ImpossibleModificationException {
         final String xmir = new Xembler(
-            new Mul(
+            new Multiplication(
                 new Literal(3),
                 new Literal(4)
             ).toXmir()

--- a/src/test/java/org/eolang/opeo/ast/MultiplicationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/MultiplicationTest.java
@@ -33,7 +33,7 @@ import org.xembly.Xembler;
  * Test case for {@link Multiplication}.
  * @since 0.1
  */
-final class MulTest {
+final class MultiplicationTest {
 
     @Test
     void convertsToXmir() throws ImpossibleModificationException {

--- a/src/test/java/org/eolang/opeo/ast/ReturnTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ReturnTest.java
@@ -33,12 +33,11 @@ import org.objectweb.asm.Opcodes;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
-
 /**
  * Test case for {@link Return}.
  * @since 0.5
  */
-class ReturnTest {
+final class ReturnTest {
 
     /**
      * Parser for all unit tests in this class.
@@ -47,7 +46,7 @@ class ReturnTest {
         final String base = node.attribute("base").orElseThrow(
             () -> new IllegalArgumentException("No base attribute")
         );
-        AstNode result;
+        final AstNode result;
         if (base.startsWith("int")) {
             result = new Literal(42);
         } else if (base.startsWith("string")) {
@@ -104,7 +103,8 @@ class ReturnTest {
             "Can't create typed return with int",
             new Return(
                 new XmlNode(
-                    "<o base='return'><o base='int' data='bytes'>00 00 00 00 00 00 00 2A</o></o>"),
+                    "<o base='return'><o base='int' data='bytes'>00 00 00 00 00 00 00 2A</o></o>"
+                ),
                 ReturnTest.PARSER
             ).opcodes(),
             Matchers.hasItems(
@@ -120,7 +120,8 @@ class ReturnTest {
             "Can't create typed return with string",
             new Return(
                 new XmlNode(
-                    "<o base='return'><o base='string' data='bytes'>66 6F 6F</o></o>"),
+                    "<o base='return'><o base='string' data='bytes'>66 6F 6F</o></o>"
+                ),
                 ReturnTest.PARSER
             ).opcodes(),
             Matchers.hasItems(
@@ -129,5 +130,4 @@ class ReturnTest {
             )
         );
     }
-
 }

--- a/src/test/java/org/eolang/opeo/ast/ReturnTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ReturnTest.java
@@ -1,0 +1,133 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.eolang.opeo.SameXml;
+import org.eolang.opeo.compilation.Parser;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+
+/**
+ * Test case for {@link Return}.
+ * @since 0.5
+ */
+class ReturnTest {
+
+    /**
+     * Parser for all unit tests in this class.
+     */
+    private static final Parser PARSER = node -> {
+        final String base = node.attribute("base").orElseThrow(
+            () -> new IllegalArgumentException("No base attribute")
+        );
+        AstNode result;
+        if (base.startsWith("int")) {
+            result = new Literal(42);
+        } else if (base.startsWith("string")) {
+            result = new Literal("foo");
+        } else {
+            throw new IllegalArgumentException(String.format("Unknown base: %s", base));
+        }
+        return result;
+    };
+
+    @Test
+    void convertsSimpleReturnToXml() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "Can't convert simple return to XML",
+            new Xembler(new Return().toXmir()).xml(),
+            new SameXml("<o base='return'/>")
+        );
+    }
+
+    @Test
+    void convertsIntReturnToXml() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "Can't convert typed return with int to XML",
+            new Xembler(new Return(new Literal(42)).toXmir()).xml(),
+            new SameXml(
+                "<o base='return'><o base='int' data='bytes'>00 00 00 00 00 00 00 2A</o></o>"
+            )
+        );
+    }
+
+    @Test
+    void convertsStringReturnToXml() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "Can't convert typed return with string to XML",
+            new Xembler(new Return(new Literal("foo")).toXmir()).xml(),
+            new SameXml(
+                "<o base='return'><o base='string' data='bytes'>66 6F 6F</o></o>"
+            )
+        );
+    }
+
+    @Test
+    void createsSimpleReturnFromXmir() {
+        MatcherAssert.assertThat(
+            "Can't create simple return",
+            new Return(new XmlNode("<o base='return'/>"), ReturnTest.PARSER).opcodes(),
+            Matchers.hasItem(new Opcode(Opcodes.RETURN))
+        );
+    }
+
+    @Test
+    void createsIntReturnFromXmir() {
+        MatcherAssert.assertThat(
+            "Can't create typed return with int",
+            new Return(
+                new XmlNode(
+                    "<o base='return'><o base='int' data='bytes'>00 00 00 00 00 00 00 2A</o></o>"),
+                ReturnTest.PARSER
+            ).opcodes(),
+            Matchers.hasItems(
+                new Opcode(Opcodes.BIPUSH, 42),
+                new Opcode(Opcodes.IRETURN)
+            )
+        );
+    }
+
+    @Test
+    void createsStringReturnFromXmir() {
+        MatcherAssert.assertThat(
+            "Can't create typed return with string",
+            new Return(
+                new XmlNode(
+                    "<o base='return'><o base='string' data='bytes'>66 6F 6F</o></o>"),
+                ReturnTest.PARSER
+            ).opcodes(),
+            Matchers.hasItems(
+                new Opcode(Opcodes.LDC, "foo"),
+                new Opcode(Opcodes.ARETURN)
+            )
+        );
+    }
+
+}

--- a/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
@@ -43,6 +43,7 @@ import org.eolang.opeo.ast.LocalVariable;
 import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.ast.Owner;
 import org.eolang.opeo.ast.Popped;
+import org.eolang.opeo.ast.Return;
 import org.eolang.opeo.ast.Root;
 import org.eolang.opeo.ast.StaticInvocation;
 import org.eolang.opeo.ast.StoreArray;
@@ -421,7 +422,7 @@ final class DecompilerMachineTest {
                                 )
                             )
                         )),
-                    new Opcode(Opcodes.RETURN, false)
+                    new Return()
                 )
             )
         );

--- a/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/DecompilerMachineTest.java
@@ -40,7 +40,6 @@ import org.eolang.opeo.ast.FieldAssignment;
 import org.eolang.opeo.ast.Invocation;
 import org.eolang.opeo.ast.Literal;
 import org.eolang.opeo.ast.LocalVariable;
-import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.ast.Owner;
 import org.eolang.opeo.ast.Popped;
 import org.eolang.opeo.ast.Return;

--- a/src/test/resources/xmir/disassembled/Lambda.xmir
+++ b/src/test/resources/xmir/disassembled/Lambda.xmir
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<program dob="2024-07-10T07:56:54.939235Z"
+         ms="1720598214943"
+         name="j$Lambda"
+         revision="0.0.0"
+         time="2024-07-10T07:56:54.939235Z"
+         version="0.0.0">
+   <listing>yv66vgAAADQALQoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWEgAAAAgMAAkACgEAA3J1bgEAFigpTGphdmEvbGFuZy9SdW5uYWJsZTsLAAwADQcADgwACQAGAQASamF2YS9sYW5nL1J1bm5hYmxlBwAQAQAZb3JnL2VvbGFuZy9zdHJlYW1zL0xhbWJkYQEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBABJMb2NhbFZhcmlhYmxlVGFibGUBAAR0aGlzAQAbTG9yZy9lb2xhbmcvc3RyZWFtcy9MYW1iZGE7AQABcgEAFExqYXZhL2xhbmcvUnVubmFibGU7AQAMbGFtYmRhJHJ1biQwAQAKU291cmNlRmlsZQEAC0xhbWJkYS5qYXZhAQAQQm9vdHN0cmFwTWV0aG9kcw8GAB0KAB4AHwcAIAwAIQAiAQAiamF2YS9sYW5nL2ludm9rZS9MYW1iZGFNZXRhZmFjdG9yeQEAC21ldGFmYWN0b3J5AQDMKExqYXZhL2xhbmcvaW52b2tlL01ldGhvZEhhbmRsZXMkTG9va3VwO0xqYXZhL2xhbmcvU3RyaW5nO0xqYXZhL2xhbmcvaW52b2tlL01ldGhvZFR5cGU7TGphdmEvbGFuZy9pbnZva2UvTWV0aG9kVHlwZTtMamF2YS9sYW5nL2ludm9rZS9NZXRob2RIYW5kbGU7TGphdmEvbGFuZy9pbnZva2UvTWV0aG9kVHlwZTspTGphdmEvbGFuZy9pbnZva2UvQ2FsbFNpdGU7EAAGDwYAJQoADwAmDAAYAAYBAAxJbm5lckNsYXNzZXMHACkBACVqYXZhL2xhbmcvaW52b2tlL01ldGhvZEhhbmRsZXMkTG9va3VwBwArAQAeamF2YS9sYW5nL2ludm9rZS9NZXRob2RIYW5kbGVzAQAGTG9va3VwACEADwACAAAAAAADAAEABQAGAAEAEQAAAC8AAQABAAAABSq3AAGxAAAAAgASAAAABgABAAAAAwATAAAADAABAAAABQAUABUAAAAJAAkABgABABEAAAA/AAEAAQAAAA26AAcAAEsquQALAQCxAAAAAgASAAAADgADAAAABgAGAAgADAAJABMAAAAMAAEABgAHABYAFwAAEAoAGAAGAAEAEQAAABkAAAAAAAAAAbEAAAABABIAAAAGAAEAAAAHAAMAGQAAAAIAGgAbAAAADAABABwAAwAjACQAIwAnAAAACgABACgAKgAsABk=</listing>
+   <errors/>
+   <sheets/>
+   <license/>
+   <metas>
+      <meta>
+         <head>package</head>
+         <tail>org.eolang.streams</tail>
+         <part>org.eolang.streams</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>org.eolang.jeo.opcode</tail>
+         <part>org.eolang.jeo.opcode</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>org.eolang.jeo.label</tail>
+         <part>org.eolang.jeo.label</part>
+      </meta>
+   </metas>
+   <objects>
+      <o abstract="" name="j$Lambda">
+         <o base="int" data="bytes" line="955424512" name="version">00 00 00 00 00 00 00 34</o>
+         <o base="int" data="bytes" line="856106619" name="access">00 00 00 00 00 00 00 21</o>
+         <o base="string" data="bytes" line="1063331418" name="supername">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
+         <o base="tuple" name="interfaces" star=""/>
+         <o abstract="" name="new-KClW">
+            <o base="int" data="bytes" line="1833849528">00 00 00 00 00 00 00 01</o>
+            <o base="string" data="bytes" line="526725872">28 29 56</o>
+            <o base="string" data="bytes" line="2040587960"/>
+            <o base="tuple" star=""/>
+            <o base="maxs">
+               <o base="int" data="bytes" line="524907708">00 00 00 00 00 00 00 01</o>
+               <o base="int" data="bytes" line="419435353">00 00 00 00 00 00 00 01</o>
+            </o>
+            <o base="seq" name="@">
+               <o base="tuple" star="">
+                  <o base="label" data="bytes" line="1505785224">66 62 39 38 65 35 30 34 2D 32 34 35 63 2D 34 31 63 64 2D 38 37 31 32 2D 65 65 39 62 64 36 39 34 66 38 33 34</o>
+                  <o base="opcode" line="999" name="ALOAD-2">
+                     <o base="int" data="bytes" line="1624533429">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes" line="1469584844">00 00 00 00 00 00 00 00</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKESPECIAL-3">
+                     <o base="int" data="bytes" line="800001115">00 00 00 00 00 00 00 B7</o>
+                     <o base="string" data="bytes" line="2121805161">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
+                     <o base="string" data="bytes" line="1967441963">3C 69 6E 69 74 3E</o>
+                     <o base="string" data="bytes" line="805502711">28 29 56</o>
+                     <o base="bool" data="bytes" line="2102187314">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="RETURN-5">
+                     <o base="int" data="bytes" line="1143934623">00 00 00 00 00 00 00 B1</o>
+                  </o>
+                  <o base="label" data="bytes" line="1961762975">66 65 62 39 33 33 30 36 2D 62 39 31 30 2D 34 39 30 62 2D 38 62 65 63 2D 39 37 35 31 32 64 30 62 37 61 66 38</o>
+               </o>
+            </o>
+         </o>
+         <o abstract="" name="j$run-KClW">
+            <o base="int" data="bytes" line="705384201">00 00 00 00 00 00 00 09</o>
+            <o base="string" data="bytes" line="1749283423">28 29 56</o>
+            <o base="string" data="bytes" line="1833216555"/>
+            <o base="tuple" star=""/>
+            <o base="maxs">
+               <o base="int" data="bytes" line="1507341425">00 00 00 00 00 00 00 01</o>
+               <o base="int" data="bytes" line="2080093762">00 00 00 00 00 00 00 01</o>
+            </o>
+            <o base="seq" name="@">
+               <o base="tuple" star="">
+                  <o base="label" data="bytes" line="24129257">33 30 63 31 64 38 31 64 2D 36 62 37 63 2D 34 30 30 39 2D 38 38 34 39 2D 34 33 36 36 32 30 65 62 62 63 37 33</o>
+                  <o base="opcode" line="999" name="INVOKEDYNAMIC-7">
+                     <o base="int" data="bytes" line="314784905">00 00 00 00 00 00 00 BA</o>
+                     <o base="string" data="bytes" line="669347357">72 75 6E</o>
+                     <o base="string" data="bytes" line="2086281923">28 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 52 75 6E 6E 61 62 6C 65 3B</o>
+                     <o base="handle">
+                        <o base="int" data="bytes" line="994493869">00 00 00 00 00 00 00 06</o>
+                        <o base="string" data="bytes" line="1555034475">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4C 61 6D 62 64 61 4D 65 74 61 66 61 63 74 6F 72 79</o>
+                        <o base="string" data="bytes" line="1464039459">6D 65 74 61 66 61 63 74 6F 72 79</o>
+                        <o base="string" data="bytes" line="324112241">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 43 61 6C 6C 53 69 74 65 3B</o>
+                        <o base="bool" data="bytes" line="1370585353">00</o>
+                     </o>
+                     <o base="type" data="bytes" line="1758565114">28 29 56</o>
+                     <o base="handle">
+                        <o base="int" data="bytes" line="1434511164">00 00 00 00 00 00 00 06</o>
+                        <o base="string" data="bytes" line="917397159">6F 72 67 2F 65 6F 6C 61 6E 67 2F 73 74 72 65 61 6D 73 2F 4C 61 6D 62 64 61</o>
+                        <o base="string" data="bytes" line="30777047">6C 61 6D 62 64 61 24 72 75 6E 24 30</o>
+                        <o base="string" data="bytes" line="1359392732">28 29 56</o>
+                        <o base="bool" data="bytes" line="1227607808">00</o>
+                     </o>
+                     <o base="type" data="bytes" line="917672890">28 29 56</o>
+                  </o>
+                  <o base="opcode" line="999" name="ASTORE-E">
+                     <o base="int" data="bytes" line="289817393">00 00 00 00 00 00 00 3A</o>
+                     <o base="int" data="bytes" line="1477663707">00 00 00 00 00 00 00 00</o>
+                  </o>
+                  <o base="label" data="bytes" line="745363441">35 61 62 61 64 33 33 30 2D 30 36 35 31 2D 34 64 61 32 2D 39 34 65 33 2D 30 64 38 32 61 33 34 61 62 64 65 61</o>
+                  <o base="opcode" line="999" name="ALOAD-F">
+                     <o base="int" data="bytes" line="406592538">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes" line="1037783276">00 00 00 00 00 00 00 00</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKEINTERFACE-10">
+                     <o base="int" data="bytes" line="1620087141">00 00 00 00 00 00 00 B9</o>
+                     <o base="string" data="bytes" line="412993410">6A 61 76 61 2F 6C 61 6E 67 2F 52 75 6E 6E 61 62 6C 65</o>
+                     <o base="string" data="bytes" line="1138165866">72 75 6E</o>
+                     <o base="string" data="bytes" line="2116602719">28 29 56</o>
+                     <o base="bool" data="bytes" line="1574815447">01</o>
+                  </o>
+                  <o base="label" data="bytes" line="1697793411">31 66 30 33 61 39 62 35 2D 31 38 31 39 2D 34 61 37 66 2D 38 31 64 36 2D 35 35 64 61 63 33 38 30 61 37 65 62</o>
+                  <o base="opcode" line="999" name="RETURN-11">
+                     <o base="int" data="bytes" line="79835190">00 00 00 00 00 00 00 B1</o>
+                  </o>
+                  <o base="label" data="bytes" line="1192209389">66 30 30 37 37 39 36 34 2D 32 32 32 66 2D 34 64 66 65 2D 62 31 35 30 2D 35 38 30 33 38 62 32 31 61 62 66 66</o>
+               </o>
+            </o>
+         </o>
+         <o abstract="" name="j$lambda$run$0-KClW">
+            <o base="int" data="bytes" line="1853842540">00 00 00 00 00 00 10 0A</o>
+            <o base="string" data="bytes" line="1292726157">28 29 56</o>
+            <o base="string" data="bytes" line="1044125909"/>
+            <o base="tuple" star=""/>
+            <o base="maxs">
+               <o base="int" data="bytes" line="2126770000">00 00 00 00 00 00 00 00</o>
+               <o base="int" data="bytes" line="1646417399">00 00 00 00 00 00 00 00</o>
+            </o>
+            <o base="seq" name="@">
+               <o base="tuple" star="">
+                  <o base="label" data="bytes" line="2129864831">64 66 30 31 32 34 35 35 2D 36 63 66 65 2D 34 30 32 35 2D 38 38 38 32 2D 30 62 64 39 32 61 38 37 34 62 33 30</o>
+                  <o base="opcode" line="999" name="RETURN-14">
+                     <o base="int" data="bytes" line="1076698361">00 00 00 00 00 00 00 B1</o>
+                  </o>
+               </o>
+            </o>
+         </o>
+         <o base="tuple" star="">
+            <o base="InnerClass">
+               <o base="string" data="bytes" line="424108783">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70</o>
+               <o base="string" data="bytes" line="574099411">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73</o>
+               <o base="string" data="bytes" line="1529682912">4C 6F 6F 6B 75 70</o>
+               <o base="int" data="bytes" line="846111641">00 00 00 00 00 00 00 19</o>
+            </o>
+         </o>
+      </o>
+   </objects>
+</program>

--- a/src/test/resources/xmir/disassembled/Main.xmir
+++ b/src/test/resources/xmir/disassembled/Main.xmir
@@ -44,264 +44,92 @@
             <o abstract="" name="arg__[Ljava/lang/String;__0"/>
             <o base="seq" name="@">
                <o base="tuple" star="">
-                  <o base="label" data="bytes" line="886952770">35 30 34 37 61 38 37 30 2D 31 39 61 62 2D 34 65 65 64 2D 38 64 33 33 2D 64 38 63 64 37 61 64 31 64 65 62 39</o>
-                  <o base="opcode" line="999" name="INVOKESTATIC-4">
-                     <o base="int" data="bytes" line="55489116">00 00 00 00 00 00 00 B8</o>
-                     <o base="string" data="bytes" line="1082781210">6A 61 76 61 2F 6C 61 6E 67 2F 53 79 73 74 65 6D</o>
-                     <o base="string" data="bytes" line="713323572">63 75 72 72 65 6E 74 54 69 6D 65 4D 69 6C 6C 69 73</o>
-                     <o base="string" data="bytes" line="418041276">28 29 4A</o>
-                     <o base="bool" data="bytes" line="280571757">00</o>
+                  <o base="label" data="bytes" line="375043862">66 66 31 35 33 35 35 61 2D 39 37 36 61 2D 34 63 65 39 2D 38 61 61 34 2D 30 61 37 31 32 64 35 33 34 64 64 61</o>
+                  <o base="opcode" line="999" name="ICONST_0-4">
+                     <o base="int" data="bytes" line="1529225299">00 00 00 00 00 00 00 03</o>
                   </o>
-                  <o base="opcode" line="999" name="LSTORE-5">
-                     <o base="int" data="bytes" line="678034249">00 00 00 00 00 00 00 37</o>
-                     <o base="int" data="bytes" line="1990879721">00 00 00 00 00 00 00 01</o>
+                  <o base="opcode" line="999" name="BIPUSH-5">
+                     <o base="int" data="bytes" line="1892532129">00 00 00 00 00 00 00 10</o>
+                     <o base="int" data="bytes" line="1712919150">00 00 00 00 00 00 00 0A</o>
                   </o>
-                  <o base="label" data="bytes" line="1851588068">66 38 31 34 63 64 62 39 2D 37 37 38 33 2D 34 32 34 65 2D 61 30 61 39 2D 39 62 32 62 61 36 31 38 32 36 34 33</o>
-                  <o base="opcode" line="999" name="ICONST_0-6">
-                     <o base="int" data="bytes" line="442199751">00 00 00 00 00 00 00 03</o>
+                  <o base="opcode" line="999" name="INVOKESTATIC-6">
+                     <o base="int" data="bytes" line="755804415">00 00 00 00 00 00 00 B8</o>
+                     <o base="string" data="bytes" line="222353765">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 49 6E 74 53 74 72 65 61 6D</o>
+                     <o base="string" data="bytes" line="1013833860">72 61 6E 67 65</o>
+                     <o base="string" data="bytes" line="888811742">28 49 49 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 49 6E 74 53 74 72 65 61 6D 3B</o>
+                     <o base="bool" data="bytes" line="46979963">01</o>
                   </o>
-                  <o base="opcode" line="999" name="BIPUSH-7">
-                     <o base="int" data="bytes" line="1583746955">00 00 00 00 00 00 00 10</o>
-                     <o base="int" data="bytes" line="1933310168">00 00 00 00 00 00 00 0A</o>
+                  <o base="opcode" line="999" name="INVOKEDYNAMIC-7">
+                     <o base="int" data="bytes" line="880915648">00 00 00 00 00 00 00 BA</o>
+                     <o base="string" data="bytes" line="151869105">61 70 70 6C 79</o>
+                     <o base="string" data="bytes" line="1928100376">28 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B</o>
+                     <o base="handle">
+                        <o base="int" data="bytes" line="57682501">00 00 00 00 00 00 00 06</o>
+                        <o base="string" data="bytes" line="1488176490">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4C 61 6D 62 64 61 4D 65 74 61 66 61 63 74 6F 72 79</o>
+                        <o base="string" data="bytes" line="158639278">6D 65 74 61 66 61 63 74 6F 72 79</o>
+                        <o base="string" data="bytes" line="1218432087">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 43 61 6C 6C 53 69 74 65 3B</o>
+                        <o base="bool" data="bytes" line="735774677">00</o>
+                     </o>
+                     <o base="type" data="bytes" line="1947513545">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B</o>
+                     <o base="handle">
+                        <o base="int" data="bytes" line="463339283">00 00 00 00 00 00 00 06</o>
+                        <o base="string" data="bytes" line="632390655">6F 72 67 2F 65 6F 6C 61 6E 67 2F 73 74 72 65 61 6D 73 2F 4D 61 69 6E</o>
+                        <o base="string" data="bytes" line="53168">6C 61 6D 62 64 61 24 6D 61 69 6E 24 30</o>
+                        <o base="string" data="bytes" line="1306300395">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
+                        <o base="bool" data="bytes" line="1724095472">00</o>
+                     </o>
+                     <o base="type" data="bytes" line="920639821">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
                   </o>
-                  <o base="opcode" line="999" name="INVOKESTATIC-8">
-                     <o base="int" data="bytes" line="1015656589">00 00 00 00 00 00 00 B8</o>
-                     <o base="string" data="bytes" line="1726271683">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 49 6E 74 53 74 72 65 61 6D</o>
-                     <o base="string" data="bytes" line="1365121358">72 61 6E 67 65</o>
-                     <o base="string" data="bytes" line="576472622">28 49 49 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 49 6E 74 53 74 72 65 61 6D 3B</o>
-                     <o base="bool" data="bytes" line="1395304786">01</o>
+                  <o base="label" data="bytes" line="1130404033">66 34 62 32 65 37 31 64 2D 63 61 30 66 2D 34 30 30 39 2D 38 34 36 33 2D 37 62 61 34 38 34 31 65 64 36 32 39</o>
+                  <o base="opcode" line="999" name="INVOKEINTERFACE-8">
+                     <o base="int" data="bytes" line="2131593121">00 00 00 00 00 00 00 B9</o>
+                     <o base="string" data="bytes" line="6067245">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 49 6E 74 53 74 72 65 61 6D</o>
+                     <o base="string" data="bytes" line="3970787">6D 61 70 54 6F 4F 62 6A</o>
+                     <o base="string" data="bytes" line="1905082863">28 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 53 74 72 65 61 6D 3B</o>
+                     <o base="bool" data="bytes" line="1184433716">01</o>
                   </o>
                   <o base="opcode" line="999" name="INVOKEDYNAMIC-9">
-                     <o base="int" data="bytes" line="1845198132">00 00 00 00 00 00 00 BA</o>
-                     <o base="string" data="bytes" line="873573192">61 70 70 6C 79</o>
-                     <o base="string" data="bytes" line="1270322867">28 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B</o>
+                     <o base="int" data="bytes" line="619457063">00 00 00 00 00 00 00 BA</o>
+                     <o base="string" data="bytes" line="1691671945">61 70 70 6C 79</o>
+                     <o base="string" data="bytes" line="1675659968">28 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B</o>
                      <o base="handle">
-                        <o base="int" data="bytes" line="976024885">00 00 00 00 00 00 00 06</o>
-                        <o base="string" data="bytes" line="359908222">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4C 61 6D 62 64 61 4D 65 74 61 66 61 63 74 6F 72 79</o>
-                        <o base="string" data="bytes" line="995955090">6D 65 74 61 66 61 63 74 6F 72 79</o>
-                        <o base="string" data="bytes" line="52856891">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 43 61 6C 6C 53 69 74 65 3B</o>
-                        <o base="bool" data="bytes" line="1277739268">00</o>
+                        <o base="int" data="bytes" line="137690707">00 00 00 00 00 00 00 06</o>
+                        <o base="string" data="bytes" line="239745594">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4C 61 6D 62 64 61 4D 65 74 61 66 61 63 74 6F 72 79</o>
+                        <o base="string" data="bytes" line="875938561">6D 65 74 61 66 61 63 74 6F 72 79</o>
+                        <o base="string" data="bytes" line="1927582604">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 43 61 6C 6C 53 69 74 65 3B</o>
+                        <o base="bool" data="bytes" line="330096958">00</o>
                      </o>
-                     <o base="type" data="bytes" line="292767422">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B</o>
+                     <o base="type" data="bytes" line="1091871205">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B</o>
                      <o base="handle">
-                        <o base="int" data="bytes" line="264834029">00 00 00 00 00 00 00 06</o>
-                        <o base="string" data="bytes" line="926136239">6F 72 67 2F 65 6F 6C 61 6E 67 2F 73 74 72 65 61 6D 73 2F 4D 61 69 6E</o>
-                        <o base="string" data="bytes" line="639768677">6C 61 6D 62 64 61 24 6D 61 69 6E 24 30</o>
-                        <o base="string" data="bytes" line="234803375">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
-                        <o base="bool" data="bytes" line="1577058892">00</o>
+                        <o base="int" data="bytes" line="1122805096">00 00 00 00 00 00 00 06</o>
+                        <o base="string" data="bytes" line="619076896">6F 72 67 2F 65 6F 6C 61 6E 67 2F 73 74 72 65 61 6D 73 2F 4D 61 69 6E</o>
+                        <o base="string" data="bytes" line="725994720">6C 61 6D 62 64 61 24 6D 61 69 6E 24 31</o>
+                        <o base="string" data="bytes" line="1892396170">28 49 29 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
+                        <o base="bool" data="bytes" line="704850184">00</o>
                      </o>
-                     <o base="type" data="bytes" line="2112906347">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
+                     <o base="type" data="bytes" line="1154005133">28 49 29 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
                   </o>
-                  <o base="label" data="bytes" line="765699904">35 63 63 30 31 62 34 63 2D 66 64 34 33 2D 34 35 36 35 2D 61 34 64 32 2D 34 31 66 31 63 35 31 35 62 64 32 62</o>
+                  <o base="label" data="bytes" line="926632778">61 64 38 37 35 33 64 63 2D 66 38 39 37 2D 34 37 62 39 2D 39 38 31 64 2D 30 38 36 34 39 32 30 62 63 30 35 37</o>
                   <o base="opcode" line="999" name="INVOKEINTERFACE-A">
-                     <o base="int" data="bytes" line="1246498841">00 00 00 00 00 00 00 B9</o>
-                     <o base="string" data="bytes" line="425302551">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 49 6E 74 53 74 72 65 61 6D</o>
-                     <o base="string" data="bytes" line="1259667456">6D 61 70 54 6F 4F 62 6A</o>
-                     <o base="string" data="bytes" line="2026283561">28 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 53 74 72 65 61 6D 3B</o>
-                     <o base="bool" data="bytes" line="2037248593">01</o>
+                     <o base="int" data="bytes" line="1338498611">00 00 00 00 00 00 00 B9</o>
+                     <o base="string" data="bytes" line="1482456615">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 53 74 72 65 61 6D</o>
+                     <o base="string" data="bytes" line="979816642">74 6F 41 72 72 61 79</o>
+                     <o base="string" data="bytes" line="1347831228">28 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B 29 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B</o>
+                     <o base="bool" data="bytes" line="845599304">01</o>
                   </o>
-                  <o base="opcode" line="999" name="INVOKEDYNAMIC-B">
-                     <o base="int" data="bytes" line="479323786">00 00 00 00 00 00 00 BA</o>
-                     <o base="string" data="bytes" line="2076177237">61 70 70 6C 79</o>
-                     <o base="string" data="bytes" line="1978877819">28 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B</o>
-                     <o base="handle">
-                        <o base="int" data="bytes" line="809757607">00 00 00 00 00 00 00 06</o>
-                        <o base="string" data="bytes" line="496560059">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4C 61 6D 62 64 61 4D 65 74 61 66 61 63 74 6F 72 79</o>
-                        <o base="string" data="bytes" line="1939396103">6D 65 74 61 66 61 63 74 6F 72 79</o>
-                        <o base="string" data="bytes" line="810919662">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 43 61 6C 6C 53 69 74 65 3B</o>
-                        <o base="bool" data="bytes" line="1948250269">00</o>
-                     </o>
-                     <o base="type" data="bytes" line="868407105">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B</o>
-                     <o base="handle">
-                        <o base="int" data="bytes" line="642576084">00 00 00 00 00 00 00 06</o>
-                        <o base="string" data="bytes" line="1910623121">6F 72 67 2F 65 6F 6C 61 6E 67 2F 73 74 72 65 61 6D 73 2F 4D 61 69 6E</o>
-                        <o base="string" data="bytes" line="1808431408">6C 61 6D 62 64 61 24 6D 61 69 6E 24 31</o>
-                        <o base="string" data="bytes" line="1618287841">28 49 29 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
-                        <o base="bool" data="bytes" line="1822452305">00</o>
-                     </o>
-                     <o base="type" data="bytes" line="313390438">28 49 29 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
+                  <o base="opcode" line="999" name="CHECKCAST-B">
+                     <o base="int" data="bytes" line="2005921930">00 00 00 00 00 00 00 C0</o>
+                     <o base="string" data="bytes" line="1415717698">5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
                   </o>
-                  <o base="label" data="bytes" line="859058999">62 65 37 66 63 65 33 38 2D 61 30 61 39 2D 34 63 35 64 2D 38 34 63 36 2D 64 38 37 30 36 32 32 37 37 65 66 64</o>
-                  <o base="opcode" line="999" name="INVOKEINTERFACE-C">
-                     <o base="int" data="bytes" line="174538774">00 00 00 00 00 00 00 B9</o>
-                     <o base="string" data="bytes" line="1765035352">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 53 74 72 65 61 6D</o>
-                     <o base="string" data="bytes" line="607118437">74 6F 41 72 72 61 79</o>
-                     <o base="string" data="bytes" line="858151820">28 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B 29 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B</o>
-                     <o base="bool" data="bytes" line="1838402301">01</o>
+                  <o base="opcode" line="999" name="ASTORE-C">
+                     <o base="int" data="bytes" line="1380030386">00 00 00 00 00 00 00 3A</o>
+                     <o base="int" data="bytes" line="1169901006">00 00 00 00 00 00 00 01</o>
                   </o>
-                  <o base="opcode" line="999" name="CHECKCAST-D">
-                     <o base="int" data="bytes" line="1055899534">00 00 00 00 00 00 00 C0</o>
-                     <o base="string" data="bytes" line="1657910274">5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
+                  <o base="label" data="bytes" line="911695649">65 33 32 38 34 36 64 35 2D 65 32 65 65 2D 34 64 63 62 2D 39 66 30 36 2D 62 30 33 63 62 66 61 30 62 62 32 64</o>
+                  <o base="opcode" line="999" name="RETURN-D">
+                     <o base="int" data="bytes" line="2130051269">00 00 00 00 00 00 00 B1</o>
                   </o>
-                  <o base="opcode" line="999" name="ASTORE-E">
-                     <o base="int" data="bytes" line="334144878">00 00 00 00 00 00 00 3A</o>
-                     <o base="int" data="bytes" line="1200106936">00 00 00 00 00 00 00 03</o>
-                  </o>
-                  <o base="label" data="bytes" line="355347216">39 63 63 37 66 31 37 63 2D 34 39 35 64 2D 34 36 30 32 2D 38 31 64 39 2D 39 36 62 61 35 30 30 39 36 66 39 30</o>
-                  <o base="opcode" line="999" name="ALOAD-F">
-                     <o base="int" data="bytes" line="409154649">00 00 00 00 00 00 00 19</o>
-                     <o base="int" data="bytes" line="1664775907">00 00 00 00 00 00 00 03</o>
-                  </o>
-                  <o base="opcode" line="999" name="INVOKESTATIC-10">
-                     <o base="int" data="bytes" line="1965678216">00 00 00 00 00 00 00 B8</o>
-                     <o base="string" data="bytes" line="1093166391">6A 61 76 61 2F 75 74 69 6C 2F 41 72 72 61 79 73</o>
-                     <o base="string" data="bytes" line="2044543541">73 74 72 65 61 6D</o>
-                     <o base="string" data="bytes" line="137121390">28 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 53 74 72 65 61 6D 3B</o>
-                     <o base="bool" data="bytes" line="91195650">00</o>
-                  </o>
-                  <o base="opcode" line="999" name="INVOKEDYNAMIC-11">
-                     <o base="int" data="bytes" line="625721225">00 00 00 00 00 00 00 BA</o>
-                     <o base="string" data="bytes" line="817619933">74 65 73 74</o>
-                     <o base="string" data="bytes" line="1444632622">28 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 50 72 65 64 69 63 61 74 65 3B</o>
-                     <o base="handle">
-                        <o base="int" data="bytes" line="1824886892">00 00 00 00 00 00 00 06</o>
-                        <o base="string" data="bytes" line="116712236">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4C 61 6D 62 64 61 4D 65 74 61 66 61 63 74 6F 72 79</o>
-                        <o base="string" data="bytes" line="1515796001">6D 65 74 61 66 61 63 74 6F 72 79</o>
-                        <o base="string" data="bytes" line="1436786622">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 43 61 6C 6C 53 69 74 65 3B</o>
-                        <o base="bool" data="bytes" line="1418431518">00</o>
-                     </o>
-                     <o base="type" data="bytes" line="1970762215">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 29 5A</o>
-                     <o base="handle">
-                        <o base="int" data="bytes" line="1567234812">00 00 00 00 00 00 00 06</o>
-                        <o base="string" data="bytes" line="970091641">6F 72 67 2F 65 6F 6C 61 6E 67 2F 73 74 72 65 61 6D 73 2F 4D 61 69 6E</o>
-                        <o base="string" data="bytes" line="430021491">6C 61 6D 62 64 61 24 6D 61 69 6E 24 32</o>
-                        <o base="string" data="bytes" line="1155956754">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 5A</o>
-                        <o base="bool" data="bytes" line="1796283187">00</o>
-                     </o>
-                     <o base="type" data="bytes" line="887201072">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 5A</o>
-                  </o>
-                  <o base="label" data="bytes" line="478295818">63 37 61 38 33 35 31 66 2D 36 32 30 63 2D 34 39 64 33 2D 39 39 66 39 2D 66 35 62 32 39 65 31 37 61 32 63 37</o>
-                  <o base="opcode" line="999" name="INVOKEINTERFACE-12">
-                     <o base="int" data="bytes" line="943554756">00 00 00 00 00 00 00 B9</o>
-                     <o base="string" data="bytes" line="2107428727">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 53 74 72 65 61 6D</o>
-                     <o base="string" data="bytes" line="39385645">66 69 6C 74 65 72</o>
-                     <o base="string" data="bytes" line="2022221175">28 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 50 72 65 64 69 63 61 74 65 3B 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 53 74 72 65 61 6D 3B</o>
-                     <o base="bool" data="bytes" line="1525827862">01</o>
-                  </o>
-                  <o base="opcode" line="999" name="INVOKEDYNAMIC-13">
-                     <o base="int" data="bytes" line="1545975626">00 00 00 00 00 00 00 BA</o>
-                     <o base="string" data="bytes" line="1680813948">61 70 70 6C 79 41 73 49 6E 74</o>
-                     <o base="string" data="bytes" line="1538274055">28 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 54 6F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B</o>
-                     <o base="handle">
-                        <o base="int" data="bytes" line="1435518808">00 00 00 00 00 00 00 06</o>
-                        <o base="string" data="bytes" line="105094909">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4C 61 6D 62 64 61 4D 65 74 61 66 61 63 74 6F 72 79</o>
-                        <o base="string" data="bytes" line="1273830798">6D 65 74 61 66 61 63 74 6F 72 79</o>
-                        <o base="string" data="bytes" line="789666066">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 43 61 6C 6C 53 69 74 65 3B</o>
-                        <o base="bool" data="bytes" line="1811168383">00</o>
-                     </o>
-                     <o base="type" data="bytes" line="1051199675">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 29 49</o>
-                     <o base="handle">
-                        <o base="int" data="bytes" line="479622467">00 00 00 00 00 00 00 06</o>
-                        <o base="string" data="bytes" line="1738518692">6F 72 67 2F 65 6F 6C 61 6E 67 2F 73 74 72 65 61 6D 73 2F 4D 61 69 6E</o>
-                        <o base="string" data="bytes" line="631632161">6C 61 6D 62 64 61 24 6D 61 69 6E 24 33</o>
-                        <o base="string" data="bytes" line="2019496193">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 49</o>
-                        <o base="bool" data="bytes" line="1324739899">00</o>
-                     </o>
-                     <o base="type" data="bytes" line="1441830595">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 49</o>
-                  </o>
-                  <o base="label" data="bytes" line="892919255">36 31 61 39 62 35 37 65 2D 34 31 31 35 2D 34 34 34 36 2D 61 65 64 64 2D 38 38 62 66 39 39 63 62 64 37 61 61</o>
-                  <o base="opcode" line="999" name="INVOKEINTERFACE-14">
-                     <o base="int" data="bytes" line="1849105056">00 00 00 00 00 00 00 B9</o>
-                     <o base="string" data="bytes" line="966627749">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 53 74 72 65 61 6D</o>
-                     <o base="string" data="bytes" line="217315033">6D 61 70 54 6F 49 6E 74</o>
-                     <o base="string" data="bytes" line="2087384598">28 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 54 6F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 49 6E 74 53 74 72 65 61 6D 3B</o>
-                     <o base="bool" data="bytes" line="1215741559">01</o>
-                  </o>
-                  <o base="label" data="bytes" line="1911541260">64 66 62 65 63 32 32 63 2D 65 64 30 64 2D 34 34 39 30 2D 61 32 65 64 2D 33 66 35 61 35 65 66 38 38 63 36 64</o>
-                  <o base="opcode" line="999" name="INVOKEINTERFACE-15">
-                     <o base="int" data="bytes" line="1830316490">00 00 00 00 00 00 00 B9</o>
-                     <o base="string" data="bytes" line="147561243">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 49 6E 74 53 74 72 65 61 6D</o>
-                     <o base="string" data="bytes" line="709548181">73 75 6D</o>
-                     <o base="string" data="bytes" line="1274855074">28 29 49</o>
-                     <o base="bool" data="bytes" line="892234647">01</o>
-                  </o>
-                  <o base="opcode" line="999" name="ISTORE-16">
-                     <o base="int" data="bytes" line="1972944027">00 00 00 00 00 00 00 36</o>
-                     <o base="int" data="bytes" line="454806459">00 00 00 00 00 00 00 04</o>
-                  </o>
-                  <o base="label" data="bytes" line="1262199930">36 32 36 62 33 34 33 61 2D 33 65 31 66 2D 34 34 37 64 2D 62 31 63 38 2D 34 64 62 63 37 37 35 30 62 63 66 34</o>
-                  <o base="opcode" line="999" name="GETSTATIC-17">
-                     <o base="int" data="bytes" line="2146401242">00 00 00 00 00 00 00 B2</o>
-                     <o base="string" data="bytes" line="1734332222">6A 61 76 61 2F 6C 61 6E 67 2F 53 79 73 74 65 6D</o>
-                     <o base="string" data="bytes" line="702345543">6F 75 74</o>
-                     <o base="string" data="bytes" line="1678811217">4C 6A 61 76 61 2F 69 6F 2F 50 72 69 6E 74 53 74 72 65 61 6D 3B</o>
-                  </o>
-                  <o base="opcode" line="999" name="LDC-18">
-                     <o base="int" data="bytes" line="1703966362">00 00 00 00 00 00 00 12</o>
-                     <o base="string" data="bytes" line="1770776307">73 75 6D 3D 25 64 20 74 69 6D 65 3D 25 64 0A</o>
-                  </o>
-                  <o base="opcode" line="999" name="ICONST_2-19">
-                     <o base="int" data="bytes" line="603044943">00 00 00 00 00 00 00 05</o>
-                  </o>
-                  <o base="opcode" line="999" name="ANEWARRAY-1A">
-                     <o base="int" data="bytes" line="1099677507">00 00 00 00 00 00 00 BD</o>
-                     <o base="string" data="bytes" line="698012466">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
-                  </o>
-                  <o base="opcode" line="999" name="DUP-1B">
-                     <o base="int" data="bytes" line="518461129">00 00 00 00 00 00 00 59</o>
-                  </o>
-                  <o base="opcode" line="999" name="ICONST_0-1C">
-                     <o base="int" data="bytes" line="1956667874">00 00 00 00 00 00 00 03</o>
-                  </o>
-                  <o base="opcode" line="999" name="ILOAD-1D">
-                     <o base="int" data="bytes" line="1470686627">00 00 00 00 00 00 00 15</o>
-                     <o base="int" data="bytes" line="337545626">00 00 00 00 00 00 00 04</o>
-                  </o>
-                  <o base="opcode" line="999" name="INVOKESTATIC-1E">
-                     <o base="int" data="bytes" line="540857091">00 00 00 00 00 00 00 B8</o>
-                     <o base="string" data="bytes" line="1449198113">6A 61 76 61 2F 6C 61 6E 67 2F 49 6E 74 65 67 65 72</o>
-                     <o base="string" data="bytes" line="1662134441">76 61 6C 75 65 4F 66</o>
-                     <o base="string" data="bytes" line="1665222181">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 49 6E 74 65 67 65 72 3B</o>
-                     <o base="bool" data="bytes" line="976151014">00</o>
-                  </o>
-                  <o base="opcode" line="999" name="AASTORE-1F">
-                     <o base="int" data="bytes" line="1772394644">00 00 00 00 00 00 00 53</o>
-                  </o>
-                  <o base="opcode" line="999" name="DUP-20">
-                     <o base="int" data="bytes" line="1484516592">00 00 00 00 00 00 00 59</o>
-                  </o>
-                  <o base="opcode" line="999" name="ICONST_1-21">
-                     <o base="int" data="bytes" line="25096432">00 00 00 00 00 00 00 04</o>
-                  </o>
-                  <o base="opcode" line="999" name="INVOKESTATIC-22">
-                     <o base="int" data="bytes" line="725214678">00 00 00 00 00 00 00 B8</o>
-                     <o base="string" data="bytes" line="957319967">6A 61 76 61 2F 6C 61 6E 67 2F 53 79 73 74 65 6D</o>
-                     <o base="string" data="bytes" line="2007855569">63 75 72 72 65 6E 74 54 69 6D 65 4D 69 6C 6C 69 73</o>
-                     <o base="string" data="bytes" line="209531188">28 29 4A</o>
-                     <o base="bool" data="bytes" line="1865815201">00</o>
-                  </o>
-                  <o base="opcode" line="999" name="LLOAD-23">
-                     <o base="int" data="bytes" line="1144516473">00 00 00 00 00 00 00 16</o>
-                     <o base="int" data="bytes" line="2042064372">00 00 00 00 00 00 00 01</o>
-                  </o>
-                  <o base="opcode" line="999" name="LSUB-24">
-                     <o base="int" data="bytes" line="884063171">00 00 00 00 00 00 00 65</o>
-                  </o>
-                  <o base="opcode" line="999" name="INVOKESTATIC-25">
-                     <o base="int" data="bytes" line="301765847">00 00 00 00 00 00 00 B8</o>
-                     <o base="string" data="bytes" line="221163100">6A 61 76 61 2F 6C 61 6E 67 2F 4C 6F 6E 67</o>
-                     <o base="string" data="bytes" line="2137698065">76 61 6C 75 65 4F 66</o>
-                     <o base="string" data="bytes" line="505428664">28 4A 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4C 6F 6E 67 3B</o>
-                     <o base="bool" data="bytes" line="1260026">00</o>
-                  </o>
-                  <o base="opcode" line="999" name="AASTORE-26">
-                     <o base="int" data="bytes" line="1242923005">00 00 00 00 00 00 00 53</o>
-                  </o>
-                  <o base="opcode" line="999" name="INVOKEVIRTUAL-27">
-                     <o base="int" data="bytes" line="1454456780">00 00 00 00 00 00 00 B6</o>
-                     <o base="string" data="bytes" line="415696501">6A 61 76 61 2F 69 6F 2F 50 72 69 6E 74 53 74 72 65 61 6D</o>
-                     <o base="string" data="bytes" line="1054939473">70 72 69 6E 74 66</o>
-                     <o base="string" data="bytes" line="1165451287">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 29 4C 6A 61 76 61 2F 69 6F 2F 50 72 69 6E 74 53 74 72 65 61 6D 3B</o>
-                     <o base="bool" data="bytes" line="472726258">00</o>
-                  </o>
-                  <o base="opcode" line="999" name="POP-28">
-                     <o base="int" data="bytes" line="671316123">00 00 00 00 00 00 00 57</o>
-                  </o>
-                  <o base="label" data="bytes" line="673448444">37 37 39 37 65 32 66 65 2D 64 62 66 66 2D 34 33 30 65 2D 61 38 31 37 2D 64 65 36 34 36 35 61 63 32 38 61 32</o>
-                  <o base="opcode" line="999" name="RETURN-29">
-                     <o base="int" data="bytes" line="505580249">00 00 00 00 00 00 00 B1</o>
-                  </o>
-                  <o base="label" data="bytes" line="225839904">65 61 30 32 36 33 34 36 2D 31 33 61 65 2D 34 37 33 62 2D 62 66 65 62 2D 33 64 35 63 35 32 38 38 32 30 61 36</o>
+                  <o base="label" data="bytes" line="1508377958">36 66 33 31 30 39 34 66 2D 62 64 64 36 2D 34 36 34 66 2D 38 38 63 39 2D 39 35 37 63 37 37 65 64 38 38 30 39</o>
                </o>
             </o>
          </o>

--- a/src/test/resources/xmir/disassembled/Main.xmir
+++ b/src/test/resources/xmir/disassembled/Main.xmir
@@ -33,103 +33,121 @@
          <o base="string" data="bytes" line="1046628787" name="supername">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
          <o base="tuple" name="interfaces" star=""/>
          <o abstract="" name="j$main-KFtMamF2YS9sYW5nL1N0cmluZzspVg==">
-            <o base="int" data="bytes" line="2099443768">00 00 00 00 00 00 00 89</o>
-            <o base="string" data="bytes" line="1761479440">28 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 56</o>
-            <o base="string" data="bytes" line="1365003218"/>
+            <o base="int" data="bytes" line="1562859400">00 00 00 00 00 00 00 89</o>
+            <o base="string" data="bytes" line="1841585714">28 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 56</o>
+            <o base="string" data="bytes" line="689445388"/>
             <o base="tuple" star=""/>
             <o base="maxs">
-               <o base="int" data="bytes" line="485625465">00 00 00 00 00 00 00 09</o>
-               <o base="int" data="bytes" line="1962203969">00 00 00 00 00 00 00 05</o>
+               <o base="int" data="bytes" line="1045509971">00 00 00 00 00 00 00 09</o>
+               <o base="int" data="bytes" line="1159106832">00 00 00 00 00 00 00 04</o>
             </o>
             <o abstract="" name="arg__[Ljava/lang/String;__0"/>
             <o base="seq" name="@">
                <o base="tuple" star="">
-                  <o base="label" data="bytes" line="375043862">66 66 31 35 33 35 35 61 2D 39 37 36 61 2D 34 63 65 39 2D 38 61 61 34 2D 30 61 37 31 32 64 35 33 34 64 64 61</o>
-                  <o base="opcode" line="999" name="ICONST_0-4">
-                     <o base="int" data="bytes" line="1529225299">00 00 00 00 00 00 00 03</o>
+                  <o base="label" data="bytes" line="946963267">66 34 35 36 38 63 30 39 2D 33 38 34 34 2D 34 64 64 62 2D 61 31 30 66 2D 64 37 33 39 36 61 34 39 36 37 63 62</o>
+                  <o base="opcode" line="999" name="INVOKESTATIC-4">
+                     <o base="int" data="bytes" line="1514707671">00 00 00 00 00 00 00 B8</o>
+                     <o base="string" data="bytes" line="1454557878">6A 61 76 61 2F 6C 61 6E 67 2F 53 79 73 74 65 6D</o>
+                     <o base="string" data="bytes" line="870451051">63 75 72 72 65 6E 74 54 69 6D 65 4D 69 6C 6C 69 73</o>
+                     <o base="string" data="bytes" line="441939972">28 29 4A</o>
+                     <o base="bool" data="bytes" line="1747279523">00</o>
                   </o>
-                  <o base="opcode" line="999" name="BIPUSH-5">
-                     <o base="int" data="bytes" line="1892532129">00 00 00 00 00 00 00 10</o>
-                     <o base="int" data="bytes" line="1712919150">00 00 00 00 00 00 00 0A</o>
+                  <o base="opcode" line="999" name="LSTORE-5">
+                     <o base="int" data="bytes" line="938728787">00 00 00 00 00 00 00 37</o>
+                     <o base="int" data="bytes" line="805802905">00 00 00 00 00 00 00 01</o>
                   </o>
-                  <o base="opcode" line="999" name="INVOKESTATIC-6">
-                     <o base="int" data="bytes" line="755804415">00 00 00 00 00 00 00 B8</o>
-                     <o base="string" data="bytes" line="222353765">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 49 6E 74 53 74 72 65 61 6D</o>
-                     <o base="string" data="bytes" line="1013833860">72 61 6E 67 65</o>
-                     <o base="string" data="bytes" line="888811742">28 49 49 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 49 6E 74 53 74 72 65 61 6D 3B</o>
-                     <o base="bool" data="bytes" line="46979963">01</o>
+                  <o base="label" data="bytes" line="373806965">36 31 38 34 33 62 65 36 2D 35 36 36 33 2D 34 63 38 64 2D 38 36 38 34 2D 39 66 62 61 64 63 35 34 32 64 31 35</o>
+                  <o base="opcode" line="999" name="BIPUSH-6">
+                     <o base="int" data="bytes" line="596335150">00 00 00 00 00 00 00 10</o>
+                     <o base="int" data="bytes" line="734616798">00 00 00 00 00 00 00 0A</o>
                   </o>
-                  <o base="opcode" line="999" name="INVOKEDYNAMIC-7">
-                     <o base="int" data="bytes" line="880915648">00 00 00 00 00 00 00 BA</o>
-                     <o base="string" data="bytes" line="151869105">61 70 70 6C 79</o>
-                     <o base="string" data="bytes" line="1928100376">28 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B</o>
-                     <o base="handle">
-                        <o base="int" data="bytes" line="57682501">00 00 00 00 00 00 00 06</o>
-                        <o base="string" data="bytes" line="1488176490">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4C 61 6D 62 64 61 4D 65 74 61 66 61 63 74 6F 72 79</o>
-                        <o base="string" data="bytes" line="158639278">6D 65 74 61 66 61 63 74 6F 72 79</o>
-                        <o base="string" data="bytes" line="1218432087">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 43 61 6C 6C 53 69 74 65 3B</o>
-                        <o base="bool" data="bytes" line="735774677">00</o>
-                     </o>
-                     <o base="type" data="bytes" line="1947513545">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B</o>
-                     <o base="handle">
-                        <o base="int" data="bytes" line="463339283">00 00 00 00 00 00 00 06</o>
-                        <o base="string" data="bytes" line="632390655">6F 72 67 2F 65 6F 6C 61 6E 67 2F 73 74 72 65 61 6D 73 2F 4D 61 69 6E</o>
-                        <o base="string" data="bytes" line="53168">6C 61 6D 62 64 61 24 6D 61 69 6E 24 30</o>
-                        <o base="string" data="bytes" line="1306300395">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
-                        <o base="bool" data="bytes" line="1724095472">00</o>
-                     </o>
-                     <o base="type" data="bytes" line="920639821">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
+                  <o base="opcode" line="999" name="ISTORE-7">
+                     <o base="int" data="bytes" line="1317197448">00 00 00 00 00 00 00 36</o>
+                     <o base="int" data="bytes" line="1568069013">00 00 00 00 00 00 00 03</o>
                   </o>
-                  <o base="label" data="bytes" line="1130404033">66 34 62 32 65 37 31 64 2D 63 61 30 66 2D 34 30 30 39 2D 38 34 36 33 2D 37 62 61 34 38 34 31 65 64 36 32 39</o>
-                  <o base="opcode" line="999" name="INVOKEINTERFACE-8">
-                     <o base="int" data="bytes" line="2131593121">00 00 00 00 00 00 00 B9</o>
-                     <o base="string" data="bytes" line="6067245">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 49 6E 74 53 74 72 65 61 6D</o>
-                     <o base="string" data="bytes" line="3970787">6D 61 70 54 6F 4F 62 6A</o>
-                     <o base="string" data="bytes" line="1905082863">28 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 53 74 72 65 61 6D 3B</o>
-                     <o base="bool" data="bytes" line="1184433716">01</o>
+                  <o base="label" data="bytes" line="25442513">35 61 64 63 66 34 34 36 2D 34 66 37 37 2D 34 31 38 36 2D 61 36 35 30 2D 30 37 36 30 34 61 63 39 61 36 33 65</o>
+                  <o base="opcode" line="999" name="GETSTATIC-8">
+                     <o base="int" data="bytes" line="2055035995">00 00 00 00 00 00 00 B2</o>
+                     <o base="string" data="bytes" line="565192967">6A 61 76 61 2F 6C 61 6E 67 2F 53 79 73 74 65 6D</o>
+                     <o base="string" data="bytes" line="307219184">6F 75 74</o>
+                     <o base="string" data="bytes" line="265213808">4C 6A 61 76 61 2F 69 6F 2F 50 72 69 6E 74 53 74 72 65 61 6D 3B</o>
                   </o>
-                  <o base="opcode" line="999" name="INVOKEDYNAMIC-9">
-                     <o base="int" data="bytes" line="619457063">00 00 00 00 00 00 00 BA</o>
-                     <o base="string" data="bytes" line="1691671945">61 70 70 6C 79</o>
-                     <o base="string" data="bytes" line="1675659968">28 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B</o>
-                     <o base="handle">
-                        <o base="int" data="bytes" line="137690707">00 00 00 00 00 00 00 06</o>
-                        <o base="string" data="bytes" line="239745594">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4C 61 6D 62 64 61 4D 65 74 61 66 61 63 74 6F 72 79</o>
-                        <o base="string" data="bytes" line="875938561">6D 65 74 61 66 61 63 74 6F 72 79</o>
-                        <o base="string" data="bytes" line="1927582604">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 43 61 6C 6C 53 69 74 65 3B</o>
-                        <o base="bool" data="bytes" line="330096958">00</o>
-                     </o>
-                     <o base="type" data="bytes" line="1091871205">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B</o>
-                     <o base="handle">
-                        <o base="int" data="bytes" line="1122805096">00 00 00 00 00 00 00 06</o>
-                        <o base="string" data="bytes" line="619076896">6F 72 67 2F 65 6F 6C 61 6E 67 2F 73 74 72 65 61 6D 73 2F 4D 61 69 6E</o>
-                        <o base="string" data="bytes" line="725994720">6C 61 6D 62 64 61 24 6D 61 69 6E 24 31</o>
-                        <o base="string" data="bytes" line="1892396170">28 49 29 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
-                        <o base="bool" data="bytes" line="704850184">00</o>
-                     </o>
-                     <o base="type" data="bytes" line="1154005133">28 49 29 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
+                  <o base="opcode" line="999" name="LDC-9">
+                     <o base="int" data="bytes" line="1364185959">00 00 00 00 00 00 00 12</o>
+                     <o base="string" data="bytes" line="983953544">73 75 6D 3D 25 64 20 74 69 6D 65 3D 25 64 0A</o>
                   </o>
-                  <o base="label" data="bytes" line="926632778">61 64 38 37 35 33 64 63 2D 66 38 39 37 2D 34 37 62 39 2D 39 38 31 64 2D 30 38 36 34 39 32 30 62 63 30 35 37</o>
-                  <o base="opcode" line="999" name="INVOKEINTERFACE-A">
-                     <o base="int" data="bytes" line="1338498611">00 00 00 00 00 00 00 B9</o>
-                     <o base="string" data="bytes" line="1482456615">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 53 74 72 65 61 6D</o>
-                     <o base="string" data="bytes" line="979816642">74 6F 41 72 72 61 79</o>
-                     <o base="string" data="bytes" line="1347831228">28 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B 29 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B</o>
-                     <o base="bool" data="bytes" line="845599304">01</o>
+                  <o base="opcode" line="999" name="ICONST_2-A">
+                     <o base="int" data="bytes" line="2105552200">00 00 00 00 00 00 00 05</o>
                   </o>
-                  <o base="opcode" line="999" name="CHECKCAST-B">
-                     <o base="int" data="bytes" line="2005921930">00 00 00 00 00 00 00 C0</o>
-                     <o base="string" data="bytes" line="1415717698">5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
+                  <o base="opcode" line="999" name="ANEWARRAY-B">
+                     <o base="int" data="bytes" line="1727102670">00 00 00 00 00 00 00 BD</o>
+                     <o base="string" data="bytes" line="1996436769">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
                   </o>
-                  <o base="opcode" line="999" name="ASTORE-C">
-                     <o base="int" data="bytes" line="1380030386">00 00 00 00 00 00 00 3A</o>
-                     <o base="int" data="bytes" line="1169901006">00 00 00 00 00 00 00 01</o>
+                  <o base="opcode" line="999" name="DUP-C">
+                     <o base="int" data="bytes" line="1170414409">00 00 00 00 00 00 00 59</o>
                   </o>
-                  <o base="label" data="bytes" line="911695649">65 33 32 38 34 36 64 35 2D 65 32 65 65 2D 34 64 63 62 2D 39 66 30 36 2D 62 30 33 63 62 66 61 30 62 62 32 64</o>
-                  <o base="opcode" line="999" name="RETURN-D">
-                     <o base="int" data="bytes" line="2130051269">00 00 00 00 00 00 00 B1</o>
+                  <o base="opcode" line="999" name="ICONST_0-D">
+                     <o base="int" data="bytes" line="906924788">00 00 00 00 00 00 00 03</o>
                   </o>
-                  <o base="label" data="bytes" line="1508377958">36 66 33 31 30 39 34 66 2D 62 64 64 36 2D 34 36 34 66 2D 38 38 63 39 2D 39 35 37 63 37 37 65 64 38 38 30 39</o>
+                  <o base="opcode" line="999" name="ILOAD-E">
+                     <o base="int" data="bytes" line="1268996700">00 00 00 00 00 00 00 15</o>
+                     <o base="int" data="bytes" line="1250172285">00 00 00 00 00 00 00 03</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKESTATIC-F">
+                     <o base="int" data="bytes" line="814699789">00 00 00 00 00 00 00 B8</o>
+                     <o base="string" data="bytes" line="275084769">6A 61 76 61 2F 6C 61 6E 67 2F 49 6E 74 65 67 65 72</o>
+                     <o base="string" data="bytes" line="2120914395">76 61 6C 75 65 4F 66</o>
+                     <o base="string" data="bytes" line="574035711">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 49 6E 74 65 67 65 72 3B</o>
+                     <o base="bool" data="bytes" line="1776088194">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="AASTORE-10">
+                     <o base="int" data="bytes" line="526254363">00 00 00 00 00 00 00 53</o>
+                  </o>
+                  <o base="opcode" line="999" name="DUP-11">
+                     <o base="int" data="bytes" line="1615307236">00 00 00 00 00 00 00 59</o>
+                  </o>
+                  <o base="opcode" line="999" name="ICONST_1-12">
+                     <o base="int" data="bytes" line="1685488795">00 00 00 00 00 00 00 04</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKESTATIC-13">
+                     <o base="int" data="bytes" line="1818523660">00 00 00 00 00 00 00 B8</o>
+                     <o base="string" data="bytes" line="2032859908">6A 61 76 61 2F 6C 61 6E 67 2F 53 79 73 74 65 6D</o>
+                     <o base="string" data="bytes" line="346973225">63 75 72 72 65 6E 74 54 69 6D 65 4D 69 6C 6C 69 73</o>
+                     <o base="string" data="bytes" line="1178233807">28 29 4A</o>
+                     <o base="bool" data="bytes" line="657454663">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="LLOAD-14">
+                     <o base="int" data="bytes" line="759242761">00 00 00 00 00 00 00 16</o>
+                     <o base="int" data="bytes" line="2079560109">00 00 00 00 00 00 00 01</o>
+                  </o>
+                  <o base="opcode" line="999" name="LSUB-15">
+                     <o base="int" data="bytes" line="1922835613">00 00 00 00 00 00 00 65</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKESTATIC-16">
+                     <o base="int" data="bytes" line="490857568">00 00 00 00 00 00 00 B8</o>
+                     <o base="string" data="bytes" line="1515276558">6A 61 76 61 2F 6C 61 6E 67 2F 4C 6F 6E 67</o>
+                     <o base="string" data="bytes" line="40029101">76 61 6C 75 65 4F 66</o>
+                     <o base="string" data="bytes" line="462946355">28 4A 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4C 6F 6E 67 3B</o>
+                     <o base="bool" data="bytes" line="1566461544">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="AASTORE-17">
+                     <o base="int" data="bytes" line="1759595527">00 00 00 00 00 00 00 53</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKEVIRTUAL-18">
+                     <o base="int" data="bytes" line="517189462">00 00 00 00 00 00 00 B6</o>
+                     <o base="string" data="bytes" line="1739871877">6A 61 76 61 2F 69 6F 2F 50 72 69 6E 74 53 74 72 65 61 6D</o>
+                     <o base="string" data="bytes" line="374511550">70 72 69 6E 74 66</o>
+                     <o base="string" data="bytes" line="439789985">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 29 4C 6A 61 76 61 2F 69 6F 2F 50 72 69 6E 74 53 74 72 65 61 6D 3B</o>
+                     <o base="bool" data="bytes" line="1104801440">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="POP-19">
+                     <o base="int" data="bytes" line="1314925306">00 00 00 00 00 00 00 57</o>
+                  </o>
+                  <o base="label" data="bytes" line="1122751170">63 64 37 65 61 30 65 35 2D 35 63 39 35 2D 34 35 38 61 2D 61 34 34 31 2D 65 37 36 65 30 34 61 35 63 61 39 33</o>
+                  <o base="opcode" line="999" name="RETURN-1A">
+                     <o base="int" data="bytes" line="1729518564">00 00 00 00 00 00 00 B1</o>
+                  </o>
+                  <o base="label" data="bytes" line="1681585647">30 33 35 64 30 64 36 66 2D 62 30 64 30 2D 34 62 32 35 2D 38 37 33 38 2D 62 36 30 65 66 39 30 37 35 61 61 37</o>
                </o>
             </o>
          </o>

--- a/src/test/resources/xmir/disassembled/Main.xmir
+++ b/src/test/resources/xmir/disassembled/Main.xmir
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<program dob="2024-07-11T08:17:48.365033Z"
+  ms="1720685868369"
+  name="j$Main"
+  revision="0.0.0"
+  time="2024-07-11T08:17:48.365033Z"
+  version="0.0.0">
+   <listing>yv66vgAAADQApwoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCgAIAAkHAAoMAAsADAEAEGphdmEvbGFuZy9TeXN0ZW0BABFjdXJyZW50VGltZU1pbGxpcwEAAygpSgsADgAPBwAQDAARABIBABpqYXZhL3V0aWwvc3RyZWFtL0ludFN0cmVhbQEABXJhbmdlAQAgKElJKUxqYXZhL3V0aWwvc3RyZWFtL0ludFN0cmVhbTsSAAAAFAwAFQAWAQAFYXBwbHkBACIoKUxqYXZhL3V0aWwvZnVuY3Rpb24vSW50RnVuY3Rpb247CwAOABgMABkAGgEACG1hcFRvT2JqAQA7KExqYXZhL3V0aWwvZnVuY3Rpb24vSW50RnVuY3Rpb247KUxqYXZhL3V0aWwvc3RyZWFtL1N0cmVhbTsSAAEAFAsAHQAeBwAfDAAgACEBABdqYXZhL3V0aWwvc3RyZWFtL1N0cmVhbQEAB3RvQXJyYXkBADUoTGphdmEvdXRpbC9mdW5jdGlvbi9JbnRGdW5jdGlvbjspW0xqYXZhL2xhbmcvT2JqZWN0OwcAIwEAE1tMamF2YS9sYW5nL1N0cmluZzsKACUAJgcAJwwAKAApAQAQamF2YS91dGlsL0FycmF5cwEABnN0cmVhbQEALihbTGphdmEvbGFuZy9PYmplY3Q7KUxqYXZhL3V0aWwvc3RyZWFtL1N0cmVhbTsSAAIAKwwALAAtAQAEdGVzdAEAICgpTGphdmEvdXRpbC9mdW5jdGlvbi9QcmVkaWNhdGU7CwAdAC8MADAAMQEABmZpbHRlcgEAOShMamF2YS91dGlsL2Z1bmN0aW9uL1ByZWRpY2F0ZTspTGphdmEvdXRpbC9zdHJlYW0vU3RyZWFtOxIAAwAzDAA0ADUBAAphcHBseUFzSW50AQAkKClMamF2YS91dGlsL2Z1bmN0aW9uL1RvSW50RnVuY3Rpb247CwAdADcMADgAOQEACG1hcFRvSW50AQBAKExqYXZhL3V0aWwvZnVuY3Rpb24vVG9JbnRGdW5jdGlvbjspTGphdmEvdXRpbC9zdHJlYW0vSW50U3RyZWFtOwsADgA7DAA8AD0BAANzdW0BAAMoKUkJAAgAPwwAQABBAQADb3V0AQAVTGphdmEvaW8vUHJpbnRTdHJlYW07CABDAQAPc3VtPSVkIHRpbWU9JWQKCgBFAEYHAEcMAEgASQEAEWphdmEvbGFuZy9JbnRlZ2VyAQAHdmFsdWVPZgEAFihJKUxqYXZhL2xhbmcvSW50ZWdlcjsKAEsATAcATQwASABOAQAOamF2YS9sYW5nL0xvbmcBABMoSilMamF2YS9sYW5nL0xvbmc7CgBQAFEHAFIMAFMAVAEAE2phdmEvaW8vUHJpbnRTdHJlYW0BAAZwcmludGYBADwoTGphdmEvbGFuZy9TdHJpbmc7W0xqYXZhL2xhbmcvT2JqZWN0OylMamF2YS9pby9QcmludFN0cmVhbTsKAEUAVgwAVwBYAQAIcGFyc2VJbnQBABUoTGphdmEvbGFuZy9TdHJpbmc7KUkIAFoBAAAKAFwAXQcAXgwAXwBgAQAQamF2YS9sYW5nL1N0cmluZwEABmVxdWFscwEAFShMamF2YS9sYW5nL09iamVjdDspWgoAYgBjBwBkDABIAGUBABFqYXZhL2xhbmcvQm9vbGVhbgEAFihaKUxqYXZhL2xhbmcvQm9vbGVhbjsKAGIAXQoAXABoDABIAGkBABUoSSlMamF2YS9sYW5nL1N0cmluZzsHAGsBABdvcmcvZW9sYW5nL3N0cmVhbXMvTWFpbgEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBABJMb2NhbFZhcmlhYmxlVGFibGUBAAR0aGlzAQAZTG9yZy9lb2xhbmcvc3RyZWFtcy9NYWluOwEABG1haW4BABYoW0xqYXZhL2xhbmcvU3RyaW5nOylWAQAEYXJncwEABXN0YXJ0AQABSgEAB3N0cmluZ3MBAAFJAQANbGFtYmRhJG1haW4kMwEAAXMBABJMamF2YS9sYW5nL1N0cmluZzsBAA1sYW1iZGEkbWFpbiQyAQAVKExqYXZhL2xhbmcvU3RyaW5nOylaAQANbGFtYmRhJG1haW4kMQEAFihJKVtMamF2YS9sYW5nL1N0cmluZzsBAAN4JDABAA1sYW1iZGEkbWFpbiQwAQABaQEAClNvdXJjZUZpbGUBAAlNYWluLmphdmEBABBCb290c3RyYXBNZXRob2RzDwYAhgoAhwCIBwCJDACKAIsBACJqYXZhL2xhbmcvaW52b2tlL0xhbWJkYU1ldGFmYWN0b3J5AQALbWV0YWZhY3RvcnkBAMwoTGphdmEvbGFuZy9pbnZva2UvTWV0aG9kSGFuZGxlcyRMb29rdXA7TGphdmEvbGFuZy9TdHJpbmc7TGphdmEvbGFuZy9pbnZva2UvTWV0aG9kVHlwZTtMamF2YS9sYW5nL2ludm9rZS9NZXRob2RUeXBlO0xqYXZhL2xhbmcvaW52b2tlL01ldGhvZEhhbmRsZTtMamF2YS9sYW5nL2ludm9rZS9NZXRob2RUeXBlOylMamF2YS9sYW5nL2ludm9rZS9DYWxsU2l0ZTsQAI0BABUoSSlMamF2YS9sYW5nL09iamVjdDsPBgCPCgBqAJAMAIAAaRAAaQ8GAJMKAGoAlAwAfQB+EAB+EABgDwYAmAoAagCZDAB7AHwQAHwQAJwBABUoTGphdmEvbGFuZy9PYmplY3Q7KUkPBgCeCgBqAJ8MAHgAWBAAWAEADElubmVyQ2xhc3NlcwcAowEAJWphdmEvbGFuZy9pbnZva2UvTWV0aG9kSGFuZGxlcyRMb29rdXAHAKUBAB5qYXZhL2xhbmcvaW52b2tlL01ldGhvZEhhbmRsZXMBAAZMb29rdXAAIQBqAAIAAAAAAAYAAQAFAAYAAQBsAAAALwABAAEAAAAFKrcAAbEAAAACAG0AAAAGAAEAAAAdAG4AAAAMAAEAAAAFAG8AcAAAAIkAcQByAAEAbAAAAM4ACQAFAAAAYrgAB0ADEAq4AA26ABMAALkAFwIAugAbAAC5ABwCAMAAIk4tuAAkugAqAAC5AC4CALoAMgAAuQA2AgC5ADoBADYEsgA+EkIFvQACWQMVBLgARFNZBLgABx9luABKU7YAT1exAAAAAgBtAAAAKgAKAAAAHwAEACAADwAhABkAIgAiACMAKwAkADUAJQA6ACYAQQAnAGEAKABuAAAAKgAEAAAAYgBzACMAAAAEAF4AdAB1AAEAIgBAAHYAIwADAEEAIQA8AHcABBAKAHgAWAABAGwAAAAvAAEAAQAAAAUquABVrAAAAAIAbQAAAAYAAQAAACUAbgAAAAwAAQAAAAUAeQB6AAAQCgB7AHwAAQBsAAAAOwACAAEAAAARKhJZtgBbuABhA7gAYbYAZqwAAAACAG0AAAAGAAEAAAAkAG4AAAAMAAEAAAARAHkAegAAEAoAfQB+AAEAbAAAAC8AAQABAAAABRq9AFywAAAAAgBtAAAABgABAAAAIgBuAAAADAABAAAABQB/AHcAABAKAIAAaQABAGwAAAAvAAEAAQAAAAUauABnsAAAAAIAbQAAAAYAAQAAACEAbgAAAAwAAQAAAAUAgQB3AAAAAwCCAAAAAgCDAIQAAAAqAAQAhQADAIwAjgCRAIUAAwCMAJIAlQCFAAMAlgCXAJoAhQADAJsAnQCgAKEAAAAKAAEAogCkAKYAGQ==</listing>
+   <errors/>
+   <sheets/>
+   <license/>
+   <metas>
+      <meta>
+         <head>package</head>
+         <tail>org.eolang.streams</tail>
+         <part>org.eolang.streams</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>org.eolang.jeo.opcode</tail>
+         <part>org.eolang.jeo.opcode</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>org.eolang.jeo.label</tail>
+         <part>org.eolang.jeo.label</part>
+      </meta>
+   </metas>
+   <objects>
+      <o abstract="" name="j$Main">
+         <o base="int" data="bytes" line="1589614846" name="version">00 00 00 00 00 00 00 34</o>
+         <o base="int" data="bytes" line="387546355" name="access">00 00 00 00 00 00 00 21</o>
+         <o base="string" data="bytes" line="1046628787" name="supername">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
+         <o base="tuple" name="interfaces" star=""/>
+         <o abstract="" name="j$main-KFtMamF2YS9sYW5nL1N0cmluZzspVg==">
+            <o base="int" data="bytes" line="2099443768">00 00 00 00 00 00 00 89</o>
+            <o base="string" data="bytes" line="1761479440">28 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 56</o>
+            <o base="string" data="bytes" line="1365003218"/>
+            <o base="tuple" star=""/>
+            <o base="maxs">
+               <o base="int" data="bytes" line="485625465">00 00 00 00 00 00 00 09</o>
+               <o base="int" data="bytes" line="1962203969">00 00 00 00 00 00 00 05</o>
+            </o>
+            <o abstract="" name="arg__[Ljava/lang/String;__0"/>
+            <o base="seq" name="@">
+               <o base="tuple" star="">
+                  <o base="label" data="bytes" line="886952770">35 30 34 37 61 38 37 30 2D 31 39 61 62 2D 34 65 65 64 2D 38 64 33 33 2D 64 38 63 64 37 61 64 31 64 65 62 39</o>
+                  <o base="opcode" line="999" name="INVOKESTATIC-4">
+                     <o base="int" data="bytes" line="55489116">00 00 00 00 00 00 00 B8</o>
+                     <o base="string" data="bytes" line="1082781210">6A 61 76 61 2F 6C 61 6E 67 2F 53 79 73 74 65 6D</o>
+                     <o base="string" data="bytes" line="713323572">63 75 72 72 65 6E 74 54 69 6D 65 4D 69 6C 6C 69 73</o>
+                     <o base="string" data="bytes" line="418041276">28 29 4A</o>
+                     <o base="bool" data="bytes" line="280571757">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="LSTORE-5">
+                     <o base="int" data="bytes" line="678034249">00 00 00 00 00 00 00 37</o>
+                     <o base="int" data="bytes" line="1990879721">00 00 00 00 00 00 00 01</o>
+                  </o>
+                  <o base="label" data="bytes" line="1851588068">66 38 31 34 63 64 62 39 2D 37 37 38 33 2D 34 32 34 65 2D 61 30 61 39 2D 39 62 32 62 61 36 31 38 32 36 34 33</o>
+                  <o base="opcode" line="999" name="ICONST_0-6">
+                     <o base="int" data="bytes" line="442199751">00 00 00 00 00 00 00 03</o>
+                  </o>
+                  <o base="opcode" line="999" name="BIPUSH-7">
+                     <o base="int" data="bytes" line="1583746955">00 00 00 00 00 00 00 10</o>
+                     <o base="int" data="bytes" line="1933310168">00 00 00 00 00 00 00 0A</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKESTATIC-8">
+                     <o base="int" data="bytes" line="1015656589">00 00 00 00 00 00 00 B8</o>
+                     <o base="string" data="bytes" line="1726271683">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 49 6E 74 53 74 72 65 61 6D</o>
+                     <o base="string" data="bytes" line="1365121358">72 61 6E 67 65</o>
+                     <o base="string" data="bytes" line="576472622">28 49 49 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 49 6E 74 53 74 72 65 61 6D 3B</o>
+                     <o base="bool" data="bytes" line="1395304786">01</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKEDYNAMIC-9">
+                     <o base="int" data="bytes" line="1845198132">00 00 00 00 00 00 00 BA</o>
+                     <o base="string" data="bytes" line="873573192">61 70 70 6C 79</o>
+                     <o base="string" data="bytes" line="1270322867">28 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B</o>
+                     <o base="handle">
+                        <o base="int" data="bytes" line="976024885">00 00 00 00 00 00 00 06</o>
+                        <o base="string" data="bytes" line="359908222">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4C 61 6D 62 64 61 4D 65 74 61 66 61 63 74 6F 72 79</o>
+                        <o base="string" data="bytes" line="995955090">6D 65 74 61 66 61 63 74 6F 72 79</o>
+                        <o base="string" data="bytes" line="52856891">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 43 61 6C 6C 53 69 74 65 3B</o>
+                        <o base="bool" data="bytes" line="1277739268">00</o>
+                     </o>
+                     <o base="type" data="bytes" line="292767422">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B</o>
+                     <o base="handle">
+                        <o base="int" data="bytes" line="264834029">00 00 00 00 00 00 00 06</o>
+                        <o base="string" data="bytes" line="926136239">6F 72 67 2F 65 6F 6C 61 6E 67 2F 73 74 72 65 61 6D 73 2F 4D 61 69 6E</o>
+                        <o base="string" data="bytes" line="639768677">6C 61 6D 62 64 61 24 6D 61 69 6E 24 30</o>
+                        <o base="string" data="bytes" line="234803375">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
+                        <o base="bool" data="bytes" line="1577058892">00</o>
+                     </o>
+                     <o base="type" data="bytes" line="2112906347">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
+                  </o>
+                  <o base="label" data="bytes" line="765699904">35 63 63 30 31 62 34 63 2D 66 64 34 33 2D 34 35 36 35 2D 61 34 64 32 2D 34 31 66 31 63 35 31 35 62 64 32 62</o>
+                  <o base="opcode" line="999" name="INVOKEINTERFACE-A">
+                     <o base="int" data="bytes" line="1246498841">00 00 00 00 00 00 00 B9</o>
+                     <o base="string" data="bytes" line="425302551">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 49 6E 74 53 74 72 65 61 6D</o>
+                     <o base="string" data="bytes" line="1259667456">6D 61 70 54 6F 4F 62 6A</o>
+                     <o base="string" data="bytes" line="2026283561">28 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 53 74 72 65 61 6D 3B</o>
+                     <o base="bool" data="bytes" line="2037248593">01</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKEDYNAMIC-B">
+                     <o base="int" data="bytes" line="479323786">00 00 00 00 00 00 00 BA</o>
+                     <o base="string" data="bytes" line="2076177237">61 70 70 6C 79</o>
+                     <o base="string" data="bytes" line="1978877819">28 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B</o>
+                     <o base="handle">
+                        <o base="int" data="bytes" line="809757607">00 00 00 00 00 00 00 06</o>
+                        <o base="string" data="bytes" line="496560059">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4C 61 6D 62 64 61 4D 65 74 61 66 61 63 74 6F 72 79</o>
+                        <o base="string" data="bytes" line="1939396103">6D 65 74 61 66 61 63 74 6F 72 79</o>
+                        <o base="string" data="bytes" line="810919662">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 43 61 6C 6C 53 69 74 65 3B</o>
+                        <o base="bool" data="bytes" line="1948250269">00</o>
+                     </o>
+                     <o base="type" data="bytes" line="868407105">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B</o>
+                     <o base="handle">
+                        <o base="int" data="bytes" line="642576084">00 00 00 00 00 00 00 06</o>
+                        <o base="string" data="bytes" line="1910623121">6F 72 67 2F 65 6F 6C 61 6E 67 2F 73 74 72 65 61 6D 73 2F 4D 61 69 6E</o>
+                        <o base="string" data="bytes" line="1808431408">6C 61 6D 62 64 61 24 6D 61 69 6E 24 31</o>
+                        <o base="string" data="bytes" line="1618287841">28 49 29 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
+                        <o base="bool" data="bytes" line="1822452305">00</o>
+                     </o>
+                     <o base="type" data="bytes" line="313390438">28 49 29 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
+                  </o>
+                  <o base="label" data="bytes" line="859058999">62 65 37 66 63 65 33 38 2D 61 30 61 39 2D 34 63 35 64 2D 38 34 63 36 2D 64 38 37 30 36 32 32 37 37 65 66 64</o>
+                  <o base="opcode" line="999" name="INVOKEINTERFACE-C">
+                     <o base="int" data="bytes" line="174538774">00 00 00 00 00 00 00 B9</o>
+                     <o base="string" data="bytes" line="1765035352">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 53 74 72 65 61 6D</o>
+                     <o base="string" data="bytes" line="607118437">74 6F 41 72 72 61 79</o>
+                     <o base="string" data="bytes" line="858151820">28 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B 29 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B</o>
+                     <o base="bool" data="bytes" line="1838402301">01</o>
+                  </o>
+                  <o base="opcode" line="999" name="CHECKCAST-D">
+                     <o base="int" data="bytes" line="1055899534">00 00 00 00 00 00 00 C0</o>
+                     <o base="string" data="bytes" line="1657910274">5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B</o>
+                  </o>
+                  <o base="opcode" line="999" name="ASTORE-E">
+                     <o base="int" data="bytes" line="334144878">00 00 00 00 00 00 00 3A</o>
+                     <o base="int" data="bytes" line="1200106936">00 00 00 00 00 00 00 03</o>
+                  </o>
+                  <o base="label" data="bytes" line="355347216">39 63 63 37 66 31 37 63 2D 34 39 35 64 2D 34 36 30 32 2D 38 31 64 39 2D 39 36 62 61 35 30 30 39 36 66 39 30</o>
+                  <o base="opcode" line="999" name="ALOAD-F">
+                     <o base="int" data="bytes" line="409154649">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes" line="1664775907">00 00 00 00 00 00 00 03</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKESTATIC-10">
+                     <o base="int" data="bytes" line="1965678216">00 00 00 00 00 00 00 B8</o>
+                     <o base="string" data="bytes" line="1093166391">6A 61 76 61 2F 75 74 69 6C 2F 41 72 72 61 79 73</o>
+                     <o base="string" data="bytes" line="2044543541">73 74 72 65 61 6D</o>
+                     <o base="string" data="bytes" line="137121390">28 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 53 74 72 65 61 6D 3B</o>
+                     <o base="bool" data="bytes" line="91195650">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKEDYNAMIC-11">
+                     <o base="int" data="bytes" line="625721225">00 00 00 00 00 00 00 BA</o>
+                     <o base="string" data="bytes" line="817619933">74 65 73 74</o>
+                     <o base="string" data="bytes" line="1444632622">28 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 50 72 65 64 69 63 61 74 65 3B</o>
+                     <o base="handle">
+                        <o base="int" data="bytes" line="1824886892">00 00 00 00 00 00 00 06</o>
+                        <o base="string" data="bytes" line="116712236">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4C 61 6D 62 64 61 4D 65 74 61 66 61 63 74 6F 72 79</o>
+                        <o base="string" data="bytes" line="1515796001">6D 65 74 61 66 61 63 74 6F 72 79</o>
+                        <o base="string" data="bytes" line="1436786622">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 43 61 6C 6C 53 69 74 65 3B</o>
+                        <o base="bool" data="bytes" line="1418431518">00</o>
+                     </o>
+                     <o base="type" data="bytes" line="1970762215">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 29 5A</o>
+                     <o base="handle">
+                        <o base="int" data="bytes" line="1567234812">00 00 00 00 00 00 00 06</o>
+                        <o base="string" data="bytes" line="970091641">6F 72 67 2F 65 6F 6C 61 6E 67 2F 73 74 72 65 61 6D 73 2F 4D 61 69 6E</o>
+                        <o base="string" data="bytes" line="430021491">6C 61 6D 62 64 61 24 6D 61 69 6E 24 32</o>
+                        <o base="string" data="bytes" line="1155956754">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 5A</o>
+                        <o base="bool" data="bytes" line="1796283187">00</o>
+                     </o>
+                     <o base="type" data="bytes" line="887201072">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 5A</o>
+                  </o>
+                  <o base="label" data="bytes" line="478295818">63 37 61 38 33 35 31 66 2D 36 32 30 63 2D 34 39 64 33 2D 39 39 66 39 2D 66 35 62 32 39 65 31 37 61 32 63 37</o>
+                  <o base="opcode" line="999" name="INVOKEINTERFACE-12">
+                     <o base="int" data="bytes" line="943554756">00 00 00 00 00 00 00 B9</o>
+                     <o base="string" data="bytes" line="2107428727">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 53 74 72 65 61 6D</o>
+                     <o base="string" data="bytes" line="39385645">66 69 6C 74 65 72</o>
+                     <o base="string" data="bytes" line="2022221175">28 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 50 72 65 64 69 63 61 74 65 3B 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 53 74 72 65 61 6D 3B</o>
+                     <o base="bool" data="bytes" line="1525827862">01</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKEDYNAMIC-13">
+                     <o base="int" data="bytes" line="1545975626">00 00 00 00 00 00 00 BA</o>
+                     <o base="string" data="bytes" line="1680813948">61 70 70 6C 79 41 73 49 6E 74</o>
+                     <o base="string" data="bytes" line="1538274055">28 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 54 6F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B</o>
+                     <o base="handle">
+                        <o base="int" data="bytes" line="1435518808">00 00 00 00 00 00 00 06</o>
+                        <o base="string" data="bytes" line="105094909">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4C 61 6D 62 64 61 4D 65 74 61 66 61 63 74 6F 72 79</o>
+                        <o base="string" data="bytes" line="1273830798">6D 65 74 61 66 61 63 74 6F 72 79</o>
+                        <o base="string" data="bytes" line="789666066">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 43 61 6C 6C 53 69 74 65 3B</o>
+                        <o base="bool" data="bytes" line="1811168383">00</o>
+                     </o>
+                     <o base="type" data="bytes" line="1051199675">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 29 49</o>
+                     <o base="handle">
+                        <o base="int" data="bytes" line="479622467">00 00 00 00 00 00 00 06</o>
+                        <o base="string" data="bytes" line="1738518692">6F 72 67 2F 65 6F 6C 61 6E 67 2F 73 74 72 65 61 6D 73 2F 4D 61 69 6E</o>
+                        <o base="string" data="bytes" line="631632161">6C 61 6D 62 64 61 24 6D 61 69 6E 24 33</o>
+                        <o base="string" data="bytes" line="2019496193">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 49</o>
+                        <o base="bool" data="bytes" line="1324739899">00</o>
+                     </o>
+                     <o base="type" data="bytes" line="1441830595">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 49</o>
+                  </o>
+                  <o base="label" data="bytes" line="892919255">36 31 61 39 62 35 37 65 2D 34 31 31 35 2D 34 34 34 36 2D 61 65 64 64 2D 38 38 62 66 39 39 63 62 64 37 61 61</o>
+                  <o base="opcode" line="999" name="INVOKEINTERFACE-14">
+                     <o base="int" data="bytes" line="1849105056">00 00 00 00 00 00 00 B9</o>
+                     <o base="string" data="bytes" line="966627749">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 53 74 72 65 61 6D</o>
+                     <o base="string" data="bytes" line="217315033">6D 61 70 54 6F 49 6E 74</o>
+                     <o base="string" data="bytes" line="2087384598">28 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 54 6F 49 6E 74 46 75 6E 63 74 69 6F 6E 3B 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 49 6E 74 53 74 72 65 61 6D 3B</o>
+                     <o base="bool" data="bytes" line="1215741559">01</o>
+                  </o>
+                  <o base="label" data="bytes" line="1911541260">64 66 62 65 63 32 32 63 2D 65 64 30 64 2D 34 34 39 30 2D 61 32 65 64 2D 33 66 35 61 35 65 66 38 38 63 36 64</o>
+                  <o base="opcode" line="999" name="INVOKEINTERFACE-15">
+                     <o base="int" data="bytes" line="1830316490">00 00 00 00 00 00 00 B9</o>
+                     <o base="string" data="bytes" line="147561243">6A 61 76 61 2F 75 74 69 6C 2F 73 74 72 65 61 6D 2F 49 6E 74 53 74 72 65 61 6D</o>
+                     <o base="string" data="bytes" line="709548181">73 75 6D</o>
+                     <o base="string" data="bytes" line="1274855074">28 29 49</o>
+                     <o base="bool" data="bytes" line="892234647">01</o>
+                  </o>
+                  <o base="opcode" line="999" name="ISTORE-16">
+                     <o base="int" data="bytes" line="1972944027">00 00 00 00 00 00 00 36</o>
+                     <o base="int" data="bytes" line="454806459">00 00 00 00 00 00 00 04</o>
+                  </o>
+                  <o base="label" data="bytes" line="1262199930">36 32 36 62 33 34 33 61 2D 33 65 31 66 2D 34 34 37 64 2D 62 31 63 38 2D 34 64 62 63 37 37 35 30 62 63 66 34</o>
+                  <o base="opcode" line="999" name="GETSTATIC-17">
+                     <o base="int" data="bytes" line="2146401242">00 00 00 00 00 00 00 B2</o>
+                     <o base="string" data="bytes" line="1734332222">6A 61 76 61 2F 6C 61 6E 67 2F 53 79 73 74 65 6D</o>
+                     <o base="string" data="bytes" line="702345543">6F 75 74</o>
+                     <o base="string" data="bytes" line="1678811217">4C 6A 61 76 61 2F 69 6F 2F 50 72 69 6E 74 53 74 72 65 61 6D 3B</o>
+                  </o>
+                  <o base="opcode" line="999" name="LDC-18">
+                     <o base="int" data="bytes" line="1703966362">00 00 00 00 00 00 00 12</o>
+                     <o base="string" data="bytes" line="1770776307">73 75 6D 3D 25 64 20 74 69 6D 65 3D 25 64 0A</o>
+                  </o>
+                  <o base="opcode" line="999" name="ICONST_2-19">
+                     <o base="int" data="bytes" line="603044943">00 00 00 00 00 00 00 05</o>
+                  </o>
+                  <o base="opcode" line="999" name="ANEWARRAY-1A">
+                     <o base="int" data="bytes" line="1099677507">00 00 00 00 00 00 00 BD</o>
+                     <o base="string" data="bytes" line="698012466">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
+                  </o>
+                  <o base="opcode" line="999" name="DUP-1B">
+                     <o base="int" data="bytes" line="518461129">00 00 00 00 00 00 00 59</o>
+                  </o>
+                  <o base="opcode" line="999" name="ICONST_0-1C">
+                     <o base="int" data="bytes" line="1956667874">00 00 00 00 00 00 00 03</o>
+                  </o>
+                  <o base="opcode" line="999" name="ILOAD-1D">
+                     <o base="int" data="bytes" line="1470686627">00 00 00 00 00 00 00 15</o>
+                     <o base="int" data="bytes" line="337545626">00 00 00 00 00 00 00 04</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKESTATIC-1E">
+                     <o base="int" data="bytes" line="540857091">00 00 00 00 00 00 00 B8</o>
+                     <o base="string" data="bytes" line="1449198113">6A 61 76 61 2F 6C 61 6E 67 2F 49 6E 74 65 67 65 72</o>
+                     <o base="string" data="bytes" line="1662134441">76 61 6C 75 65 4F 66</o>
+                     <o base="string" data="bytes" line="1665222181">28 49 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 49 6E 74 65 67 65 72 3B</o>
+                     <o base="bool" data="bytes" line="976151014">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="AASTORE-1F">
+                     <o base="int" data="bytes" line="1772394644">00 00 00 00 00 00 00 53</o>
+                  </o>
+                  <o base="opcode" line="999" name="DUP-20">
+                     <o base="int" data="bytes" line="1484516592">00 00 00 00 00 00 00 59</o>
+                  </o>
+                  <o base="opcode" line="999" name="ICONST_1-21">
+                     <o base="int" data="bytes" line="25096432">00 00 00 00 00 00 00 04</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKESTATIC-22">
+                     <o base="int" data="bytes" line="725214678">00 00 00 00 00 00 00 B8</o>
+                     <o base="string" data="bytes" line="957319967">6A 61 76 61 2F 6C 61 6E 67 2F 53 79 73 74 65 6D</o>
+                     <o base="string" data="bytes" line="2007855569">63 75 72 72 65 6E 74 54 69 6D 65 4D 69 6C 6C 69 73</o>
+                     <o base="string" data="bytes" line="209531188">28 29 4A</o>
+                     <o base="bool" data="bytes" line="1865815201">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="LLOAD-23">
+                     <o base="int" data="bytes" line="1144516473">00 00 00 00 00 00 00 16</o>
+                     <o base="int" data="bytes" line="2042064372">00 00 00 00 00 00 00 01</o>
+                  </o>
+                  <o base="opcode" line="999" name="LSUB-24">
+                     <o base="int" data="bytes" line="884063171">00 00 00 00 00 00 00 65</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKESTATIC-25">
+                     <o base="int" data="bytes" line="301765847">00 00 00 00 00 00 00 B8</o>
+                     <o base="string" data="bytes" line="221163100">6A 61 76 61 2F 6C 61 6E 67 2F 4C 6F 6E 67</o>
+                     <o base="string" data="bytes" line="2137698065">76 61 6C 75 65 4F 66</o>
+                     <o base="string" data="bytes" line="505428664">28 4A 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4C 6F 6E 67 3B</o>
+                     <o base="bool" data="bytes" line="1260026">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="AASTORE-26">
+                     <o base="int" data="bytes" line="1242923005">00 00 00 00 00 00 00 53</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKEVIRTUAL-27">
+                     <o base="int" data="bytes" line="1454456780">00 00 00 00 00 00 00 B6</o>
+                     <o base="string" data="bytes" line="415696501">6A 61 76 61 2F 69 6F 2F 50 72 69 6E 74 53 74 72 65 61 6D</o>
+                     <o base="string" data="bytes" line="1054939473">70 72 69 6E 74 66</o>
+                     <o base="string" data="bytes" line="1165451287">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 5B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 29 4C 6A 61 76 61 2F 69 6F 2F 50 72 69 6E 74 53 74 72 65 61 6D 3B</o>
+                     <o base="bool" data="bytes" line="472726258">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="POP-28">
+                     <o base="int" data="bytes" line="671316123">00 00 00 00 00 00 00 57</o>
+                  </o>
+                  <o base="label" data="bytes" line="673448444">37 37 39 37 65 32 66 65 2D 64 62 66 66 2D 34 33 30 65 2D 61 38 31 37 2D 64 65 36 34 36 35 61 63 32 38 61 32</o>
+                  <o base="opcode" line="999" name="RETURN-29">
+                     <o base="int" data="bytes" line="505580249">00 00 00 00 00 00 00 B1</o>
+                  </o>
+                  <o base="label" data="bytes" line="225839904">65 61 30 32 36 33 34 36 2D 31 33 61 65 2D 34 37 33 62 2D 62 66 65 62 2D 33 64 35 63 35 32 38 38 32 30 61 36</o>
+               </o>
+            </o>
+         </o>
+         <o base="tuple" star="">
+            <o base="InnerClass">
+               <o base="string" data="bytes" line="1996872675">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70</o>
+               <o base="string" data="bytes" line="1155868574">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73</o>
+               <o base="string" data="bytes" line="1811083002">4C 6F 6F 6B 75 70</o>
+               <o base="int" data="bytes" line="1821161658">00 00 00 00 00 00 00 19</o>
+            </o>
+         </o>
+      </o>
+   </objects>
+</program>


### PR DESCRIPTION
In this PR I added the special integration test that checks how `opeo-maven-plugin` converts Java Streams to PHI expressions.
It is only the first attempt to convert them, so the representation might (and will) dramatically changed in the future.

Related to #329.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates class names and refactors code for clarity. 

### Detailed summary
- Renamed `MulTest` to `MultiplicationTest`
- Updated `Mul` class to `Multiplication`
- Added `Typed` interface to `Empty` and `ArrayConstructor`
- Refactored `ReturnHandler` to handle different return types

> The following files were skipped due to too many changes: `src/it/streams/src/main/java/org/eolang/streams/Main.java`, `src/main/java/org/eolang/opeo/decompilation/handlers/CheckCastHandler.java`, `src/main/java/org/eolang/opeo/decompilation/handlers/InvokedynamicHandler.java`, `src/it/streams/verify.groovy`, `src/main/java/org/eolang/opeo/compilation/XmirParser.java`, `src/main/java/org/eolang/opeo/ast/LocalVariable.java`, `src/test/java/org/eolang/opeo/ast/CheckCastTest.java`, `src/main/java/org/eolang/opeo/ast/CheckCast.java`, `src/main/java/org/eolang/opeo/ast/Return.java`, `src/test/java/org/eolang/opeo/ast/ReturnTest.java`, `src/test/java/org/eolang/opeo/ast/DynamicInvocationTest.java`, `src/it/streams/pom.xml`, `src/main/java/org/eolang/opeo/ast/DynamicInvocation.java`, `src/main/java/org/eolang/opeo/ast/Handle.java`, `src/test/resources/xmir/disassembled/Lambda.xmir`, `src/test/resources/xmir/disassembled/Main.xmir`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->