### PR TITLE
chore(#350): upgrade jcabi.parent version 0.68.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.67.0</version>
+    <version>0.68.0</version>
   </parent>
   <groupId>org.eolang</groupId>
   <artifactId>opeo-maven-plugin</artifactId>


### PR DESCRIPTION
In this PR I update `jcabi.parent` version `0.68.0`.

Closes: #350.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `parent` artifact from 0.67.0 to 0.68.0 in the `pom.xml`.

### Detailed summary
- Updated the version of the `parent` artifact from 0.67.0 to 0.68.0 in the `pom.xml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->