### PR TITLE
feat(#288): Add More Types For Multiplication

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/Multiplication.java
+++ b/src/main/java/org/eolang/opeo/ast/Multiplication.java
@@ -96,19 +96,21 @@ public final class Multiplication implements AstNode, Typed {
      * @return Opcode.
      */
     private int opcode() {
+        final int result;
         final Type type = this.type();
         if (type.equals(Type.INT_TYPE)) {
-            return Opcodes.IMUL;
+            result = Opcodes.IMUL;
         } else if (type.equals(Type.LONG_TYPE)) {
-            return Opcodes.LMUL;
+            result = Opcodes.LMUL;
         } else if (type.equals(Type.FLOAT_TYPE)) {
-            return Opcodes.FMUL;
+            result = Opcodes.FMUL;
         } else if (type.equals(Type.DOUBLE_TYPE)) {
-            return Opcodes.DMUL;
+            result = Opcodes.DMUL;
+        } else {
+            throw new IllegalArgumentException(String.format("Unsupported type: %s", type));
         }
-        throw new IllegalArgumentException("Unsupported type: " + type);
+        return result;
     }
-
 
     /**
      * Extracts the first value.

--- a/src/main/java/org/eolang/opeo/ast/Multiplication.java
+++ b/src/main/java/org/eolang/opeo/ast/Multiplication.java
@@ -36,10 +36,6 @@ import org.xembly.Directives;
 /**
  * Multiplication.
  * @since 0.1
- * @todo #284:90min Add types for Multiplication.
- *  Currently we support only integer multiplication.
- *  We need to add support for other types, such as floating point numbers, longs, etc.
- *  Don't forget to add tests for the new types.
  */
 public final class Multiplication implements AstNode, Typed {
 
@@ -86,7 +82,7 @@ public final class Multiplication implements AstNode, Typed {
         final List<AstNode> res = new ArrayList<>(0);
         res.addAll(this.left.opcodes());
         res.addAll(this.right.opcodes());
-        res.add(new Opcode(Opcodes.IMUL));
+        res.add(new Opcode(this.opcode()));
         return res;
     }
 
@@ -94,6 +90,25 @@ public final class Multiplication implements AstNode, Typed {
     public Type type() {
         return new ExpressionType(this.left, this.right).type();
     }
+
+    /**
+     * Determines the opcode based on the argument types.
+     * @return Opcode.
+     */
+    private int opcode() {
+        final Type type = this.type();
+        if (type.equals(Type.INT_TYPE)) {
+            return Opcodes.IMUL;
+        } else if (type.equals(Type.LONG_TYPE)) {
+            return Opcodes.LMUL;
+        } else if (type.equals(Type.FLOAT_TYPE)) {
+            return Opcodes.FMUL;
+        } else if (type.equals(Type.DOUBLE_TYPE)) {
+            return Opcodes.DMUL;
+        }
+        throw new IllegalArgumentException("Unsupported type: " + type);
+    }
+
 
     /**
      * Extracts the first value.

--- a/src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java
@@ -160,6 +160,11 @@ public final class AllAgents implements DecompilationAgent {
     /**
      * Get supported opcodes.
      * @return Supported opcodes.
+     * @todo #288:30min Refactor supportedOpcodes method.
+     *  Currently we keep the map of agents to be able to get supported opcodes.
+     *  This is not a good practice. We should refactor it to a more elegant solution.
+     *  For example, recently we added {@link Supported} class which might be used in each agent.
+     *  Then, each agent will be able to provide supported opcodes.
      */
     public String[] supportedOpcodes() {
         return this.agents.keySet()

--- a/src/main/java/org/eolang/opeo/decompilation/agents/Supported.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/Supported.java
@@ -23,36 +23,45 @@
  */
 package org.eolang.opeo.decompilation.agents;
 
-import org.eolang.opeo.ast.AstNode;
-import org.eolang.opeo.ast.Multiplication;
-import org.eolang.opeo.decompilation.DecompilationAgent;
-import org.eolang.opeo.decompilation.DecompilerState;
-import org.objectweb.asm.Opcodes;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.eolang.opeo.ast.Opcode;
 
 /**
- * Mul instruction handler.
- * @since 0.1
+ * Supported opcodes.
+ * Used to check if the instruction is supported.
+ * @since 0.4
  */
-public final class MulAgent implements DecompilationAgent {
+public final class Supported {
 
     /**
      * Supported opcodes.
      */
-    private static final Supported SUPPORTED = new Supported(
-        Opcodes.IMUL,
-        Opcodes.LMUL,
-        Opcodes.FMUL,
-        Opcodes.DMUL
-    );
+    private final Set<Integer> supported;
 
-    @Override
-    public void handle(final DecompilerState state) {
-        if (MulAgent.SUPPORTED.isSupported(state.instruction())) {
-            final AstNode right = state.stack().pop();
-            final AstNode left = state.stack().pop();
-            state.stack().push(new Multiplication(left, right));
-            state.popInstruction();
-        }
+    /**
+     * Constructor.
+     * @param supported Supported opcodes.
+     */
+    public Supported(final int... supported) {
+        this(Arrays.stream(supported).boxed().collect(Collectors.toSet()));
     }
 
+    /**
+     * Constructor.
+     * @param supported Supported opcodes.
+     */
+    public Supported(final Set<Integer> supported) {
+        this.supported = supported;
+    }
+
+    /**
+     * Check if the instruction is supported.
+     * @param opcode Instruction to check.
+     * @return True if the instruction is supported, false otherwise.
+     */
+    public boolean isSupported(final Opcode opcode) {
+        return this.supported.contains(opcode.opcode());
+    }
 }

--- a/src/main/java/org/eolang/opeo/decompilation/agents/Supported.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/Supported.java
@@ -33,18 +33,18 @@ import org.eolang.opeo.ast.Opcode;
  * Used to check if the instruction is supported.
  * @since 0.4
  */
-public final class Supported {
+final class Supported {
 
     /**
      * Supported opcodes.
      */
-    private final Set<Integer> supported;
+    private final Set<Integer> all;
 
     /**
      * Constructor.
      * @param supported Supported opcodes.
      */
-    public Supported(final int... supported) {
+    Supported(final int... supported) {
         this(Arrays.stream(supported).boxed().collect(Collectors.toSet()));
     }
 
@@ -52,8 +52,8 @@ public final class Supported {
      * Constructor.
      * @param supported Supported opcodes.
      */
-    public Supported(final Set<Integer> supported) {
-        this.supported = supported;
+    Supported(final Set<Integer> supported) {
+        this.all = supported;
     }
 
     /**
@@ -61,7 +61,7 @@ public final class Supported {
      * @param opcode Instruction to check.
      * @return True if the instruction is supported, false otherwise.
      */
-    public boolean isSupported(final Opcode opcode) {
-        return this.supported.contains(opcode.opcode());
+    boolean isSupported(final Opcode opcode) {
+        return this.all.contains(opcode.opcode());
     }
 }

--- a/src/test/java/org/eolang/opeo/ast/MultiplicationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/MultiplicationTest.java
@@ -89,6 +89,7 @@ final class MultiplicationTest {
      * For test case {@link #convertsToOpcodesWithDifferentTypes(AstNode, AstNode, int)}
      * @return Test cases.
      */
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static Stream<org.junit.jupiter.params.provider.Arguments> multiplications() {
         return Stream.of(
             org.junit.jupiter.params.provider.Arguments.of(

--- a/src/test/java/org/eolang/opeo/ast/MultiplicationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/MultiplicationTest.java
@@ -24,8 +24,14 @@
 package org.eolang.opeo.ast;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import java.util.List;
+import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.objectweb.asm.Opcodes;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
@@ -53,6 +59,57 @@ final class MultiplicationTest {
                 "./o[@base='times']",
                 "./o[@base='times']/o[@base='int' and contains(text(),'3')]",
                 "./o[@base='times']/o[@base='int' and contains(text(),'4')]"
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("multiplications")
+    void convertsToOpcodesWithDifferentTypes(
+        final AstNode left,
+        final AstNode right,
+        final int expected
+    ) {
+        final List<AstNode> opcodes = new Multiplication(left, right).opcodes();
+        final AstNode last = opcodes.get(opcodes.size() - 1);
+        MatcherAssert.assertThat(
+            String.format(
+                "We expect that multiplication with two arguments ('%s' and '%s') will be converted to a opcode '%s'",
+                left,
+                right,
+                new OpcodeName(expected).simplified()
+            ),
+            last,
+            Matchers.equalTo(new Opcode(expected))
+        );
+    }
+
+    /**
+     * Provide multiplication test cases.
+     * For test case {@link #convertsToOpcodesWithDifferentTypes(AstNode, AstNode, int)}
+     * @return Test cases.
+     */
+    private static Stream<org.junit.jupiter.params.provider.Arguments> multiplications() {
+        return Stream.of(
+            org.junit.jupiter.params.provider.Arguments.of(
+                new Literal(1),
+                new Literal(2),
+                Opcodes.IMUL
+            ),
+            org.junit.jupiter.params.provider.Arguments.of(
+                new Literal(3L),
+                new Literal(4L),
+                Opcodes.LMUL
+            ),
+            org.junit.jupiter.params.provider.Arguments.of(
+                new Literal(5.0f),
+                new Literal(6.0f),
+                Opcodes.FMUL
+            ),
+            org.junit.jupiter.params.provider.Arguments.of(
+                new Literal(7.0),
+                new Literal(8.0),
+                Opcodes.DMUL
             )
         );
     }


### PR DESCRIPTION
Recently `Multiplication` node supported only `IMUL` instruction. In this PR I addded support of `DMUL`, `FMUL` and `LMUL` instructions as well.

Closes: #288.
History:
- **feat(#288): add more multiplication opcodes**
- **feat(#288): fix all qulice suggestions**
- **feat(#288): add Supported class that might be used to check all the supported instructions**
- **feat(#288): hide 'Supported' class**
- **feat(#288): add one more puzzle**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the handling of supported opcodes in the codebase by introducing a `Supported` class and improving the `MulAgent` and `Multiplication` classes.

### Detailed summary
- Introduces `Supported` class to manage supported opcodes
- Refactors `MulAgent` to use `Supported` class
- Updates `Multiplication` to determine opcode based on types
- Adds tests for different types of multiplication

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->