### PR TITLE
feat(#348): WithoutLines.java

### DIFF
--- a/src/test/java/it/DetectiveIT.java
+++ b/src/test/java/it/DetectiveIT.java
@@ -268,10 +268,10 @@ final class DetectiveIT {
             try {
                 this.results.oneMore();
                 final List<XmlMethod> gmethods = new XmlProgram(
-                    SameXml.withoutLines(this.xml(gpath))
+                    new SameXml.WithoutLines(this.xml(gpath)).value()
                 ).top().methods();
                 final List<XmlMethod> bmethods = new XmlProgram(
-                    SameXml.withoutLines(this.xml(rpath))
+                    new SameXml.WithoutLines(this.xml(gpath)).value()
                 ).top().methods();
                 final int size = gmethods.size();
                 for (int index = 0; index < size; ++index) {

--- a/src/test/java/org/eolang/opeo/SameXml.java
+++ b/src/test/java/org/eolang/opeo/SameXml.java
@@ -25,6 +25,7 @@ package org.eolang.opeo;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
+import org.cactoos.Scalar;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.xembly.Directives;
@@ -66,8 +67,8 @@ public final class SameXml extends TypeSafeMatcher<String> {
 
     @Override
     public boolean matchesSafely(final String item) {
-        return SameXml.withoutLines(new XMLDocument(this.expected))
-            .equals(SameXml.withoutLines(new XMLDocument(item)));
+        return new SameXml.WithoutLines(new XMLDocument(this.expected)).value()
+            .equals(new SameXml.WithoutLines(new XMLDocument(item)).value());
     }
 
     @Override
@@ -78,23 +79,36 @@ public final class SameXml extends TypeSafeMatcher<String> {
     }
 
     /**
-     * Remove 'line' attributes from the XML document.
-     * @param original Original XML document.
-     * @return XML document without 'line' attributes.
-     * @todo #329:30min Avoid Using Public Static Method From SameXml Class.
-     *  I exposed this method to avoid the problem with XMIR comparision in {@link it.DetectiveIT}
-     *  test. But it's much better to hide this static method and invent more OOP-suitable solution.
+     * The same XML, but without lines.
      */
-    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
-    public static XML withoutLines(final XML original) {
-        try {
-            return new XMLDocument(
-                new Xembler(
-                    new Directives().xpath(".//o[@line]/@line").remove()
-                ).apply(original.node())
-            );
-        } catch (final ImpossibleModificationException exception) {
-            throw new IllegalStateException("Failed to remove 'line' attributes", exception);
+    public static final class WithoutLines implements Scalar<XML> {
+
+        /**
+         * The original.
+         */
+        private final XML original;
+
+        /**
+         * Constructor.
+         * @param orgnl original XML
+         */
+        public WithoutLines(final XML orgnl) {
+            this.original = orgnl;
+        }
+
+        @Override
+        public XML value() {
+            try {
+                return new XMLDocument(
+                    new Xembler(
+                        new Directives().xpath(".//o[@line]/@line").remove()
+                    ).apply(this.original.node())
+                );
+            } catch (final ImpossibleModificationException exception) {
+                throw new IllegalStateException(
+                    "Failed to remove 'line' attributes", exception
+                );
+            }
         }
     }
 }

--- a/src/test/java/org/eolang/opeo/SameXml.java
+++ b/src/test/java/org/eolang/opeo/SameXml.java
@@ -80,6 +80,7 @@ public final class SameXml extends TypeSafeMatcher<String> {
 
     /**
      * The same XML, but without lines.
+     * @since 0.3.1
      */
     public static final class WithoutLines implements Scalar<XML> {
 
@@ -90,7 +91,7 @@ public final class SameXml extends TypeSafeMatcher<String> {
 
         /**
          * Constructor.
-         * @param orgnl original XML
+         * @param orgnl Original XML
          */
         public WithoutLines(final XML orgnl) {
             this.original = orgnl;


### PR DESCRIPTION
In this pull I've refactored old `SameXml.withoutLines()` public static method into new class: `WithoutLines`, in OOP manner.

@volodya-lombrozo take a look, please

closes #348

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor XML handling in tests for better readability and maintainability.

### Detailed summary
- Refactored `SameXml` class to use a `WithoutLines` inner class implementing `Scalar`
- Replaced static method with instance method for removing 'line' attributes from XML documents

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->