### PR TITLE
feat(#367): Fix PHI Printing in 'spring-fat' Integration Test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>jeo-maven-plugin</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>0.5.3</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>jeo-maven-plugin</artifactId>
-      <version>0.5.1</version>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/src/it/fuse/pom.xml
+++ b/src/it/fuse/pom.xml
@@ -47,7 +47,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <jeo.version>0.5.1</jeo.version>
+    <jeo.version>1.0-SNAPSHOT</jeo.version>
     <ineo.version>0.3.2</ineo.version>
     <opeo.version>@project.version@</opeo.version>
   </properties>

--- a/src/it/fuse/pom.xml
+++ b/src/it/fuse/pom.xml
@@ -47,7 +47,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <jeo.version>1.0-SNAPSHOT</jeo.version>
+    <jeo.version>0.5.3</jeo.version>
     <ineo.version>0.3.2</ineo.version>
     <opeo.version>@project.version@</opeo.version>
   </properties>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -53,7 +53,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <jeo.version>0.5.1</jeo.version>
+    <jeo.version>1.0-SNAPSHOT</jeo.version>
     <ineo.version>0.3.2</ineo.version>
     <jeo.disassemble.output>${project.build.directory}/generated-sources/jeo-disassemble-xmir</jeo.disassemble.output>
     <opeo.decompile.output>${project.build.directory}/generated-sources/opeo-decompile-xmir</opeo.decompile.output>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -53,7 +53,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <jeo.version>1.0-SNAPSHOT</jeo.version>
+    <jeo.version>0.5.3</jeo.version>
     <ineo.version>0.3.2</ineo.version>
     <jeo.disassemble.output>${project.build.directory}/generated-sources/jeo-disassemble-xmir</jeo.disassemble.output>
     <opeo.decompile.output>${project.build.directory}/generated-sources/opeo-decompile-xmir</opeo.decompile.output>

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -53,7 +53,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <jeo.version>1.0-SNAPSHOT</jeo.version>
+    <jeo.version>0.5.3</jeo.version>
     <ineo.version>0.3.2</ineo.version>
   </properties>
   <dependencies>

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -53,7 +53,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <jeo.version>0.5.1</jeo.version>
+    <jeo.version>1.0-SNAPSHOT</jeo.version>
     <ineo.version>0.3.2</ineo.version>
   </properties>
   <dependencies>

--- a/src/it/staticize/pom.xml
+++ b/src/it/staticize/pom.xml
@@ -50,7 +50,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
-    <jeo.version>0.5.1</jeo.version>
+    <jeo.version>1.0-SNAPSHOT</jeo.version>
     <ineo.version>0.3.2</ineo.version>
     <opeo.version>@project.version@</opeo.version>
   </properties>

--- a/src/it/staticize/pom.xml
+++ b/src/it/staticize/pom.xml
@@ -50,7 +50,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
-    <jeo.version>1.0-SNAPSHOT</jeo.version>
+    <jeo.version>0.5.3</jeo.version>
     <ineo.version>0.3.2</ineo.version>
     <opeo.version>@project.version@</opeo.version>
   </properties>

--- a/src/it/streams/pom.xml
+++ b/src/it/streams/pom.xml
@@ -40,7 +40,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
-    <jeo.version>0.5.1</jeo.version>
+    <jeo.version>1.0-SNAPSHOT</jeo.version>
     <opeo.version>@project.version@</opeo.version>
   </properties>
   <build>

--- a/src/it/streams/pom.xml
+++ b/src/it/streams/pom.xml
@@ -40,7 +40,7 @@ SOFTWARE.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
-    <jeo.version>1.0-SNAPSHOT</jeo.version>
+    <jeo.version>0.5.3</jeo.version>
     <opeo.version>@project.version@</opeo.version>
   </properties>
   <build>


### PR DESCRIPTION
In this PR I fix the problem with PHI printing errors in 'spring-fat' integration test.
Since most of the bugs went from `jeo-maven-plugin`, we can just update it to fix all the bugs in PHI printing here.

Closes: #367

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `jeo-maven-plugin` version from `0.5.1` to `0.5.3` in multiple modules.

### Detailed summary
- Updated `jeo-maven-plugin` version from `0.5.1` to `0.5.3` in various `pom.xml` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->