### PR TITLE
feat(#344): Enable 'spring-fat' Integration Test

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/Constant.java
+++ b/src/main/java/org/eolang/opeo/ast/Constant.java
@@ -54,7 +54,10 @@ public final class Constant implements AstNode, Typed {
      */
     private final Object value;
 
-    private final Type type;
+    /**
+     * The constant value type.
+     */
+    private final Type vtype;
 
     /**
      * Constructor.
@@ -72,9 +75,14 @@ public final class Constant implements AstNode, Typed {
         this(value, Type.getType(value.getClass()));
     }
 
+    /**
+     * Constructor.
+     * @param value The constant value.
+     * @param type The constant value type.
+     */
     public Constant(final Object value, final Type type) {
         this.value = value;
-        this.type = type;
+        this.vtype = type;
     }
 
     @Override
@@ -92,16 +100,14 @@ public final class Constant implements AstNode, Typed {
 
     @Override
     public Type type() {
-        return this.type;
-//        final Type result;
-//        if (this.value instanceof Type) {
-//            result = (Type) this.value;
-//        } else {
-//            result = Type.getType(this.value.getClass());
-//        }
-//        return result;
+        return this.vtype;
     }
 
+    /**
+     * Parse the Constant type from XMIR representation.
+     * @param node The node to parse.
+     * @return The parsed type.
+     */
     private static Type xtype(final XmlNode node) {
         final XmlNode child = node.firstChild();
         final DataType type = DataType.find(
@@ -109,28 +115,40 @@ public final class Constant implements AstNode, Typed {
                 () -> new IllegalStateException("Constant node has no 'base' attribute")
             )
         );
+        final Type result;
         switch (type) {
             case INT:
-                return Type.INT_TYPE;
+                result = Type.INT_TYPE;
+                break;
             case LONG:
-                return Type.LONG_TYPE;
+                result = Type.LONG_TYPE;
+                break;
             case FLOAT:
-                return Type.FLOAT_TYPE;
+                result = Type.FLOAT_TYPE;
+                break;
             case DOUBLE:
-                return Type.DOUBLE_TYPE;
+                result = Type.DOUBLE_TYPE;
+                break;
             case CHAR:
-                return Type.CHAR_TYPE;
+                result = Type.CHAR_TYPE;
+                break;
             case BYTE:
-                return Type.BYTE_TYPE;
+                result = Type.BYTE_TYPE;
+                break;
             case SHORT:
-                return Type.SHORT_TYPE;
+                result = Type.SHORT_TYPE;
+                break;
             case STRING:
-                return Type.getType(String.class);
+                result = Type.getType(String.class);
+                break;
             case TYPE_REFERENCE:
-                return Type.getType(Type.class);
+                result = Type.getType(Type.class);
+                break;
             default:
-                return Type.getType(type.type());
+                result = Type.getType(type.type());
+                break;
         }
+        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/Constructor.java
+++ b/src/main/java/org/eolang/opeo/ast/Constructor.java
@@ -39,10 +39,6 @@ import org.xembly.Directives;
 /**
  * Constructor output node.
  * @since 0.1
- * @todo #329:90min Continue enable 'spring-fat' integration test.
- *  Currently 'spring-fat' integration test fails.
- *  Now it fails because some problems with Constructor transformation.
- *  We should fix them and continue to enable 'spring-fat' integration test.
  */
 @ToString
 @EqualsAndHashCode

--- a/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
@@ -120,16 +120,28 @@ public final class InterfaceInvocation implements AstNode, Typed {
                 )
             );
         }
-        final Typed owner = (Typed) this.source;
         res.add(
             new Opcode(
                 Opcodes.INVOKEINTERFACE,
-                owner.type().getClassName().replace('.', '/'),
+                this.attrs.owner(),
                 this.attrs.name(),
                 this.attrs.descriptor(),
                 this.attrs.interfaced()
             )
         );
+
+
+//        final Typed owner = (Typed) this.source;
+//
+//        res.add(
+//            new Opcode(
+//                Opcodes.INVOKEINTERFACE,
+//                owner.type().getClassName().replace('.', '/'),
+//                this.attrs.name(),
+//                this.attrs.descriptor(),
+//                this.attrs.interfaced()
+//            )
+//        );
         return res;
     }
 

--- a/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
@@ -45,6 +45,24 @@ import org.xembly.Directives;
  *  It means that we have a code duplication. We need to remove it somehow.
  *  Also pay attention that {@link #xargs} method is duplicate of the same method from
  *  {@link org.eolang.opeo.compilation.XmirParser#args} class.
+ * @todo #344:90min Interface Invocation Type Inference
+ *  We used to infer 'owner' of a interface method invocation from the {@link #source}.
+ *  However it led to failed tests.
+ *  <p> Here is how we did it:
+ *  {@code
+ *   final Typed owner = (Typed) this.source;
+ *   res.add(
+ *       new Opcode(
+ *           Opcodes.INVOKEINTERFACE,
+ *           owner.type().getClassName().replace('.', '/'),
+ *           this.attrs.name(),
+ *           this.attrs.descriptor(),
+ *           this.attrs.interfaced()
+ *       )
+ *   );
+ *  }
+ *  </p>
+ *  We should use the similar approach, but we also have to ensure that all the tests pass.
  */
 @ToString
 @EqualsAndHashCode
@@ -129,19 +147,6 @@ public final class InterfaceInvocation implements AstNode, Typed {
                 this.attrs.interfaced()
             )
         );
-
-
-//        final Typed owner = (Typed) this.source;
-//
-//        res.add(
-//            new Opcode(
-//                Opcodes.INVOKEINTERFACE,
-//                owner.type().getClassName().replace('.', '/'),
-//                this.attrs.name(),
-//                this.attrs.descriptor(),
-//                this.attrs.interfaced()
-//            )
-//        );
         return res;
     }
 

--- a/src/main/java/org/eolang/opeo/ast/LocalVariable.java
+++ b/src/main/java/org/eolang/opeo/ast/LocalVariable.java
@@ -103,13 +103,13 @@ public final class LocalVariable implements AstNode, Typed {
     public List<AstNode> opcodes() {
         final Type type = this.type();
         final List<AstNode> result;
-        if (type.equals(Type.INT_TYPE) || type.equals(Type.getType(Integer.class))) {
+        if (type.equals(Type.INT_TYPE)) {
             result = Arrays.asList(new Opcode(Opcodes.ILOAD, this.identifier));
-        } else if (type.equals(Type.LONG_TYPE) || type.equals(Type.getType(Long.class))) {
+        } else if (type.equals(Type.LONG_TYPE)) {
             result = Arrays.asList(new Opcode(Opcodes.LLOAD, this.identifier));
-        } else if (type.equals(Type.FLOAT_TYPE) || type.equals(Type.getType(Float.class))) {
+        } else if (type.equals(Type.FLOAT_TYPE)) {
             result = Arrays.asList(new Opcode(Opcodes.FLOAD, this.identifier));
-        } else if (type.equals(Type.DOUBLE_TYPE) || type.equals(Type.getType(Double.class))) {
+        } else if (type.equals(Type.DOUBLE_TYPE)) {
             result = Arrays.asList(new Opcode(Opcodes.DLOAD, this.identifier));
         } else {
             result = Arrays.asList(new Opcode(type.getOpcode(Opcodes.ILOAD), this.identifier));

--- a/src/main/java/org/eolang/opeo/ast/Return.java
+++ b/src/main/java/org/eolang/opeo/ast/Return.java
@@ -92,25 +92,6 @@ public final class Return implements AstNode {
      * @checkstyle CyclomaticComplexityCheck (20 lines)
      */
     private Opcode opcode() {
-//        final Type type = this.type();
-//        final Opcode result;
-//        if (type.equals(Type.VOID_TYPE)) {
-//            result = new Opcode(Opcodes.RETURN);
-//        } else if (type.equals(Type.INT_TYPE) || type.equals(Type.getType(Integer.class))) {
-//            result = new Opcode(Opcodes.IRETURN);
-//        } else if (type.equals(Type.LONG_TYPE) || type.equals(Type.getType(Long.class))) {
-//            result = new Opcode(Opcodes.LRETURN);
-//        } else if (type.equals(Type.FLOAT_TYPE) || type.equals(Type.getType(Float.class))) {
-//            result = new Opcode(Opcodes.FRETURN);
-//        } else if (type.equals(Type.DOUBLE_TYPE) || type.equals(Type.getType(Double.class))) {
-//            result = new Opcode(Opcodes.DRETURN);
-//        } else if (type.equals(Type.BOOLEAN_TYPE) || type.equals(Type.getType(Boolean.class))) {
-//            result = new Opcode(Opcodes.IRETURN);
-//        } else {
-//            result = new Opcode(Opcodes.ARETURN);
-//        }
-//        return result;
-
         final Type type = this.type();
         final Opcode result;
         if (type.equals(Type.VOID_TYPE)) {

--- a/src/main/java/org/eolang/opeo/ast/Return.java
+++ b/src/main/java/org/eolang/opeo/ast/Return.java
@@ -92,19 +92,38 @@ public final class Return implements AstNode {
      * @checkstyle CyclomaticComplexityCheck (20 lines)
      */
     private Opcode opcode() {
+//        final Type type = this.type();
+//        final Opcode result;
+//        if (type.equals(Type.VOID_TYPE)) {
+//            result = new Opcode(Opcodes.RETURN);
+//        } else if (type.equals(Type.INT_TYPE) || type.equals(Type.getType(Integer.class))) {
+//            result = new Opcode(Opcodes.IRETURN);
+//        } else if (type.equals(Type.LONG_TYPE) || type.equals(Type.getType(Long.class))) {
+//            result = new Opcode(Opcodes.LRETURN);
+//        } else if (type.equals(Type.FLOAT_TYPE) || type.equals(Type.getType(Float.class))) {
+//            result = new Opcode(Opcodes.FRETURN);
+//        } else if (type.equals(Type.DOUBLE_TYPE) || type.equals(Type.getType(Double.class))) {
+//            result = new Opcode(Opcodes.DRETURN);
+//        } else if (type.equals(Type.BOOLEAN_TYPE) || type.equals(Type.getType(Boolean.class))) {
+//            result = new Opcode(Opcodes.IRETURN);
+//        } else {
+//            result = new Opcode(Opcodes.ARETURN);
+//        }
+//        return result;
+
         final Type type = this.type();
         final Opcode result;
         if (type.equals(Type.VOID_TYPE)) {
             result = new Opcode(Opcodes.RETURN);
-        } else if (type.equals(Type.INT_TYPE) || type.equals(Type.getType(Integer.class))) {
+        } else if (type.equals(Type.INT_TYPE)) {
             result = new Opcode(Opcodes.IRETURN);
-        } else if (type.equals(Type.LONG_TYPE) || type.equals(Type.getType(Long.class))) {
+        } else if (type.equals(Type.LONG_TYPE)) {
             result = new Opcode(Opcodes.LRETURN);
-        } else if (type.equals(Type.FLOAT_TYPE) || type.equals(Type.getType(Float.class))) {
+        } else if (type.equals(Type.FLOAT_TYPE)) {
             result = new Opcode(Opcodes.FRETURN);
-        } else if (type.equals(Type.DOUBLE_TYPE) || type.equals(Type.getType(Double.class))) {
+        } else if (type.equals(Type.DOUBLE_TYPE)) {
             result = new Opcode(Opcodes.DRETURN);
-        } else if (type.equals(Type.BOOLEAN_TYPE) || type.equals(Type.getType(Boolean.class))) {
+        } else if (type.equals(Type.BOOLEAN_TYPE)) {
             result = new Opcode(Opcodes.IRETURN);
         } else {
             result = new Opcode(Opcodes.ARETURN);

--- a/src/test/java/it/JeoAndOpeoTest.java
+++ b/src/test/java/it/JeoAndOpeoTest.java
@@ -23,7 +23,6 @@
  */
 package it;
 
-import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.util.List;
 import org.cactoos.bytes.BytesOf;
@@ -136,7 +135,7 @@ final class JeoAndOpeoTest {
         "xmir/disassembled/ApplicationContextAssertProvider.xmir",
         "xmir/disassembled/Sum.xmir",
         "xmir/disassembled/CachingJupiterConfiguration2.xmir",
-        "xmir/disassembled/DateFormatterRegistrar$LongToDateConverter.xmir",
+        "xmir/disassembled/DateFormatterRegistrar$LongToDateConverter.xmir"
     })
     void decompilesCompilesAndKeepsTheSameInstructions(final String path) throws Exception {
         final XMLDocument original = new XMLDocument(new BytesOf(new ResourceOf(path)).asBytes());
@@ -175,10 +174,10 @@ final class JeoAndOpeoTest {
             ).compile()
         ).top().methods();
         final List<XmlMethod> methods = new XmlProgram(original).top().methods();
-        for (int i = 0; i < methods.size(); i++) {
-            final XmlMethod method = methods.get(i);
+        for (int mindex = 0; mindex < methods.size(); ++mindex) {
+            final XmlMethod method = methods.get(mindex);
             final List<XmlBytecodeEntry> expected = method.instructions();
-            final List<XmlBytecodeEntry> actual = amethods.get(i).instructions();
+            final List<XmlBytecodeEntry> actual = amethods.get(mindex).instructions();
             final int size = expected.size();
             for (int index = 0; index < size; ++index) {
                 final XmlBytecodeEntry expect = expected.get(index);
@@ -192,7 +191,6 @@ final class JeoAndOpeoTest {
                     Matchers.equalTo(expect)
                 );
             }
-
         }
     }
 

--- a/src/test/java/it/JeoAndOpeoTest.java
+++ b/src/test/java/it/JeoAndOpeoTest.java
@@ -135,18 +135,17 @@ final class JeoAndOpeoTest {
         "xmir/disassembled/SpringBootExceptionHandler$LoggedExceptionHandlerThreadLocal.xmir",
         "xmir/disassembled/ApplicationContextAssertProvider.xmir",
         "xmir/disassembled/Sum.xmir",
-        "xmir/disassembled/CachingJupiterConfiguration2.xmir"
+        "xmir/disassembled/CachingJupiterConfiguration2.xmir",
+        "xmir/disassembled/DateFormatterRegistrar$LongToDateConverter.xmir",
     })
     void decompilesCompilesAndKeepsTheSameInstructions(final String path) throws Exception {
         final XMLDocument original = new XMLDocument(new BytesOf(new ResourceOf(path)).asBytes());
-        final XML decompiled = new JeoDecompiler(original).decompile();
-        System.out.println(decompiled);
         MatcherAssert.assertThat(
             "The original and compiled instructions are not equal",
             new JeoInstructions(
                 new XmlProgram(
                     new JeoCompiler(
-                        decompiled
+                        new JeoDecompiler(original).decompile()
                     ).compile()
                 ).top().methods().get(0)
             ).instuctionNames(),
@@ -170,14 +169,16 @@ final class JeoAndOpeoTest {
     ) throws Exception {
         Opcode.disableCounting();
         final XMLDocument original = new XMLDocument(new BytesOf(new ResourceOf(path)).asBytes());
-        final List<XmlBytecodeEntry> actual = new XmlProgram(
+        final List<XmlMethod> amethods = new XmlProgram(
             new JeoCompiler(
                 new JeoDecompiler(original).decompile()
             ).compile()
-        ).top().methods().get(0).instructions();
+        ).top().methods();
         final List<XmlMethod> methods = new XmlProgram(original).top().methods();
-        for (final XmlMethod method : methods) {
+        for (int i = 0; i < methods.size(); i++) {
+            final XmlMethod method = methods.get(i);
             final List<XmlBytecodeEntry> expected = method.instructions();
+            final List<XmlBytecodeEntry> actual = amethods.get(i).instructions();
             final int size = expected.size();
             for (int index = 0; index < size; ++index) {
                 final XmlBytecodeEntry expect = expected.get(index);
@@ -191,6 +192,7 @@ final class JeoAndOpeoTest {
                     Matchers.equalTo(expect)
                 );
             }
+
         }
     }
 

--- a/src/test/java/it/JeoAndOpeoTest.java
+++ b/src/test/java/it/JeoAndOpeoTest.java
@@ -163,7 +163,7 @@ final class JeoAndOpeoTest {
         "xmir/disassembled/SimpleLog.xmir",
         "xmir/disassembled/Main.xmir",
         "xmir/disassembled/CachingJupiterConfiguration.xmir",
-        "xmir/disassembled/EngineDiscoveryRequestResolver$DefaultInitializationContext.xmir"
+        "xmir/disassembled/DateFormatterRegistrar$LongToDateConverter.xmir"
     })
     void decompilesCompilesAndKeepsTheSameInstructionsWithTheSameOperands(
         final String path

--- a/src/test/java/it/JeoAndOpeoTest.java
+++ b/src/test/java/it/JeoAndOpeoTest.java
@@ -162,7 +162,8 @@ final class JeoAndOpeoTest {
     @CsvSource({
         "xmir/disassembled/SimpleLog.xmir",
         "xmir/disassembled/Main.xmir",
-        "xmir/disassembled/CachingJupiterConfiguration.xmir"
+        "xmir/disassembled/CachingJupiterConfiguration.xmir",
+        "xmir/disassembled/EngineDiscoveryRequestResolver$DefaultInitializationContext.xmir"
     })
     void decompilesCompilesAndKeepsTheSameInstructionsWithTheSameOperands(
         final String path

--- a/src/test/resources/xmir/disassembled/CachingJupiterConfiguration2.xmir
+++ b/src/test/resources/xmir/disassembled/CachingJupiterConfiguration2.xmir
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<program dob="2024-08-06T06:27:02.486070Z"
+  ms="1722925622486"
+  name="j$CachingJupiterConfiguration"
+  revision="0.0.0"
+  time="2024-08-06T06:27:02.486070Z"
+  version="0.0.0">
+   <listing>yv66vgAAADQAzQoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWBwAIAQAmamF2YS91dGlsL2NvbmN1cnJlbnQvQ29uY3VycmVudEhhc2hNYXAKAAcAAwkACwAMBwANDAAOAA8BADtvcmcvanVuaXQvanVwaXRlci9lbmdpbmUvY29uZmlnL0NhY2hpbmdKdXBpdGVyQ29uZmlndXJhdGlvbgEABWNhY2hlAQAoTGphdmEvdXRpbC9jb25jdXJyZW50L0NvbmN1cnJlbnRIYXNoTWFwOwkACwARDAASABMBAAhkZWxlZ2F0ZQEANkxvcmcvanVuaXQvanVwaXRlci9lbmdpbmUvY29uZmlnL0p1cGl0ZXJDb25maWd1cmF0aW9uOwsAFQAWBwAXDAAYABkBADRvcmcvanVuaXQvanVwaXRlci9lbmdpbmUvY29uZmlnL0p1cGl0ZXJDb25maWd1cmF0aW9uAQAcZ2V0UmF3Q29uZmlndXJhdGlvblBhcmFtZXRlcgEAKChMamF2YS9sYW5nL1N0cmluZzspTGphdmEvdXRpbC9PcHRpb25hbDsLABUAGwwAGAAcAQBFKExqYXZhL2xhbmcvU3RyaW5nO0xqYXZhL3V0aWwvZnVuY3Rpb24vRnVuY3Rpb247KUxqYXZhL3V0aWwvT3B0aW9uYWw7CAAeAQAoanVuaXQuanVwaXRlci5leGVjdXRpb24ucGFyYWxsZWwuZW5hYmxlZBIAAAAgDAAhACIBAAVhcHBseQEAXChMb3JnL2p1bml0L2p1cGl0ZXIvZW5naW5lL2NvbmZpZy9DYWNoaW5nSnVwaXRlckNvbmZpZ3VyYXRpb247KUxqYXZhL3V0aWwvZnVuY3Rpb24vRnVuY3Rpb247CgAHACQMACUAJgEAD2NvbXB1dGVJZkFic2VudAEAQyhMamF2YS9sYW5nL09iamVjdDtMamF2YS91dGlsL2Z1bmN0aW9uL0Z1bmN0aW9uOylMamF2YS9sYW5nL09iamVjdDsHACgBABFqYXZhL2xhbmcvQm9vbGVhbgoAJwAqDAArACwBAAxib29sZWFuVmFsdWUBAAMoKVoIAC4BAC5qdW5pdC5qdXBpdGVyLmV4dGVuc2lvbnMuYXV0b2RldGVjdGlvbi5lbmFibGVkEgABACAIADEBAC1qdW5pdC5qdXBpdGVyLmV4ZWN1dGlvbi5wYXJhbGxlbC5tb2RlLmRlZmF1bHQSAAIAIAcANAEALG9yZy9qdW5pdC9qdXBpdGVyL2FwaS9wYXJhbGxlbC9FeGVjdXRpb25Nb2RlCAA2AQA1anVuaXQuanVwaXRlci5leGVjdXRpb24ucGFyYWxsZWwubW9kZS5jbGFzc2VzLmRlZmF1bHQSAAMAIAgAOQEALGp1bml0Lmp1cGl0ZXIudGVzdGluc3RhbmNlLmxpZmVjeWNsZS5kZWZhdWx0EgAEACAHADwBACxvcmcvanVuaXQvanVwaXRlci9hcGkvVGVzdEluc3RhbmNlJExpZmVjeWNsZQgAPgEAI2p1bml0Lmp1cGl0ZXIuY29uZGl0aW9ucy5kZWFjdGl2YXRlEgAFACAHAEEBABxqYXZhL3V0aWwvZnVuY3Rpb24vUHJlZGljYXRlCABDAQAranVuaXQuanVwaXRlci5kaXNwbGF5bmFtZS5nZW5lcmF0b3IuZGVmYXVsdBIABgAgBwBGAQAqb3JnL2p1bml0L2p1cGl0ZXIvYXBpL0Rpc3BsYXlOYW1lR2VuZXJhdG9yCABIAQAmanVuaXQuanVwaXRlci50ZXN0bWV0aG9kLm9yZGVyLmRlZmF1bHQSAAcAIAcASwEAEmphdmEvdXRpbC9PcHRpb25hbAgATQEAJWp1bml0Lmp1cGl0ZXIudGVzdGNsYXNzLm9yZGVyLmRlZmF1bHQSAAgAIAsAFQBQDABRAFIBABpnZXREZWZhdWx0VGVzdENsYXNzT3JkZXJlcgEAFigpTGphdmEvdXRpbC9PcHRpb25hbDsLABUAVAwAVQBSAQAbZ2V0RGVmYXVsdFRlc3RNZXRob2RPcmRlcmVyCwAVAFcMAFgAWQEAHmdldERlZmF1bHREaXNwbGF5TmFtZUdlbmVyYXRvcgEALigpTG9yZy9qdW5pdC9qdXBpdGVyL2FwaS9EaXNwbGF5TmFtZUdlbmVyYXRvcjsLABUAWwwAXABdAQAbZ2V0RXhlY3V0aW9uQ29uZGl0aW9uRmlsdGVyAQAgKClMamF2YS91dGlsL2Z1bmN0aW9uL1ByZWRpY2F0ZTsLABUAXwwAYABhAQAfZ2V0RGVmYXVsdFRlc3RJbnN0YW5jZUxpZmVjeWNsZQEAMCgpTG9yZy9qdW5pdC9qdXBpdGVyL2FwaS9UZXN0SW5zdGFuY2UkTGlmZWN5Y2xlOwsAFQBjDABkAGUBAB5nZXREZWZhdWx0Q2xhc3Nlc0V4ZWN1dGlvbk1vZGUBADAoKUxvcmcvanVuaXQvanVwaXRlci9hcGkvcGFyYWxsZWwvRXhlY3V0aW9uTW9kZTsLABUAZwwAaABlAQAXZ2V0RGVmYXVsdEV4ZWN1dGlvbk1vZGULABUAagwAawAsAQAfaXNFeHRlbnNpb25BdXRvRGV0ZWN0aW9uRW5hYmxlZAoAJwBtDABuAG8BAAd2YWx1ZU9mAQAWKFopTGphdmEvbGFuZy9Cb29sZWFuOwsAFQBxDAByACwBABppc1BhcmFsbGVsRXhlY3V0aW9uRW5hYmxlZAEACVNpZ25hdHVyZQEATkxqYXZhL3V0aWwvY29uY3VycmVudC9Db25jdXJyZW50SGFzaE1hcDxMamF2YS9sYW5nL1N0cmluZztMamF2YS9sYW5nL09iamVjdDs+OwEAOShMb3JnL2p1bml0L2p1cGl0ZXIvZW5naW5lL2NvbmZpZy9KdXBpdGVyQ29uZmlndXJhdGlvbjspVgEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBABJMb2NhbFZhcmlhYmxlVGFibGUBAAR0aGlzAQA9TG9yZy9qdW5pdC9qdXBpdGVyL2VuZ2luZS9jb25maWcvQ2FjaGluZ0p1cGl0ZXJDb25maWd1cmF0aW9uOwEAA2tleQEAEkxqYXZhL2xhbmcvU3RyaW5nOwEAPChMamF2YS9sYW5nL1N0cmluZzspTGphdmEvdXRpbC9PcHRpb25hbDxMamF2YS9sYW5nL1N0cmluZzs+OwEAC3RyYW5zZm9ybWVyAQAdTGphdmEvdXRpbC9mdW5jdGlvbi9GdW5jdGlvbjsBABZMb2NhbFZhcmlhYmxlVHlwZVRhYmxlAQA0TGphdmEvdXRpbC9mdW5jdGlvbi9GdW5jdGlvbjxMamF2YS9sYW5nL1N0cmluZztUVDs+OwEAdzxUOkxqYXZhL2xhbmcvT2JqZWN0Oz4oTGphdmEvbGFuZy9TdHJpbmc7TGphdmEvdXRpbC9mdW5jdGlvbi9GdW5jdGlvbjxMamF2YS9sYW5nL1N0cmluZztUVDs+OylMamF2YS91dGlsL09wdGlvbmFsPFRUOz47AQBWKClMamF2YS91dGlsL2Z1bmN0aW9uL1ByZWRpY2F0ZTxMb3JnL2p1bml0L2p1cGl0ZXIvYXBpL2V4dGVuc2lvbi9FeGVjdXRpb25Db25kaXRpb247PjsBAD0oKUxqYXZhL3V0aWwvT3B0aW9uYWw8TG9yZy9qdW5pdC9qdXBpdGVyL2FwaS9NZXRob2RPcmRlcmVyOz47AQA8KClMamF2YS91dGlsL09wdGlvbmFsPExvcmcvanVuaXQvanVwaXRlci9hcGkvQ2xhc3NPcmRlcmVyOz47AQAjbGFtYmRhJGdldERlZmF1bHRUZXN0Q2xhc3NPcmRlcmVyJDgBACYoTGphdmEvbGFuZy9TdHJpbmc7KUxqYXZhL2xhbmcvT2JqZWN0OwEAJGxhbWJkYSRnZXREZWZhdWx0VGVzdE1ldGhvZE9yZGVyZXIkNwEAJ2xhbWJkYSRnZXREZWZhdWx0RGlzcGxheU5hbWVHZW5lcmF0b3IkNgEAJGxhbWJkYSRnZXRFeGVjdXRpb25Db25kaXRpb25GaWx0ZXIkNQEAKGxhbWJkYSRnZXREZWZhdWx0VGVzdEluc3RhbmNlTGlmZWN5Y2xlJDQBACdsYW1iZGEkZ2V0RGVmYXVsdENsYXNzZXNFeGVjdXRpb25Nb2RlJDMBACBsYW1iZGEkZ2V0RGVmYXVsdEV4ZWN1dGlvbk1vZGUkMgEAKGxhbWJkYSRpc0V4dGVuc2lvbkF1dG9EZXRlY3Rpb25FbmFibGVkJDEBACNsYW1iZGEkaXNQYXJhbGxlbEV4ZWN1dGlvbkVuYWJsZWQkMAEAClNvdXJjZUZpbGUBACBDYWNoaW5nSnVwaXRlckNvbmZpZ3VyYXRpb24uamF2YQEAGVJ1bnRpbWVWaXNpYmxlQW5ub3RhdGlvbnMBABlMb3JnL2FwaWd1YXJkaWFuL2FwaS9BUEk7AQAGc3RhdHVzAQAgTG9yZy9hcGlndWFyZGlhbi9hcGkvQVBJJFN0YXR1czsBAAhJTlRFUk5BTAEABXNpbmNlAQADNS40AQAQQm9vdHN0cmFwTWV0aG9kcw8GAJsKAJwAnQcAngwAnwCgAQAiamF2YS9sYW5nL2ludm9rZS9MYW1iZGFNZXRhZmFjdG9yeQEAC21ldGFmYWN0b3J5AQDMKExqYXZhL2xhbmcvaW52b2tlL01ldGhvZEhhbmRsZXMkTG9va3VwO0xqYXZhL2xhbmcvU3RyaW5nO0xqYXZhL2xhbmcvaW52b2tlL01ldGhvZFR5cGU7TGphdmEvbGFuZy9pbnZva2UvTWV0aG9kVHlwZTtMamF2YS9sYW5nL2ludm9rZS9NZXRob2RIYW5kbGU7TGphdmEvbGFuZy9pbnZva2UvTWV0aG9kVHlwZTspTGphdmEvbGFuZy9pbnZva2UvQ2FsbFNpdGU7EACiAQAmKExqYXZhL2xhbmcvT2JqZWN0OylMamF2YS9sYW5nL09iamVjdDsPBwCkCgALAKUMAI8AhxAAhw8HAKgKAAsAqQwAjgCHDwcAqwoACwCsDACNAIcPBwCuCgALAK8MAIwAhw8HALEKAAsAsgwAiwCHDwcAtAoACwC1DACKAIcPBwC3CgALALgMAIkAhw8HALoKAAsAuwwAiACHDwcAvQoACwC+DACGAIcBAAxJbm5lckNsYXNzZXMHAMEBACJvcmcvanVuaXQvanVwaXRlci9hcGkvVGVzdEluc3RhbmNlAQAJTGlmZWN5Y2xlBwDEAQAeb3JnL2FwaWd1YXJkaWFuL2FwaS9BUEkkU3RhdHVzBwDGAQAXb3JnL2FwaWd1YXJkaWFuL2FwaS9BUEkBAAZTdGF0dXMHAMkBACVqYXZhL2xhbmcvaW52b2tlL01ldGhvZEhhbmRsZXMkTG9va3VwBwDLAQAeamF2YS9sYW5nL2ludm9rZS9NZXRob2RIYW5kbGVzAQAGTG9va3VwACEACwACAAEAFQACABIADgAPAAEAcwAAAAIAdAASABIAEwAAABUAAQAFAHUAAQB2AAAAVQADAAIAAAAVKrcAASq7AAdZtwAJtQAKKiu1ABCxAAAAAgB3AAAAEgAEAAAAJwAEACQADwAoABQAKQB4AAAAFgACAAAAFQB5AHoAAAAAABUAEgATAAEAAQAYABkAAgB2AAAAPwACAAIAAAALKrQAECu5ABQCALAAAAACAHcAAAAGAAEAAAAtAHgAAAAWAAIAAAALAHkAegAAAAAACwB7AHwAAQBzAAAAAgB9AAEAGAAcAAIAdgAAAFwAAwADAAAADCq0ABArLLkAGgMAsAAAAAMAdwAAAAYAAQAAADIAeAAAACAAAwAAAAwAeQB6AAAAAAAMAHsAfAABAAAADAB+AH8AAgCAAAAADAABAAAADAB+AIEAAgBzAAAAAgCCAAEAcgAsAAEAdgAAAEAAAwABAAAAFiq0AAoSHSq6AB8AALYAI8AAJ7YAKawAAAACAHcAAAAGAAEAAAA3AHgAAAAMAAEAAAAWAHkAegAAAAEAawAsAAEAdgAAAEAAAwABAAAAFiq0AAoSLSq6AC8AALYAI8AAJ7YAKawAAAACAHcAAAAGAAEAAAA9AHgAAAAMAAEAAAAWAHkAegAAAAEAaABlAAEAdgAAAD0AAwABAAAAEyq0AAoSMCq6ADIAALYAI8AAM7AAAAACAHcAAAAGAAEAAABDAHgAAAAMAAEAAAATAHkAegAAAAEAZABlAAEAdgAAAD0AAwABAAAAEyq0AAoSNSq6ADcAALYAI8AAM7AAAAACAHcAAAAGAAEAAABJAHgAAAAMAAEAAAATAHkAegAAAAEAYABhAAEAdgAAAD0AAwABAAAAEyq0AAoSOCq6ADoAALYAI8AAO7AAAAACAHcAAAAGAAEAAABPAHgAAAAMAAEAAAATAHkAegAAAAEAXABdAAIAdgAAAD0AAwABAAAAEyq0AAoSPSq6AD8AALYAI8AAQLAAAAACAHcAAAAGAAEAAABWAHgAAAAMAAEAAAATAHkAegAAAHMAAAACAIMAAQBYAFkAAQB2AAAAPQADAAEAAAATKrQAChJCKroARAAAtgAjwABFsAAAAAIAdwAAAAYAAQAAAFwAeAAAAAwAAQAAABMAeQB6AAAAAQBVAFIAAgB2AAAAPQADAAEAAAATKrQAChJHKroASQAAtgAjwABKsAAAAAIAdwAAAAYAAQAAAGMAeAAAAAwAAQAAABMAeQB6AAAAcwAAAAIAhAABAFEAUgACAHYAAAA9AAMAAQAAABMqtAAKEkwqugBOAAC2ACPAAEqwAAAAAgB3AAAABgABAAAAagB4AAAADAABAAAAEwB5AHoAAABzAAAAAgCFEAIAhgCHAAEAdgAAAD4AAQACAAAACiq0ABC5AE8BALAAAAACAHcAAAAGAAEAAABrAHgAAAAWAAIAAAAKAHkAegAAAAAACgB7AHwAARACAIgAhwABAHYAAAA+AAEAAgAAAAoqtAAQuQBTAQCwAAAAAgB3AAAABgABAAAAZAB4AAAAFgACAAAACgB5AHoAAAAAAAoAewB8AAEQAgCJAIcAAQB2AAAAPgABAAIAAAAKKrQAELkAVgEAsAAAAAIAdwAAAAYAAQAAAF0AeAAAABYAAgAAAAoAeQB6AAAAAAAKAHsAfAABEAIAigCHAAEAdgAAAD4AAQACAAAACiq0ABC5AFoBALAAAAACAHcAAAAGAAEAAABXAHgAAAAWAAIAAAAKAHkAegAAAAAACgB7AHwAARACAIsAhwABAHYAAAA+AAEAAgAAAAoqtAAQuQBeAQCwAAAAAgB3AAAABgABAAAAUAB4AAAAFgACAAAACgB5AHoAAAAAAAoAewB8AAEQAgCMAIcAAQB2AAAAPgABAAIAAAAKKrQAELkAYgEAsAAAAAIAdwAAAAYAAQAAAEoAeAAAABYAAgAAAAoAeQB6AAAAAAAKAHsAfAABEAIAjQCHAAEAdgAAAD4AAQACAAAACiq0ABC5AGYBALAAAAACAHcAAAAGAAEAAABEAHgAAAAWAAIAAAAKAHkAegAAAAAACgB7AHwAARACAI4AhwABAHYAAABBAAEAAgAAAA0qtAAQuQBpAQC4AGywAAAAAgB3AAAABgABAAAAPgB4AAAAFgACAAAADQB5AHoAAAAAAA0AewB8AAEQAgCPAIcAAQB2AAAAQQABAAIAAAANKrQAELkAcAEAuABssAAAAAIAdwAAAAYAAQAAADgAeAAAABYAAgAAAA0AeQB6AAAAAAANAHsAfAABAAQAkAAAAAIAkQCSAAAAEgABAJMAAgCUZQCVAJYAl3MAmACZAAAAXAAJAJoAAwChAKMApgCaAAMAoQCnAKYAmgADAKEAqgCmAJoAAwChAK0ApgCaAAMAoQCwAKYAmgADAKEAswCmAJoAAwChALYApgCaAAMAoQC5AKYAmgADAKEAvACmAL8AAAAaAAMAOwDAAMJAGQDDAMUAx0AZAMgAygDMABk=</listing>
+   <errors/>
+   <sheets/>
+   <license/>
+   <metas>
+      <meta>
+         <head>package</head>
+         <tail>org.junit.jupiter.engine.config</tail>
+         <part>org.junit.jupiter.engine.config</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>org.eolang.jeo.opcode</tail>
+         <part>org.eolang.jeo.opcode</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>org.eolang.jeo.label</tail>
+         <part>org.eolang.jeo.label</part>
+      </meta>
+   </metas>
+   <objects>
+      <o abstract="" name="j$CachingJupiterConfiguration">
+         <o base="int" data="bytes" line="21616660" name="version">00 00 00 00 00 00 00 34</o>
+         <o base="int" data="bytes" line="538746483" name="access">00 00 00 00 00 00 00 21</o>
+         <o base="string" data="bytes" line="451728290" name="supername">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
+         <o base="tuple" line="1712168514" name="interfaces" star="">
+            <o base="string" data="bytes" line="530878828">6F 72 67 2F 6A 75 6E 69 74 2F 6A 75 70 69 74 65 72 2F 65 6E 67 69 6E 65 2F 63 6F 6E 66 69 67 2F 4A 75 70 69 74 65 72 43 6F 6E 66 69 67 75 72 61 74 69 6F 6E</o>
+         </o>
+         <o base="field" line="999" name="j$cache">
+            <o base="int" data="bytes" line="1180874198" name="access-j$cache">00 00 00 00 00 00 00 12</o>
+            <o base="string"
+              data="bytes"
+              line="154953649"
+              name="descriptor-j$cache">4C 6A 61 76 61 2F 75 74 69 6C 2F 63 6F 6E 63 75 72 72 65 6E 74 2F 43 6F 6E 63 75 72 72 65 6E 74 48 61 73 68 4D 61 70 3B</o>
+            <o base="string"
+              data="bytes"
+              line="1717743117"
+              name="signature-j$cache">4C 6A 61 76 61 2F 75 74 69 6C 2F 63 6F 6E 63 75 72 72 65 6E 74 2F 43 6F 6E 63 75 72 72 65 6E 74 48 61 73 68 4D 61 70 3C 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 3E 3B</o>
+            <o base="class"
+              data="bytes"
+              line="1049757213"
+              name="value-j$cache"
+              scope="nullable"/>
+         </o>
+         <o base="field" line="999" name="j$delegate">
+            <o base="int"
+              data="bytes"
+              line="637923364"
+              name="access-j$delegate">00 00 00 00 00 00 00 12</o>
+            <o base="string"
+              data="bytes"
+              line="48213409"
+              name="descriptor-j$delegate">4C 6F 72 67 2F 6A 75 6E 69 74 2F 6A 75 70 69 74 65 72 2F 65 6E 67 69 6E 65 2F 63 6F 6E 66 69 67 2F 4A 75 70 69 74 65 72 43 6F 6E 66 69 67 75 72 61 74 69 6F 6E 3B</o>
+            <o base="string"
+              data="bytes"
+              line="50487485"
+              name="signature-j$delegate"/>
+            <o base="class"
+              data="bytes"
+              line="1528913226"
+              name="value-j$delegate"
+              scope="nullable"/>
+         </o>
+         <o abstract=""
+           name="j$lambda$isParallelExecutionEnabled$0-KExqYXZhL2xhbmcvU3RyaW5nOylMamF2YS9sYW5nL09iamVjdDs=">
+            <o base="int" data="bytes" line="1866326456" name="access">00 00 00 00 00 00 10 02</o>
+            <o base="string" data="bytes" line="393468237" name="descriptor">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B</o>
+            <o base="string" data="bytes" line="1351463114" name="signature"/>
+            <o base="tuple" line="392143076" name="exceptions" star=""/>
+            <o abstract="" line="849595374" name="maxs">
+               <o base="int" data="bytes" line="261954035" name="stack">00 00 00 00 00 00 00 01</o>
+               <o base="int" data="bytes" line="1483571055" name="locals">00 00 00 00 00 00 00 02</o>
+            </o>
+            <o abstract="" name="arg__Ljava/lang/String;__0"/>
+            <o base="seq" name="@">
+               <o base="tuple" line="646548627" name="instructions" star="">
+                  <o base="label" data="bytes" line="1817762244">32 66 65 35 63 38 61 36 2D 32 61 65 37 2D 34 34 33 66 2D 39 39 30 39 2D 37 32 37 39 65 33 63 36 62 66 61 64</o>
+                  <o base="opcode" line="999" name="ALOAD-207332">
+                     <o base="int" data="bytes" line="386358752">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes" line="595424193">00 00 00 00 00 00 00 00</o>
+                  </o>
+                  <o base="opcode" line="999" name="GETFIELD-207333">
+                     <o base="int" data="bytes" line="224094423">00 00 00 00 00 00 00 B4</o>
+                     <o base="string" data="bytes" line="597710034">6F 72 67 2F 6A 75 6E 69 74 2F 6A 75 70 69 74 65 72 2F 65 6E 67 69 6E 65 2F 63 6F 6E 66 69 67 2F 43 61 63 68 69 6E 67 4A 75 70 69 74 65 72 43 6F 6E 66 69 67 75 72 61 74 69 6F 6E</o>
+                     <o base="string" data="bytes" line="558972792">64 65 6C 65 67 61 74 65</o>
+                     <o base="string" data="bytes" line="861226521">4C 6F 72 67 2F 6A 75 6E 69 74 2F 6A 75 70 69 74 65 72 2F 65 6E 67 69 6E 65 2F 63 6F 6E 66 69 67 2F 4A 75 70 69 74 65 72 43 6F 6E 66 69 67 75 72 61 74 69 6F 6E 3B</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKEINTERFACE-207334">
+                     <o base="int" data="bytes" line="16914582">00 00 00 00 00 00 00 B9</o>
+                     <o base="string" data="bytes" line="267219780">6F 72 67 2F 6A 75 6E 69 74 2F 6A 75 70 69 74 65 72 2F 65 6E 67 69 6E 65 2F 63 6F 6E 66 69 67 2F 4A 75 70 69 74 65 72 43 6F 6E 66 69 67 75 72 61 74 69 6F 6E</o>
+                     <o base="string" data="bytes" line="372268234">69 73 50 61 72 61 6C 6C 65 6C 45 78 65 63 75 74 69 6F 6E 45 6E 61 62 6C 65 64</o>
+                     <o base="string" data="bytes" line="425838290">28 29 5A</o>
+                     <o base="bool" data="bytes" line="733598139">01</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKESTATIC-207335">
+                     <o base="int" data="bytes" line="1299975739">00 00 00 00 00 00 00 B8</o>
+                     <o base="string" data="bytes" line="715623634">6A 61 76 61 2F 6C 61 6E 67 2F 42 6F 6F 6C 65 61 6E</o>
+                     <o base="string" data="bytes" line="379585476">76 61 6C 75 65 4F 66</o>
+                     <o base="string" data="bytes" line="2062828882">28 5A 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 42 6F 6F 6C 65 61 6E 3B</o>
+                     <o base="bool" data="bytes" line="1052826321">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="ARETURN-207336">
+                     <o base="int" data="bytes" line="459117116">00 00 00 00 00 00 00 B0</o>
+                  </o>
+                  <o base="label" data="bytes" line="275357337">39 37 38 66 39 64 63 37 2D 35 64 38 32 2D 34 36 34 34 2D 38 31 34 34 2D 31 32 33 36 36 66 31 33 33 64 62 32</o>
+               </o>
+            </o>
+         </o>
+         <o base="tuple" line="1882321859" name="annotations" star="">
+            <o base="annotation"
+              line="571964939"
+              name="org.eolang.jeo.representation.MethodName@1730a38f">
+               <o base="string" data="bytes" line="968610059">4C 6F 72 67 2F 61 70 69 67 75 61 72 64 69 61 6E 2F 61 70 69 2F 41 50 49 3B</o>
+               <o base="bool" data="bytes" line="897634766">01</o>
+               <o base="annotation-property">
+                  <o base="string" data="bytes" line="1599543944">45 4E 55 4D</o>
+                  <o base="string" data="bytes" line="833111236">73 74 61 74 75 73</o>
+                  <o base="string" data="bytes" line="773995423">4C 6F 72 67 2F 61 70 69 67 75 61 72 64 69 61 6E 2F 61 70 69 2F 41 50 49 24 53 74 61 74 75 73 3B</o>
+                  <o base="string" data="bytes" line="348950341">49 4E 54 45 52 4E 41 4C</o>
+               </o>
+               <o base="annotation-property">
+                  <o base="string" data="bytes" line="1692866022">50 4C 41 49 4E</o>
+                  <o base="string" data="bytes" line="822677547">73 69 6E 63 65</o>
+                  <o base="string" data="bytes" line="141091856">35 2E 34</o>
+               </o>
+            </o>
+         </o>
+         <o base="tuple" line="1825305738" name="attributes" star="">
+            <o base="InnerClass">
+               <o base="string" data="bytes" line="2145785915">6F 72 67 2F 6A 75 6E 69 74 2F 6A 75 70 69 74 65 72 2F 61 70 69 2F 54 65 73 74 49 6E 73 74 61 6E 63 65 24 4C 69 66 65 63 79 63 6C 65</o>
+               <o base="string" data="bytes" line="423290058">6F 72 67 2F 6A 75 6E 69 74 2F 6A 75 70 69 74 65 72 2F 61 70 69 2F 54 65 73 74 49 6E 73 74 61 6E 63 65</o>
+               <o base="string" data="bytes" line="2109813640">4C 69 66 65 63 79 63 6C 65</o>
+               <o base="int" data="bytes" line="562705156">00 00 00 00 00 00 40 19</o>
+            </o>
+            <o base="InnerClass">
+               <o base="string" data="bytes" line="896639058">6F 72 67 2F 61 70 69 67 75 61 72 64 69 61 6E 2F 61 70 69 2F 41 50 49 24 53 74 61 74 75 73</o>
+               <o base="string" data="bytes" line="1040693718">6F 72 67 2F 61 70 69 67 75 61 72 64 69 61 6E 2F 61 70 69 2F 41 50 49</o>
+               <o base="string" data="bytes" line="1153032249">53 74 61 74 75 73</o>
+               <o base="int" data="bytes" line="913675536">00 00 00 00 00 00 40 19</o>
+            </o>
+            <o base="InnerClass">
+               <o base="string" data="bytes" line="2140198840">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70</o>
+               <o base="string" data="bytes" line="212860455">6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73</o>
+               <o base="string" data="bytes" line="1392198483">4C 6F 6F 6B 75 70</o>
+               <o base="int" data="bytes" line="462750284">00 00 00 00 00 00 00 19</o>
+            </o>
+         </o>
+      </o>
+   </objects>
+</program>

--- a/src/test/resources/xmir/disassembled/DateFormatterRegistrar$LongToDateConverter.xmir
+++ b/src/test/resources/xmir/disassembled/DateFormatterRegistrar$LongToDateConverter.xmir
@@ -48,7 +48,6 @@
             <o abstract="" name="arg__Ljava/lang/Long;__0"/>
             <o base="seq" name="@">
                <o base="tuple" line="1925909822" name="instructions" star="">
-                  <o base="label" data="bytes" line="2045494741">63 63 33 62 35 36 64 31 2D 34 63 38 34 2D 34 66 32 63 2D 61 30 31 61 2D 31 65 33 62 64 33 39 62 64 32 38 37</o>
                   <o base="opcode" line="999" name="NEW-1C5548">
                      <o base="int" data="bytes" line="1481579125">00 00 00 00 00 00 00 BB</o>
                      <o base="string" data="bytes" line="1038953597">6A 61 76 61 2F 75 74 69 6C 2F 44 61 74 65</o>
@@ -77,7 +76,6 @@
                   <o base="opcode" line="999" name="ARETURN-1C554D">
                      <o base="int" data="bytes" line="1061728938">00 00 00 00 00 00 00 B0</o>
                   </o>
-                  <o base="label" data="bytes" line="662991420">39 66 65 36 63 62 61 35 2D 65 34 37 31 2D 34 36 63 35 2D 38 35 65 65 2D 66 33 62 32 38 37 63 66 34 61 30 31</o>
                </o>
             </o>
          </o>

--- a/src/test/resources/xmir/disassembled/DateFormatterRegistrar$LongToDateConverter.xmir
+++ b/src/test/resources/xmir/disassembled/DateFormatterRegistrar$LongToDateConverter.xmir
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<program dob="2024-08-06T07:58:33.543475Z"
+         ms="1722931113543"
+         name="j$DateFormatterRegistrar$LongToDateConverter"
+         revision="0.0.0"
+         time="2024-08-06T07:58:33.543475Z"
+         version="0.0.0">
+   <listing>yv66vgAAADQAMQoACAAiCgAJACIHACMKAAYAJAoAAwAlBwAmCgAIACcHACkHACoHACsBAAY8aW5pdD4BAAMoKVYBAARDb2RlAQAPTGluZU51bWJlclRhYmxlAQASTG9jYWxWYXJpYWJsZVRhYmxlAQAEdGhpcwEAE0xvbmdUb0RhdGVDb252ZXJ0ZXIBAAxJbm5lckNsYXNzZXMBAFBMb3JnL3NwcmluZ2ZyYW1ld29yay9mb3JtYXQvZGF0ZXRpbWUvRGF0ZUZvcm1hdHRlclJlZ2lzdHJhciRMb25nVG9EYXRlQ29udmVydGVyOwEAB2NvbnZlcnQBACIoTGphdmEvbGFuZy9Mb25nOylMamF2YS91dGlsL0RhdGU7AQAGc291cmNlAQAQTGphdmEvbGFuZy9Mb25nOwEAEE1ldGhvZFBhcmFtZXRlcnMBACYoTGphdmEvbGFuZy9PYmplY3Q7KUxqYXZhL2xhbmcvT2JqZWN0OwcALAEAQShMb3JnL3NwcmluZ2ZyYW1ld29yay9mb3JtYXQvZGF0ZXRpbWUvRGF0ZUZvcm1hdHRlclJlZ2lzdHJhciQxOylWAQACeDABAD5Mb3JnL3NwcmluZ2ZyYW1ld29yay9mb3JtYXQvZGF0ZXRpbWUvRGF0ZUZvcm1hdHRlclJlZ2lzdHJhciQxOwEACVNpZ25hdHVyZQEAakxqYXZhL2xhbmcvT2JqZWN0O0xvcmcvc3ByaW5nZnJhbWV3b3JrL2NvcmUvY29udmVydC9jb252ZXJ0ZXIvQ29udmVydGVyPExqYXZhL2xhbmcvTG9uZztMamF2YS91dGlsL0RhdGU7PjsBAApTb3VyY2VGaWxlAQAbRGF0ZUZvcm1hdHRlclJlZ2lzdHJhci5qYXZhDAALAAwBAA5qYXZhL3V0aWwvRGF0ZQwALQAuDAALAC8BAA5qYXZhL2xhbmcvTG9uZwwAFAAVBwAwAQBOb3JnL3NwcmluZ2ZyYW1ld29yay9mb3JtYXQvZGF0ZXRpbWUvRGF0ZUZvcm1hdHRlclJlZ2lzdHJhciRMb25nVG9EYXRlQ29udmVydGVyAQAQamF2YS9sYW5nL09iamVjdAEANG9yZy9zcHJpbmdmcmFtZXdvcmsvY29yZS9jb252ZXJ0L2NvbnZlcnRlci9Db252ZXJ0ZXIBADxvcmcvc3ByaW5nZnJhbWV3b3JrL2Zvcm1hdC9kYXRldGltZS9EYXRlRm9ybWF0dGVyUmVnaXN0cmFyJDEBAAlsb25nVmFsdWUBAAMoKUoBAAQoSilWAQA6b3JnL3NwcmluZ2ZyYW1ld29yay9mb3JtYXQvZGF0ZXRpbWUvRGF0ZUZvcm1hdHRlclJlZ2lzdHJhcgAgAAgACQABAAoAAAAEAAIACwAMAAEADQAAAC8AAQABAAAABSq3AAKxAAAAAgAOAAAABgABAAAAfQAPAAAADAABAAAABQAQABMAAAABABQAFQACAA0AAABAAAQAAgAAAAy7AANZK7YABLcABbAAAAACAA4AAAAGAAEAAACBAA8AAAAWAAIAAAAMABAAEwAAAAAADAAWABcAAQAYAAAABQEAFgAAEEEAFAAZAAIADQAAADMAAgACAAAACSorwAAGtgAHsAAAAAIADgAAAAYAAQAAAH0ADwAAAAwAAQAAAAkAEAATAAAAGAAAAAUBABYQABAAAAsAGwABAA0AAAA5AAEAAgAAAAUqtwABsQAAAAIADgAAAAYAAQAAAH0ADwAAABYAAgAAAAUAEAATAAAAAAAFABwAHQABAAMAHgAAAAIAHwAgAAAAAgAhABIAAAASAAIACAAoABEACgAaAAAAABAI</listing>
+   <errors/>
+   <sheets/>
+   <license/>
+   <metas>
+      <meta>
+         <head>package</head>
+         <tail>org.springframework.format.datetime</tail>
+         <part>org.springframework.format.datetime</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>org.eolang.jeo.opcode</tail>
+         <part>org.eolang.jeo.opcode</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>org.eolang.jeo.label</tail>
+         <part>org.eolang.jeo.label</part>
+      </meta>
+   </metas>
+   <objects>
+      <o abstract="" name="j$DateFormatterRegistrar$LongToDateConverter">
+         <o base="int" data="bytes" line="1690035899" name="version">00 00 00 00 00 00 00 34</o>
+         <o base="int" data="bytes" line="1071824818" name="access">00 00 00 00 00 00 00 20</o>
+         <o base="string" data="bytes" line="300724051" name="signature">4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 4C 6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 72 65 2F 63 6F 6E 76 65 72 74 2F 63 6F 6E 76 65 72 74 65 72 2F 43 6F 6E 76 65 72 74 65 72 3C 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4C 6F 6E 67 3B 4C 6A 61 76 61 2F 75 74 69 6C 2F 44 61 74 65 3B 3E 3B</o>
+         <o base="string" data="bytes" line="1087283678" name="supername">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
+         <o base="tuple" line="1458433201" name="interfaces" star="">
+            <o base="string" data="bytes" line="1087741193">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 63 6F 72 65 2F 63 6F 6E 76 65 72 74 2F 63 6F 6E 76 65 72 74 65 72 2F 43 6F 6E 76 65 72 74 65 72</o>
+         </o>
+         <o abstract=""
+            name="j$convert-KExqYXZhL2xhbmcvTG9uZzspTGphdmEvdXRpbC9EYXRlOw==">
+            <o base="int" data="bytes" line="1835817828" name="access">00 00 00 00 00 00 00 01</o>
+            <o base="string" data="bytes" line="1757875052" name="descriptor">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4C 6F 6E 67 3B 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 44 61 74 65 3B</o>
+            <o base="string" data="bytes" line="726494812" name="signature"/>
+            <o base="tuple" line="1852253434" name="exceptions" star=""/>
+            <o abstract="" line="1906085142" name="maxs">
+               <o base="int" data="bytes" line="1222566269" name="stack">00 00 00 00 00 00 00 04</o>
+               <o base="int" data="bytes" line="1442931693" name="locals">00 00 00 00 00 00 00 02</o>
+            </o>
+            <o abstract="" name="arg__Ljava/lang/Long;__0"/>
+            <o base="seq" name="@">
+               <o base="tuple" line="1925909822" name="instructions" star="">
+                  <o base="label" data="bytes" line="2045494741">63 63 33 62 35 36 64 31 2D 34 63 38 34 2D 34 66 32 63 2D 61 30 31 61 2D 31 65 33 62 64 33 39 62 64 32 38 37</o>
+                  <o base="opcode" line="999" name="NEW-1C5548">
+                     <o base="int" data="bytes" line="1481579125">00 00 00 00 00 00 00 BB</o>
+                     <o base="string" data="bytes" line="1038953597">6A 61 76 61 2F 75 74 69 6C 2F 44 61 74 65</o>
+                  </o>
+                  <o base="opcode" line="999" name="DUP-1C5549">
+                     <o base="int" data="bytes" line="45805570">00 00 00 00 00 00 00 59</o>
+                  </o>
+                  <o base="opcode" line="999" name="ALOAD-1C554A">
+                     <o base="int" data="bytes" line="1766649937">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes" line="499870819">00 00 00 00 00 00 00 01</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKEVIRTUAL-1C554B">
+                     <o base="int" data="bytes" line="2147463205">00 00 00 00 00 00 00 B6</o>
+                     <o base="string" data="bytes" line="651451830">6A 61 76 61 2F 6C 61 6E 67 2F 4C 6F 6E 67</o>
+                     <o base="string" data="bytes" line="167175775">6C 6F 6E 67 56 61 6C 75 65</o>
+                     <o base="string" data="bytes" line="1440344208">28 29 4A</o>
+                     <o base="bool" data="bytes" line="164640301">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKESPECIAL-1C554C">
+                     <o base="int" data="bytes" line="473196712">00 00 00 00 00 00 00 B7</o>
+                     <o base="string" data="bytes" line="1419979894">6A 61 76 61 2F 75 74 69 6C 2F 44 61 74 65</o>
+                     <o base="string" data="bytes" line="1281829171">3C 69 6E 69 74 3E</o>
+                     <o base="string" data="bytes" line="658855277">28 4A 29 56</o>
+                     <o base="bool" data="bytes" line="699153173">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="ARETURN-1C554D">
+                     <o base="int" data="bytes" line="1061728938">00 00 00 00 00 00 00 B0</o>
+                  </o>
+                  <o base="label" data="bytes" line="662991420">39 66 65 36 63 62 61 35 2D 65 34 37 31 2D 34 36 63 35 2D 38 35 65 65 2D 66 33 62 32 38 37 63 66 34 61 30 31</o>
+               </o>
+            </o>
+         </o>
+         <o abstract=""
+            name="j$convert-KExqYXZhL2xhbmcvT2JqZWN0OylMamF2YS9sYW5nL09iamVjdDs=">
+            <o base="int" data="bytes" line="30293153" name="access">00 00 00 00 00 00 10 41</o>
+            <o base="string" data="bytes" line="1312685217" name="descriptor">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B</o>
+            <o base="string" data="bytes" line="271349437" name="signature"/>
+            <o base="tuple" line="1247572253" name="exceptions" star=""/>
+            <o abstract="" line="1748778204" name="maxs">
+               <o base="int" data="bytes" line="1902978243" name="stack">00 00 00 00 00 00 00 02</o>
+               <o base="int" data="bytes" line="440215690" name="locals">00 00 00 00 00 00 00 02</o>
+            </o>
+            <o abstract="" name="arg__Ljava/lang/Object;__0"/>
+            <o base="seq" name="@">
+               <o base="tuple" line="246633564" name="instructions" star="">
+                  <o base="label" data="bytes" line="1053994279">63 62 37 31 65 32 31 63 2D 62 38 31 32 2D 34 63 31 34 2D 39 65 39 37 2D 31 62 32 38 33 36 66 63 61 38 38 32</o>
+                  <o base="opcode" line="999" name="ALOAD-1C554E">
+                     <o base="int" data="bytes" line="99050981">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes" line="246935599">00 00 00 00 00 00 00 00</o>
+                  </o>
+                  <o base="opcode" line="999" name="ALOAD-1C554F">
+                     <o base="int" data="bytes" line="671072907">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes" line="62011927">00 00 00 00 00 00 00 01</o>
+                  </o>
+                  <o base="opcode" line="999" name="CHECKCAST-1C5550">
+                     <o base="int" data="bytes" line="394065753">00 00 00 00 00 00 00 C0</o>
+                     <o base="string" data="bytes" line="1081476544">6A 61 76 61 2F 6C 61 6E 67 2F 4C 6F 6E 67</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKEVIRTUAL-1C5551">
+                     <o base="int" data="bytes" line="496842474">00 00 00 00 00 00 00 B6</o>
+                     <o base="string" data="bytes" line="1835911490">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 66 6F 72 6D 61 74 2F 64 61 74 65 74 69 6D 65 2F 44 61 74 65 46 6F 72 6D 61 74 74 65 72 52 65 67 69 73 74 72 61 72 24 4C 6F 6E 67 54 6F 44 61 74 65 43 6F 6E 76 65 72 74 65 72</o>
+                     <o base="string" data="bytes" line="1561038678">63 6F 6E 76 65 72 74</o>
+                     <o base="string" data="bytes" line="1698274785">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4C 6F 6E 67 3B 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 44 61 74 65 3B</o>
+                     <o base="bool" data="bytes" line="545706107">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="ARETURN-1C5552">
+                     <o base="int" data="bytes" line="808816709">00 00 00 00 00 00 00 B0</o>
+                  </o>
+                  <o base="label" data="bytes" line="985394796">36 61 64 31 39 37 37 31 2D 66 34 30 62 2D 34 65 38 62 2D 39 62 34 35 2D 65 62 35 36 62 65 61 37 65 32 36 32</o>
+               </o>
+            </o>
+         </o>
+         <o base="tuple" line="944017640" name="attributes" star="">
+            <o base="InnerClass">
+               <o base="string" data="bytes" line="653239898">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 66 6F 72 6D 61 74 2F 64 61 74 65 74 69 6D 65 2F 44 61 74 65 46 6F 72 6D 61 74 74 65 72 52 65 67 69 73 74 72 61 72 24 4C 6F 6E 67 54 6F 44 61 74 65 43 6F 6E 76 65 72 74 65 72</o>
+               <o base="string" data="bytes" line="644757377">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 66 6F 72 6D 61 74 2F 64 61 74 65 74 69 6D 65 2F 44 61 74 65 46 6F 72 6D 61 74 74 65 72 52 65 67 69 73 74 72 61 72</o>
+               <o base="string" data="bytes" line="1987233927">4C 6F 6E 67 54 6F 44 61 74 65 43 6F 6E 76 65 72 74 65 72</o>
+               <o base="int" data="bytes" line="1126503244">00 00 00 00 00 00 00 0A</o>
+            </o>
+            <o base="InnerClass">
+               <o base="string" data="bytes" line="1641610914">6F 72 67 2F 73 70 72 69 6E 67 66 72 61 6D 65 77 6F 72 6B 2F 66 6F 72 6D 61 74 2F 64 61 74 65 74 69 6D 65 2F 44 61 74 65 46 6F 72 6D 61 74 74 65 72 52 65 67 69 73 74 72 61 72 24 31</o>
+               <o base="string" data="bytes" line="1427232180"/>
+               <o base="string" data="bytes" line="150318617"/>
+               <o base="int" data="bytes" line="722703936">00 00 00 00 00 00 10 08</o>
+            </o>
+         </o>
+      </o>
+   </objects>
+</program>

--- a/src/test/resources/xmir/disassembled/EngineDiscoveryRequestResolver$DefaultInitializationContext.xmir
+++ b/src/test/resources/xmir/disassembled/EngineDiscoveryRequestResolver$DefaultInitializationContext.xmir
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<program dob="2024-08-06T07:12:09.583471Z"
+         ms="1722928329583"
+         name="j$EngineDiscoveryRequestResolver$DefaultInitializationContext"
+         revision="0.0.0"
+         time="2024-08-06T07:12:09.583471Z"
+         version="0.0.0">
+   <listing>yv66vgAAADQAVwoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCQAIAAkHAAoMAAsADAEAZ29yZy9qdW5pdC9wbGF0Zm9ybS9lbmdpbmUvc3VwcG9ydC9kaXNjb3ZlcnkvRW5naW5lRGlzY292ZXJ5UmVxdWVzdFJlc29sdmVyJERlZmF1bHRJbml0aWFsaXphdGlvbkNvbnRleHQBAAdyZXF1ZXN0AQAyTG9yZy9qdW5pdC9wbGF0Zm9ybS9lbmdpbmUvRW5naW5lRGlzY292ZXJ5UmVxdWVzdDsJAAgADgwADwAQAQAQZW5naW5lRGVzY3JpcHRvcgEAKkxvcmcvanVuaXQvcGxhdGZvcm0vZW5naW5lL1Rlc3REZXNjcmlwdG9yOwoACAASDAATABQBABdidWlsZENsYXNzTmFtZVByZWRpY2F0ZQEAUihMb3JnL2p1bml0L3BsYXRmb3JtL2VuZ2luZS9FbmdpbmVEaXNjb3ZlcnlSZXF1ZXN0OylMamF2YS91dGlsL2Z1bmN0aW9uL1ByZWRpY2F0ZTsJAAgAFgwAFwAYAQAPY2xhc3NOYW1lRmlsdGVyAQAeTGphdmEvdXRpbC9mdW5jdGlvbi9QcmVkaWNhdGU7BwAaAQATamF2YS91dGlsL0FycmF5TGlzdAoAGQADBwAdAQAzb3JnL2p1bml0L3BsYXRmb3JtL2VuZ2luZS9kaXNjb3ZlcnkvQ2xhc3NOYW1lRmlsdGVyCwAfACAHACEMACIAIwEAMG9yZy9qdW5pdC9wbGF0Zm9ybS9lbmdpbmUvRW5naW5lRGlzY292ZXJ5UmVxdWVzdAEAEGdldEZpbHRlcnNCeVR5cGUBACMoTGphdmEvbGFuZy9DbGFzczspTGphdmEvdXRpbC9MaXN0OwsAJQAmBwAnDAAoACkBAA5qYXZhL3V0aWwvTGlzdAEABmFkZEFsbAEAGShMamF2YS91dGlsL0NvbGxlY3Rpb247KVoHACsBADVvcmcvanVuaXQvcGxhdGZvcm0vZW5naW5lL2Rpc2NvdmVyeS9QYWNrYWdlTmFtZUZpbHRlcgsALQAuBwAvDAAwADEBACBvcmcvanVuaXQvcGxhdGZvcm0vZW5naW5lL0ZpbHRlcgEADmNvbXBvc2VGaWx0ZXJzAQA6KExqYXZhL3V0aWwvQ29sbGVjdGlvbjspTG9yZy9qdW5pdC9wbGF0Zm9ybS9lbmdpbmUvRmlsdGVyOwsALQAzDAA0ADUBAAt0b1ByZWRpY2F0ZQEAICgpTGphdmEvdXRpbC9mdW5jdGlvbi9QcmVkaWNhdGU7BwA3AQBgb3JnL2p1bml0L3BsYXRmb3JtL2VuZ2luZS9zdXBwb3J0L2Rpc2NvdmVyeS9FbmdpbmVEaXNjb3ZlcnlSZXF1ZXN0UmVzb2x2ZXIkSW5pdGlhbGl6YXRpb25Db250ZXh0AQAJU2lnbmF0dXJlAQADVFQ7AQAyTGphdmEvdXRpbC9mdW5jdGlvbi9QcmVkaWNhdGU8TGphdmEvbGFuZy9TdHJpbmc7PjsBAF8oTG9yZy9qdW5pdC9wbGF0Zm9ybS9lbmdpbmUvRW5naW5lRGlzY292ZXJ5UmVxdWVzdDtMb3JnL2p1bml0L3BsYXRmb3JtL2VuZ2luZS9UZXN0RGVzY3JpcHRvcjspVgEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBABJMb2NhbFZhcmlhYmxlVGFibGUBAAR0aGlzAQBpTG9yZy9qdW5pdC9wbGF0Zm9ybS9lbmdpbmUvc3VwcG9ydC9kaXNjb3ZlcnkvRW5naW5lRGlzY292ZXJ5UmVxdWVzdFJlc29sdmVyJERlZmF1bHRJbml0aWFsaXphdGlvbkNvbnRleHQ7AQAWTG9jYWxWYXJpYWJsZVR5cGVUYWJsZQEAbkxvcmcvanVuaXQvcGxhdGZvcm0vZW5naW5lL3N1cHBvcnQvZGlzY292ZXJ5L0VuZ2luZURpc2NvdmVyeVJlcXVlc3RSZXNvbHZlciREZWZhdWx0SW5pdGlhbGl6YXRpb25Db250ZXh0PFRUOz47AQA4KExvcmcvanVuaXQvcGxhdGZvcm0vZW5naW5lL0VuZ2luZURpc2NvdmVyeVJlcXVlc3Q7VFQ7KVYBAAdmaWx0ZXJzAQAQTGphdmEvdXRpbC9MaXN0OwEAUUxqYXZhL3V0aWwvTGlzdDxMb3JnL2p1bml0L3BsYXRmb3JtL2VuZ2luZS9EaXNjb3ZlcnlGaWx0ZXI8TGphdmEvbGFuZy9TdHJpbmc7Pjs+OwEAZihMb3JnL2p1bml0L3BsYXRmb3JtL2VuZ2luZS9FbmdpbmVEaXNjb3ZlcnlSZXF1ZXN0OylMamF2YS91dGlsL2Z1bmN0aW9uL1ByZWRpY2F0ZTxMamF2YS9sYW5nL1N0cmluZzs+OwEAE2dldERpc2NvdmVyeVJlcXVlc3QBADQoKUxvcmcvanVuaXQvcGxhdGZvcm0vZW5naW5lL0VuZ2luZURpc2NvdmVyeVJlcXVlc3Q7AQATZ2V0RW5naW5lRGVzY3JpcHRvcgEALCgpTG9yZy9qdW5pdC9wbGF0Zm9ybS9lbmdpbmUvVGVzdERlc2NyaXB0b3I7AQAFKClUVDsBABJnZXRDbGFzc05hbWVGaWx0ZXIBADQoKUxqYXZhL3V0aWwvZnVuY3Rpb24vUHJlZGljYXRlPExqYXZhL2xhbmcvU3RyaW5nOz47AQCoPFQ6OkxvcmcvanVuaXQvcGxhdGZvcm0vZW5naW5lL1Rlc3REZXNjcmlwdG9yOz5MamF2YS9sYW5nL09iamVjdDtMb3JnL2p1bml0L3BsYXRmb3JtL2VuZ2luZS9zdXBwb3J0L2Rpc2NvdmVyeS9FbmdpbmVEaXNjb3ZlcnlSZXF1ZXN0UmVzb2x2ZXIkSW5pdGlhbGl6YXRpb25Db250ZXh0PFRUOz47AQAKU291cmNlRmlsZQEAI0VuZ2luZURpc2NvdmVyeVJlcXVlc3RSZXNvbHZlci5qYXZhAQAMSW5uZXJDbGFzc2VzBwBUAQBKb3JnL2p1bml0L3BsYXRmb3JtL2VuZ2luZS9zdXBwb3J0L2Rpc2NvdmVyeS9FbmdpbmVEaXNjb3ZlcnlSZXF1ZXN0UmVzb2x2ZXIBABxEZWZhdWx0SW5pdGlhbGl6YXRpb25Db250ZXh0AQAVSW5pdGlhbGl6YXRpb25Db250ZXh0ACAACAACAAEANgADABIACwAMAAAAEgAPABAAAQA4AAAAAgA5ABIAFwAYAAEAOAAAAAIAOgAFAAAABQA7AAIAPAAAAIIAAwADAAAAGCq3AAEqK7UAByostQANKiortwARtQAVsQAAAAMAPQAAABYABQAAAQIABAEDAAkBBAAOAQUAFwEGAD4AAAAgAAMAAAAYAD8AQAAAAAAAGAALAAwAAQAAABgADwAQAAIAQQAAABYAAgAAABgAPwBCAAAAAAAYAA8AOQACADgAAAACAEMAAgATABQAAgA8AAAAlgADAAMAAAAwuwAZWbcAG00sKxIcuQAeAgC5ACQCAFcsKxIquQAeAgC5ACQCAFcsuAAsuQAyAQCwAAAAAwA9AAAAEgAEAAABDwAIARAAFwERACYBEgA+AAAAIAADAAAAMAA/AEAAAAAAADAACwAMAAEACAAoAEQARQACAEEAAAAWAAIAAAAwAD8AQgAAAAgAKABEAEYAAgA4AAAAAgBHAAEASABJAAEAPAAAAEEAAQABAAAABSq0AAewAAAAAwA9AAAABgABAAABFwA+AAAADAABAAAABQA/AEAAAABBAAAADAABAAAABQA/AEIAAAABAEoASwACADwAAABBAAEAAQAAAAUqtAANsAAAAAMAPQAAAAYAAQAAARwAPgAAAAwAAQAAAAUAPwBAAAAAQQAAAAwAAQAAAAUAPwBCAAAAOAAAAAIATAABAE0ANQACADwAAABBAAEAAQAAAAUqtAAVsAAAAAMAPQAAAAYAAQAAASEAPgAAAAwAAQAAAAUAPwBAAAAAQQAAAAwAAQAAAAUAPwBCAAAAOAAAAAIATgADADgAAAACAE8AUAAAAAIAUQBSAAAAEgACAAgAUwBVAAoANgBTAFYGCQ==</listing>
+   <errors/>
+   <sheets/>
+   <license/>
+   <metas>
+      <meta>
+         <head>package</head>
+         <tail>org.junit.platform.engine.support.discovery</tail>
+         <part>org.junit.platform.engine.support.discovery</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>org.eolang.jeo.opcode</tail>
+         <part>org.eolang.jeo.opcode</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>org.eolang.jeo.label</tail>
+         <part>org.eolang.jeo.label</part>
+      </meta>
+   </metas>
+   <objects>
+      <o abstract=""
+         name="j$EngineDiscoveryRequestResolver$DefaultInitializationContext">
+         <o base="int" data="bytes" line="566699749" name="version">00 00 00 00 00 00 00 34</o>
+         <o base="int" data="bytes" line="1146731750" name="access">00 00 00 00 00 00 00 20</o>
+         <o base="string" data="bytes" line="40472226" name="signature">3C 54 3A 3A 4C 6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 54 65 73 74 44 65 73 63 72 69 70 74 6F 72 3B 3E 4C 6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74 3B 4C 6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 73 75 70 70 6F 72 74 2F 64 69 73 63 6F 76 65 72 79 2F 45 6E 67 69 6E 65 44 69 73 63 6F 76 65 72 79 52 65 71 75 65 73 74 52 65 73 6F 6C 76 65 72 24 49 6E 69 74 69 61 6C 69 7A 61 74 69 6F 6E 43 6F 6E 74 65 78 74 3C 54 54 3B 3E 3B</o>
+         <o base="string" data="bytes" line="1690691797" name="supername">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
+         <o base="tuple" line="1202975457" name="interfaces" star="">
+            <o base="string" data="bytes" line="806131770">6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 73 75 70 70 6F 72 74 2F 64 69 73 63 6F 76 65 72 79 2F 45 6E 67 69 6E 65 44 69 73 63 6F 76 65 72 79 52 65 71 75 65 73 74 52 65 73 6F 6C 76 65 72 24 49 6E 69 74 69 61 6C 69 7A 61 74 69 6F 6E 43 6F 6E 74 65 78 74</o>
+         </o>
+         <o base="field" line="999" name="j$request">
+            <o base="int"
+               data="bytes"
+               line="2047958684"
+               name="access-j$request">00 00 00 00 00 00 00 12</o>
+            <o base="string"
+               data="bytes"
+               line="2066127543"
+               name="descriptor-j$request">4C 6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 45 6E 67 69 6E 65 44 69 73 63 6F 76 65 72 79 52 65 71 75 65 73 74 3B</o>
+            <o base="string"
+               data="bytes"
+               line="2053772265"
+               name="signature-j$request"/>
+            <o base="class"
+               data="bytes"
+               line="1925646608"
+               name="value-j$request"
+               scope="nullable"/>
+         </o>
+         <o base="field" line="999" name="j$engineDescriptor">
+            <o base="int"
+               data="bytes"
+               line="987466114"
+               name="access-j$engineDescriptor">00 00 00 00 00 00 00 12</o>
+            <o base="string"
+               data="bytes"
+               line="1596162677"
+               name="descriptor-j$engineDescriptor">4C 6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 54 65 73 74 44 65 73 63 72 69 70 74 6F 72 3B</o>
+            <o base="string"
+               data="bytes"
+               line="1312991077"
+               name="signature-j$engineDescriptor">54 54 3B</o>
+            <o base="class"
+               data="bytes"
+               line="799371602"
+               name="value-j$engineDescriptor"
+               scope="nullable"/>
+         </o>
+         <o base="field" line="999" name="j$classNameFilter">
+            <o base="int"
+               data="bytes"
+               line="795159330"
+               name="access-j$classNameFilter">00 00 00 00 00 00 00 12</o>
+            <o base="string"
+               data="bytes"
+               line="270436158"
+               name="descriptor-j$classNameFilter">4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 50 72 65 64 69 63 61 74 65 3B</o>
+            <o base="string"
+               data="bytes"
+               line="596276345"
+               name="signature-j$classNameFilter">4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 50 72 65 64 69 63 61 74 65 3C 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 3E 3B</o>
+            <o base="class"
+               data="bytes"
+               line="318719786"
+               name="value-j$classNameFilter"
+               scope="nullable"/>
+         </o>
+         <o abstract=""
+            name="j$buildClassNamePredicate-KExvcmcvanVuaXQvcGxhdGZvcm0vZW5naW5lL0VuZ2luZURpc2NvdmVyeVJlcXVlc3Q7KUxqYXZhL3V0aWwvZnVuY3Rpb24vUHJlZGljYXRlOw==">
+            <o base="int" data="bytes" line="866573482" name="access">00 00 00 00 00 00 00 02</o>
+            <o base="string" data="bytes" line="742540167" name="descriptor">28 4C 6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 45 6E 67 69 6E 65 44 69 73 63 6F 76 65 72 79 52 65 71 75 65 73 74 3B 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 50 72 65 64 69 63 61 74 65 3B</o>
+            <o base="string" data="bytes" line="1673062449" name="signature">28 4C 6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 45 6E 67 69 6E 65 44 69 73 63 6F 76 65 72 79 52 65 71 75 65 73 74 3B 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 50 72 65 64 69 63 61 74 65 3C 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 3E 3B</o>
+            <o base="tuple" line="611100932" name="exceptions" star=""/>
+            <o abstract="" line="407520195" name="maxs">
+               <o base="int" data="bytes" line="79794694" name="stack">00 00 00 00 00 00 00 03</o>
+               <o base="int" data="bytes" line="799456477" name="locals">00 00 00 00 00 00 00 03</o>
+            </o>
+            <o abstract=""
+               name="arg__Lorg/junit/platform/engine/EngineDiscoveryRequest;__0"/>
+            <o base="seq" name="@">
+               <o base="tuple" line="948885229" name="instructions" star="">
+                  <o base="label" data="bytes" line="2118350732">32 65 35 64 32 39 30 66 2D 61 64 62 65 2D 34 65 34 62 2D 62 39 39 63 2D 31 30 65 65 66 65 64 37 61 36 30 32</o>
+                  <o base="opcode" line="999" name="NEW-138A6A">
+                     <o base="int" data="bytes" line="1307877948">00 00 00 00 00 00 00 BB</o>
+                     <o base="string" data="bytes" line="2094063806">6A 61 76 61 2F 75 74 69 6C 2F 41 72 72 61 79 4C 69 73 74</o>
+                  </o>
+                  <o base="opcode" line="999" name="DUP-138A6B">
+                     <o base="int" data="bytes" line="1141721172">00 00 00 00 00 00 00 59</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKESPECIAL-138A6C">
+                     <o base="int" data="bytes" line="1523253935">00 00 00 00 00 00 00 B7</o>
+                     <o base="string" data="bytes" line="1338719177">6A 61 76 61 2F 75 74 69 6C 2F 41 72 72 61 79 4C 69 73 74</o>
+                     <o base="string" data="bytes" line="210495292">3C 69 6E 69 74 3E</o>
+                     <o base="string" data="bytes" line="1052872791">28 29 56</o>
+                     <o base="bool" data="bytes" line="1297332118">00</o>
+                  </o>
+                  <o base="opcode" line="999" name="ASTORE-138A6D">
+                     <o base="int" data="bytes" line="804087937">00 00 00 00 00 00 00 3A</o>
+                     <o base="int" data="bytes" line="438095782">00 00 00 00 00 00 00 02</o>
+                  </o>
+                  <o base="label" data="bytes" line="1064250696">61 36 37 33 31 63 64 63 2D 63 66 37 32 2D 34 32 64 37 2D 62 38 65 61 2D 33 66 66 64 39 62 61 61 62 30 36 63</o>
+                  <o base="opcode" line="999" name="ALOAD-138A6E">
+                     <o base="int" data="bytes" line="329523740">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes" line="1498833980">00 00 00 00 00 00 00 02</o>
+                  </o>
+                  <o base="opcode" line="999" name="ALOAD-138A6F">
+                     <o base="int" data="bytes" line="1767807964">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes" line="1098858827">00 00 00 00 00 00 00 01</o>
+                  </o>
+                  <o base="opcode" line="999" name="LDC-138A70">
+                     <o base="int" data="bytes" line="1362094350">00 00 00 00 00 00 00 12</o>
+                     <o base="type" data="bytes" line="2121560692">4C 6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 64 69 73 63 6F 76 65 72 79 2F 43 6C 61 73 73 4E 61 6D 65 46 69 6C 74 65 72 3B</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKEINTERFACE-138A71">
+                     <o base="int" data="bytes" line="773490909">00 00 00 00 00 00 00 B9</o>
+                     <o base="string" data="bytes" line="207629722">6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 45 6E 67 69 6E 65 44 69 73 63 6F 76 65 72 79 52 65 71 75 65 73 74</o>
+                     <o base="string" data="bytes" line="191427588">67 65 74 46 69 6C 74 65 72 73 42 79 54 79 70 65</o>
+                     <o base="string" data="bytes" line="2061401594">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 43 6C 61 73 73 3B 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 4C 69 73 74 3B</o>
+                     <o base="bool" data="bytes" line="1328600907">01</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKEINTERFACE-138A72">
+                     <o base="int" data="bytes" line="565795144">00 00 00 00 00 00 00 B9</o>
+                     <o base="string" data="bytes" line="610513860">6A 61 76 61 2F 75 74 69 6C 2F 4C 69 73 74</o>
+                     <o base="string" data="bytes" line="1847795056">61 64 64 41 6C 6C</o>
+                     <o base="string" data="bytes" line="828415509">28 4C 6A 61 76 61 2F 75 74 69 6C 2F 43 6F 6C 6C 65 63 74 69 6F 6E 3B 29 5A</o>
+                     <o base="bool" data="bytes" line="1223472113">01</o>
+                  </o>
+                  <o base="opcode" line="999" name="POP-138A73">
+                     <o base="int" data="bytes" line="412608967">00 00 00 00 00 00 00 57</o>
+                  </o>
+                  <o base="label" data="bytes" line="1837842380">65 65 31 62 63 33 39 65 2D 36 30 65 32 2D 34 66 37 33 2D 39 65 30 39 2D 65 36 63 30 65 64 30 61 38 31 35 39</o>
+                  <o base="opcode" line="999" name="ALOAD-138A74">
+                     <o base="int" data="bytes" line="1402821060">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes" line="328033436">00 00 00 00 00 00 00 02</o>
+                  </o>
+                  <o base="opcode" line="999" name="ALOAD-138A75">
+                     <o base="int" data="bytes" line="1196823316">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes" line="324049752">00 00 00 00 00 00 00 01</o>
+                  </o>
+                  <o base="opcode" line="999" name="LDC-138A76">
+                     <o base="int" data="bytes" line="1269232755">00 00 00 00 00 00 00 12</o>
+                     <o base="type" data="bytes" line="1382275775">4C 6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 64 69 73 63 6F 76 65 72 79 2F 50 61 63 6B 61 67 65 4E 61 6D 65 46 69 6C 74 65 72 3B</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKEINTERFACE-138A77">
+                     <o base="int" data="bytes" line="1630164500">00 00 00 00 00 00 00 B9</o>
+                     <o base="string" data="bytes" line="1159982705">6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 45 6E 67 69 6E 65 44 69 73 63 6F 76 65 72 79 52 65 71 75 65 73 74</o>
+                     <o base="string" data="bytes" line="291702253">67 65 74 46 69 6C 74 65 72 73 42 79 54 79 70 65</o>
+                     <o base="string" data="bytes" line="221220984">28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 43 6C 61 73 73 3B 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 4C 69 73 74 3B</o>
+                     <o base="bool" data="bytes" line="11623858">01</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKEINTERFACE-138A78">
+                     <o base="int" data="bytes" line="49312576">00 00 00 00 00 00 00 B9</o>
+                     <o base="string" data="bytes" line="1436668000">6A 61 76 61 2F 75 74 69 6C 2F 4C 69 73 74</o>
+                     <o base="string" data="bytes" line="1477488802">61 64 64 41 6C 6C</o>
+                     <o base="string" data="bytes" line="1136596679">28 4C 6A 61 76 61 2F 75 74 69 6C 2F 43 6F 6C 6C 65 63 74 69 6F 6E 3B 29 5A</o>
+                     <o base="bool" data="bytes" line="1984294253">01</o>
+                  </o>
+                  <o base="opcode" line="999" name="POP-138A79">
+                     <o base="int" data="bytes" line="1168847984">00 00 00 00 00 00 00 57</o>
+                  </o>
+                  <o base="label" data="bytes" line="13113058">30 36 31 37 64 63 31 35 2D 33 64 39 32 2D 34 35 35 64 2D 39 36 34 63 2D 62 32 31 36 38 34 30 36 64 61 61 37</o>
+                  <o base="opcode" line="999" name="ALOAD-138A7A">
+                     <o base="int" data="bytes" line="1410250323">00 00 00 00 00 00 00 19</o>
+                     <o base="int" data="bytes" line="898052538">00 00 00 00 00 00 00 02</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKESTATIC-138A7B">
+                     <o base="int" data="bytes" line="1126588789">00 00 00 00 00 00 00 B8</o>
+                     <o base="string" data="bytes" line="1563922083">6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 46 69 6C 74 65 72</o>
+                     <o base="string" data="bytes" line="1583184509">63 6F 6D 70 6F 73 65 46 69 6C 74 65 72 73</o>
+                     <o base="string" data="bytes" line="1457827145">28 4C 6A 61 76 61 2F 75 74 69 6C 2F 43 6F 6C 6C 65 63 74 69 6F 6E 3B 29 4C 6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 46 69 6C 74 65 72 3B</o>
+                     <o base="bool" data="bytes" line="997906962">01</o>
+                  </o>
+                  <o base="opcode" line="999" name="INVOKEINTERFACE-138A7C">
+                     <o base="int" data="bytes" line="2017606775">00 00 00 00 00 00 00 B9</o>
+                     <o base="string" data="bytes" line="1037560898">6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 46 69 6C 74 65 72</o>
+                     <o base="string" data="bytes" line="1592588851">74 6F 50 72 65 64 69 63 61 74 65</o>
+                     <o base="string" data="bytes" line="103626391">28 29 4C 6A 61 76 61 2F 75 74 69 6C 2F 66 75 6E 63 74 69 6F 6E 2F 50 72 65 64 69 63 61 74 65 3B</o>
+                     <o base="bool" data="bytes" line="3824955">01</o>
+                  </o>
+                  <o base="opcode" line="999" name="ARETURN-138A7D">
+                     <o base="int" data="bytes" line="220382590">00 00 00 00 00 00 00 B0</o>
+                  </o>
+                  <o base="label" data="bytes" line="1262306832">61 37 33 33 34 33 34 33 2D 37 63 32 32 2D 34 33 36 36 2D 38 39 39 63 2D 35 37 64 62 38 32 38 64 62 61 33 35</o>
+               </o>
+            </o>
+         </o>
+         <o base="tuple" line="1184331710" name="attributes" star="">
+            <o base="InnerClass">
+               <o base="string" data="bytes" line="1057648241">6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 73 75 70 70 6F 72 74 2F 64 69 73 63 6F 76 65 72 79 2F 45 6E 67 69 6E 65 44 69 73 63 6F 76 65 72 79 52 65 71 75 65 73 74 52 65 73 6F 6C 76 65 72 24 44 65 66 61 75 6C 74 49 6E 69 74 69 61 6C 69 7A 61 74 69 6F 6E 43 6F 6E 74 65 78 74</o>
+               <o base="string" data="bytes" line="1837434785">6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 73 75 70 70 6F 72 74 2F 64 69 73 63 6F 76 65 72 79 2F 45 6E 67 69 6E 65 44 69 73 63 6F 76 65 72 79 52 65 71 75 65 73 74 52 65 73 6F 6C 76 65 72</o>
+               <o base="string" data="bytes" line="1975953041">44 65 66 61 75 6C 74 49 6E 69 74 69 61 6C 69 7A 61 74 69 6F 6E 43 6F 6E 74 65 78 74</o>
+               <o base="int" data="bytes" line="1650821251">00 00 00 00 00 00 00 0A</o>
+            </o>
+            <o base="InnerClass">
+               <o base="string" data="bytes" line="1921836004">6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 73 75 70 70 6F 72 74 2F 64 69 73 63 6F 76 65 72 79 2F 45 6E 67 69 6E 65 44 69 73 63 6F 76 65 72 79 52 65 71 75 65 73 74 52 65 73 6F 6C 76 65 72 24 49 6E 69 74 69 61 6C 69 7A 61 74 69 6F 6E 43 6F 6E 74 65 78 74</o>
+               <o base="string" data="bytes" line="1035123867">6F 72 67 2F 6A 75 6E 69 74 2F 70 6C 61 74 66 6F 72 6D 2F 65 6E 67 69 6E 65 2F 73 75 70 70 6F 72 74 2F 64 69 73 63 6F 76 65 72 79 2F 45 6E 67 69 6E 65 44 69 73 63 6F 76 65 72 79 52 65 71 75 65 73 74 52 65 73 6F 6C 76 65 72</o>
+               <o base="string" data="bytes" line="260714529">49 6E 69 74 69 61 6C 69 7A 61 74 69 6F 6E 43 6F 6E 74 65 78 74</o>
+               <o base="int" data="bytes" line="130158684">00 00 00 00 00 00 06 09</o>
+            </o>
+         </o>
+      </o>
+   </objects>
+</program>


### PR DESCRIPTION
In this PR I finally enabled 'spring-fat' integration test and not it works without any problems.
Closes: #344.
History:
- **feat(#344): solve the problem with primitive types in the return instruction**
- **feat(#344): add one more unit test**
- **feat(#344): find one more problem**
- **feat(#344): fix type inference for LOAD opcode**
- **feat(#344): fix all the qulice offences**
- **feat(#344): remove the puzzle for #344 issue**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving type inference in method invocations. 

### Detailed summary
- Updated type inference in `InterfaceInvocation` for method invocations.
- Added `vtype` field to `Constant` class for constant value type.
- Modified `LocalVariable` and `Return` classes to handle type comparisons.
- Updated test cases in `JeoAndOpeoTest` for method instructions.
- Added a new XMIR file for `DateFormatterRegistrar$LongToDateConverter`.

> The following files were skipped due to too many changes: `src/test/resources/xmir/disassembled/DateFormatterRegistrar$LongToDateConverter.xmir`, `src/test/resources/xmir/disassembled/CachingJupiterConfiguration2.xmir`, `src/test/resources/xmir/disassembled/EngineDiscoveryRequestResolver$DefaultInitializationContext.xmir`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->