### PR TITLE
feat(#391): Refactor Supported Opcodes in Agents

### DIFF
--- a/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
+++ b/src/main/java/org/eolang/opeo/SelectiveDecompiler.java
@@ -69,7 +69,7 @@ public final class SelectiveDecompiler implements Decompiler {
      * @param modified Folder where to save the modified XMIRs.
      */
     public SelectiveDecompiler(final Path input, final Path output, final Path modified) {
-        this(input, output, modified, new AllAgents(false).supportedOpcodes());
+        this(input, output, modified, new AllAgents().supportedOpcodes());
     }
 
     /**
@@ -97,7 +97,7 @@ public final class SelectiveDecompiler implements Decompiler {
     public SelectiveDecompiler(
         final Storage storage, final Storage modified
     ) {
-        this(storage, modified, new AllAgents(false).supportedOpcodes());
+        this(storage, modified, new AllAgents().supportedOpcodes());
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/compilation/SelectiveCompiler.java
+++ b/src/main/java/org/eolang/opeo/compilation/SelectiveCompiler.java
@@ -65,7 +65,7 @@ public final class SelectiveCompiler implements Compiler {
      */
     public SelectiveCompiler(final Storage storage) {
         this.storage = storage;
-        this.supported = new AllAgents(false).supportedOpcodes();
+        this.supported = new AllAgents().supportedOpcodes();
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerState.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerState.java
@@ -96,7 +96,7 @@ public final class DecompilerState {
      * Retrieve current bytecode instruction.
      * @return Current bytecode instruction.
      */
-    public Opcode instruction() {
+    public Opcode current() {
         return Optional.ofNullable(this.opcodes.peek()).orElse(new Opcode(-1));
     }
 
@@ -124,7 +124,7 @@ public final class DecompilerState {
      * @return Instruction operand.
      */
     public Object operand(final int index) {
-        return this.instruction().operand(index);
+        return this.current().operand(index);
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerState.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerState.java
@@ -97,7 +97,10 @@ public final class DecompilerState {
      * @return Current bytecode instruction.
      */
     public Opcode current() {
-        return Optional.ofNullable(this.opcodes.peek()).orElse(new Opcode(-1));
+        if (this.opcodes.isEmpty()) {
+            throw new IllegalStateException("No instructions left");
+        }
+        return this.opcodes.peek();
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerState.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerState.java
@@ -25,7 +25,6 @@ package org.eolang.opeo.decompilation;
 
 import java.util.Deque;
 import java.util.LinkedList;
-import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.opeo.ast.AstNode;

--- a/src/main/java/org/eolang/opeo/decompilation/agents/AddAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/AddAgent.java
@@ -23,12 +23,8 @@
  */
 package org.eolang.opeo.decompilation.agents;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import org.eolang.opeo.ast.Addition;
 import org.eolang.opeo.ast.AstNode;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 
@@ -38,27 +34,19 @@ import org.objectweb.asm.Opcodes;
  */
 public final class AddAgent implements DecompilationAgent {
 
-    /**
-     * Supported opcodes.
-     */
-    private static final Set<Integer> SUPPORTED = new HashSet<>(
-        Arrays.asList(
-            Opcodes.IADD,
-            Opcodes.LADD,
-            Opcodes.FADD,
-            Opcodes.DADD
-        )
-    );
-
     @Override
     public void handle(final DecompilerState state) {
-        final int opcode = state.instruction().opcode();
-        if (AddAgent.SUPPORTED.contains(opcode)) {
+        if (this.supported().isSupported(state.current())) {
             final AstNode right = state.stack().pop();
             final AstNode left = state.stack().pop();
             state.stack().push(new Addition(left, right));
             state.popInstruction();
         }
+    }
+
+    @Override
+    public Supported supported() {
+        return new Supported(Opcodes.IADD, Opcodes.LADD, Opcodes.FADD, Opcodes.DADD);
     }
 
 }

--- a/src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java
@@ -192,7 +192,7 @@ public final class AllAgents implements DecompilationAgent {
 
         @Override
         public void handle(final DecompilerState state) {
-            if (!new AllAgents(false).agents.keySet().contains(state.current().opcode())) {
+            if (!new AllAgents(false).supported().isSupported(state.current())) {
                 state.stack().push(
                     new Opcode(
                         state.current().opcode(),

--- a/src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java
@@ -64,32 +64,32 @@ public final class AllAgents implements DecompilationAgent {
         this(
             new HashSet<>(
                 Arrays.asList(
-                    new ConstAgent(),
-                    new AddAgent(),
-                    new SubAgent(),
-                    new MulAgent(),
-                    new IfAgent(),
-                    new CastAgent(),
-                    new LoadAgent(),
-                    new StoreAgent(),
-                    new StoreToArrayAgent(),
-                    new NewArrayAgent(),
-                    new CheckCastAgent(),
-                    new NewAgent(),
-                    new DupAgent(),
-                    new BipushAgent(),
-                    new InvokespecialAgent(),
-                    new InvokevirtualAgent(),
-                    new InvokestaticAgent(),
-                    new InvokeinterfaceAgent(),
-                    new InvokedynamicAgent(),
-                    new GetFieldAgent(),
-                    new PutFieldAgent(),
-                    new GetStaticAgent(),
-                    new LdcAgent(),
-                    new PopAgent(),
-                    new ReturnAgent(),
-                    new LabelAgent(),
+                    new OpcodeAgent(new ConstAgent()),
+                    new OpcodeAgent(new AddAgent()),
+                    new OpcodeAgent(new SubAgent()),
+                    new OpcodeAgent(new MulAgent()),
+                    new OpcodeAgent(new IfAgent()),
+                    new OpcodeAgent(new CastAgent()),
+                    new OpcodeAgent(new LoadAgent()),
+                    new OpcodeAgent(new StoreAgent()),
+                    new OpcodeAgent(new StoreToArrayAgent()),
+                    new OpcodeAgent(new NewArrayAgent()),
+                    new OpcodeAgent(new CheckCastAgent()),
+                    new OpcodeAgent(new NewAgent()),
+                    new OpcodeAgent(new DupAgent()),
+                    new OpcodeAgent(new BipushAgent()),
+                    new OpcodeAgent(new InvokespecialAgent()),
+                    new OpcodeAgent(new InvokevirtualAgent()),
+                    new OpcodeAgent(new InvokestaticAgent()),
+                    new OpcodeAgent(new InvokeinterfaceAgent()),
+                    new OpcodeAgent(new InvokedynamicAgent()),
+                    new OpcodeAgent(new GetFieldAgent()),
+                    new OpcodeAgent(new PutFieldAgent()),
+                    new OpcodeAgent(new GetStaticAgent()),
+                    new OpcodeAgent(new LdcAgent()),
+                    new OpcodeAgent(new PopAgent()),
+                    new OpcodeAgent(new ReturnAgent()),
+                    new OpcodeAgent(new LabelAgent()),
                     new UnimplementedAgent(counting)
                 )
             )
@@ -106,9 +106,11 @@ public final class AllAgents implements DecompilationAgent {
 
     @Override
     public void handle(final DecompilerState state) {
-        while (state.hasInstructions()) {
+        int hash;
+        do {
+            hash = state.hashCode();
             this.agents.forEach(agent -> agent.handle(state));
-        }
+        } while (hash != state.hashCode());
     }
 
     @Override
@@ -147,7 +149,8 @@ public final class AllAgents implements DecompilationAgent {
 
         @Override
         public void handle(final DecompilerState state) {
-            if (!new AllAgents().supported().isSupported(state.current())) {
+            final Supported supported = new AllAgents().supported();
+            if (state.hasInstructions() && !supported.isSupported(state.current())) {
                 state.stack().push(
                     new Opcode(
                         state.current().opcode(),

--- a/src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java
@@ -29,7 +29,6 @@ import org.cactoos.map.MapOf;
 import org.eolang.opeo.LabelInstruction;
 import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.ast.OpcodeName;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 
@@ -86,10 +85,10 @@ public final class AllAgents implements DecompilationAgent {
                 new MapEntry<>(Opcodes.LADD, new AddAgent()),
                 new MapEntry<>(Opcodes.FADD, new AddAgent()),
                 new MapEntry<>(Opcodes.DADD, new AddAgent()),
-                new MapEntry<>(Opcodes.ISUB, new SubstractionAgent()),
-                new MapEntry<>(Opcodes.LSUB, new SubstractionAgent()),
-                new MapEntry<>(Opcodes.FSUB, new SubstractionAgent()),
-                new MapEntry<>(Opcodes.DSUB, new SubstractionAgent()),
+                new MapEntry<>(Opcodes.ISUB, new SubAgent()),
+                new MapEntry<>(Opcodes.LSUB, new SubAgent()),
+                new MapEntry<>(Opcodes.FSUB, new SubAgent()),
+                new MapEntry<>(Opcodes.DSUB, new SubAgent()),
                 new MapEntry<>(Opcodes.IMUL, new MulAgent()),
                 new MapEntry<>(Opcodes.IF_ICMPGT, new IfAgent()),
                 new MapEntry<>(Opcodes.I2B, new CastAgent()),
@@ -157,6 +156,13 @@ public final class AllAgents implements DecompilationAgent {
         }
     }
 
+    @Override
+    public Supported supported() {
+        return this.agents.values().stream()
+            .map(DecompilationAgent::supported).
+            reduce(new Supported(), Supported::merge);
+    }
+
     /**
      * Get supported opcodes.
      * @return Supported opcodes.
@@ -195,16 +201,21 @@ public final class AllAgents implements DecompilationAgent {
 
         @Override
         public void handle(final DecompilerState state) {
-            if (!new AllAgents(false).agents.keySet().contains(state.instruction().opcode())) {
+            if (!new AllAgents(false).agents.keySet().contains(state.current().opcode())) {
                 state.stack().push(
                     new Opcode(
-                        state.instruction().opcode(),
-                        state.instruction().params(),
+                        state.current().opcode(),
+                        state.current().params(),
                         this.counting
                     )
                 );
                 state.popInstruction();
             }
+        }
+
+        @Override
+        public Supported supported() {
+            return new Supported();
         }
     }
 }

--- a/src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java
@@ -166,18 +166,9 @@ public final class AllAgents implements DecompilationAgent {
     /**
      * Get supported opcodes.
      * @return Supported opcodes.
-     * @todo #288:30min Refactor supportedOpcodes method.
-     *  Currently we keep the map of agents to be able to get supported opcodes.
-     *  This is not a good practice. We should refactor it to a more elegant solution.
-     *  For example, recently we added {@link Supported} class which might be used in each agent.
-     *  Then, each agent will be able to provide supported opcodes.
      */
     public String[] supportedOpcodes() {
-        return this.agents.keySet()
-            .stream()
-            .map(OpcodeName::new)
-            .map(OpcodeName::simplified)
-            .toArray(String[]::new);
+        return this.supported().names();
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java
@@ -26,11 +26,7 @@ package org.eolang.opeo.decompilation.agents;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import org.cactoos.map.MapEntry;
-import org.eolang.opeo.LabelInstruction;
-import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.decompilation.DecompilerState;
-import org.objectweb.asm.Opcodes;
 
 /**
  * All agents that try to decompile incoming instructions.
@@ -41,6 +37,7 @@ import org.objectweb.asm.Opcodes;
  *  We should check decompilation stack instead.
  *  If it changes, we should continue. Otherwise, we should stop.
  *  The current implementation you can find here {@link #handle(DecompilerState)}.
+ * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
 public final class AllAgents implements DecompilationAgent {
 
@@ -116,8 +113,8 @@ public final class AllAgents implements DecompilationAgent {
     @Override
     public Supported supported() {
         return this.agents.stream()
-            .map(DecompilationAgent::supported).
-            reduce(new Supported(), Supported::merge);
+            .map(DecompilationAgent::supported)
+            .reduce(new Supported(), Supported::merge);
     }
 
     /**
@@ -128,43 +125,4 @@ public final class AllAgents implements DecompilationAgent {
         return this.supported().names();
     }
 
-    /**
-     * Unimplemented instruction handler.
-     * @since 0.1
-     */
-    private static final class UnimplementedAgent implements DecompilationAgent {
-
-        /**
-         * Do we put numbers to opcodes?
-         */
-        private final boolean counting;
-
-        /**
-         * Constructor.
-         * @param counting Flag which decides if we need to count opcodes.
-         */
-        private UnimplementedAgent(final boolean counting) {
-            this.counting = counting;
-        }
-
-        @Override
-        public void handle(final DecompilerState state) {
-            final Supported supported = new AllAgents().supported();
-            if (state.hasInstructions() && !supported.isSupported(state.current())) {
-                state.stack().push(
-                    new Opcode(
-                        state.current().opcode(),
-                        state.current().params(),
-                        this.counting
-                    )
-                );
-                state.popInstruction();
-            }
-        }
-
-        @Override
-        public Supported supported() {
-            return new Supported();
-        }
-    }
 }

--- a/src/main/java/org/eolang/opeo/decompilation/agents/BipushAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/BipushAgent.java
@@ -23,11 +23,7 @@
  */
 package org.eolang.opeo.decompilation.agents;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import org.eolang.opeo.ast.Literal;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 
@@ -37,21 +33,17 @@ import org.objectweb.asm.Opcodes;
  */
 public final class BipushAgent implements DecompilationAgent {
 
-    /**
-     * Supported opcodes.
-     */
-    private static final Set<Integer> SUPPORTED = new HashSet<>(
-        Arrays.asList(
-            Opcodes.BIPUSH
-        )
-    );
-
     @Override
     public void handle(final DecompilerState state) {
-        if (BipushAgent.SUPPORTED.contains(state.instruction().opcode())) {
+        if (this.supported().isSupported(state.current())) {
             state.stack().push(new Literal(state.operand(0)));
             state.popInstruction();
         }
+    }
+
+    @Override
+    public Supported supported() {
+        return new Supported(Opcodes.BIPUSH);
     }
 
 }

--- a/src/main/java/org/eolang/opeo/decompilation/agents/CastAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/CastAgent.java
@@ -23,11 +23,8 @@
  */
 package org.eolang.opeo.decompilation.agents;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import org.eolang.opeo.ast.Cast;
-import org.eolang.opeo.decompilation.DecompilationAgent;
+import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -41,38 +38,41 @@ public final class CastAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Set<Integer> SUPPROTED = new HashSet<>(
-        Arrays.asList(
-            Opcodes.I2B,
-            Opcodes.I2C,
-            Opcodes.I2S,
-            Opcodes.I2L,
-            Opcodes.I2F,
-            Opcodes.I2D,
-            Opcodes.L2I,
-            Opcodes.L2F,
-            Opcodes.L2D,
-            Opcodes.F2I,
-            Opcodes.F2L,
-            Opcodes.F2D,
-            Opcodes.D2I,
-            Opcodes.D2L,
-            Opcodes.D2F
-        )
+    private static final Supported SUPPORTED = new Supported(
+        Opcodes.I2B,
+        Opcodes.I2C,
+        Opcodes.I2S,
+        Opcodes.I2L,
+        Opcodes.I2F,
+        Opcodes.I2D,
+        Opcodes.L2I,
+        Opcodes.L2F,
+        Opcodes.L2D,
+        Opcodes.F2I,
+        Opcodes.F2L,
+        Opcodes.F2D,
+        Opcodes.D2I,
+        Opcodes.D2L,
+        Opcodes.D2F
     );
 
     @Override
     public void handle(final DecompilerState state) {
-        final int opcode = state.instruction().opcode();
-        if (CastAgent.SUPPROTED.contains(opcode)) {
+        final Opcode instruction = state.current();
+        if (this.supported().isSupported(instruction)) {
             state.stack().push(
                 new Cast(
-                    CastAgent.target(opcode),
+                    CastAgent.target(instruction.opcode()),
                     state.stack().pop()
                 )
             );
             state.popInstruction();
         }
+    }
+
+    @Override
+    public Supported supported() {
+        return CastAgent.SUPPORTED;
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/decompilation/agents/CastAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/CastAgent.java
@@ -38,7 +38,7 @@ public final class CastAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Supported SUPPORTED = new Supported(
+    private static final Supported OPCODES = new Supported(
         Opcodes.I2B,
         Opcodes.I2C,
         Opcodes.I2S,
@@ -72,7 +72,7 @@ public final class CastAgent implements DecompilationAgent {
 
     @Override
     public Supported supported() {
-        return CastAgent.SUPPORTED;
+        return CastAgent.OPCODES;
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/decompilation/agents/CheckCastAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/CheckCastAgent.java
@@ -39,7 +39,7 @@ public final class CheckCastAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Supported SUPPORTED = new Supported(Opcodes.CHECKCAST);
+    private static final Supported OPCODES = new Supported(Opcodes.CHECKCAST);
 
     @Override
     public void handle(final DecompilerState state) {
@@ -53,6 +53,6 @@ public final class CheckCastAgent implements DecompilationAgent {
 
     @Override
     public Supported supported() {
-        return CheckCastAgent.SUPPORTED;
+        return CheckCastAgent.OPCODES;
     }
 }

--- a/src/main/java/org/eolang/opeo/decompilation/agents/CheckCastAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/CheckCastAgent.java
@@ -23,12 +23,8 @@
  */
 package org.eolang.opeo.decompilation.agents;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.CheckCast;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -43,19 +39,20 @@ public final class CheckCastAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Set<Integer> SUPPORTED = new HashSet<>(
-        Arrays.asList(
-            Opcodes.CHECKCAST
-        )
-    );
+    private static final Supported SUPPORTED = new Supported(Opcodes.CHECKCAST);
 
     @Override
     public void handle(final DecompilerState state) {
-        if (CheckCastAgent.SUPPORTED.contains(state.instruction().opcode())) {
+        if (this.supported().isSupported(state.current())) {
             final AstNode value = state.stack().pop();
             final Object type = state.operand(0);
             state.stack().push(new CheckCast(Type.getObjectType((String) type), value));
             state.popInstruction();
         }
+    }
+
+    @Override
+    public Supported supported() {
+        return CheckCastAgent.SUPPORTED;
     }
 }

--- a/src/main/java/org/eolang/opeo/decompilation/agents/ConstAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/ConstAgent.java
@@ -23,12 +23,9 @@
  */
 package org.eolang.opeo.decompilation.agents;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.Literal;
-import org.eolang.opeo.decompilation.DecompilationAgent;
+import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 
@@ -42,29 +39,33 @@ public final class ConstAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Set<Integer> SUPPORTED = new HashSet<>(
-        Arrays.asList(
-            Opcodes.ICONST_M1,
-            Opcodes.ICONST_0,
-            Opcodes.ICONST_1,
-            Opcodes.ICONST_2,
-            Opcodes.ICONST_3,
-            Opcodes.ICONST_4,
-            Opcodes.ICONST_5,
-            Opcodes.LCONST_0,
-            Opcodes.LCONST_1,
-            Opcodes.FCONST_0,
-            Opcodes.FCONST_1,
-            Opcodes.FCONST_2,
-            Opcodes.DCONST_0,
-            Opcodes.DCONST_1
-        )
+    private static final Supported SUPPORTED = new Supported(
+        Opcodes.ICONST_M1,
+        Opcodes.ICONST_0,
+        Opcodes.ICONST_1,
+        Opcodes.ICONST_2,
+        Opcodes.ICONST_3,
+        Opcodes.ICONST_4,
+        Opcodes.ICONST_5,
+        Opcodes.LCONST_0,
+        Opcodes.LCONST_1,
+        Opcodes.FCONST_0,
+        Opcodes.FCONST_1,
+        Opcodes.FCONST_2,
+        Opcodes.DCONST_0,
+        Opcodes.DCONST_1
     );
 
     @Override
+    public Supported supported() {
+        return ConstAgent.SUPPORTED;
+    }
+
+    @Override
     public void handle(final DecompilerState state) {
-        final int opcode = state.instruction().opcode();
-        if (ConstAgent.SUPPORTED.contains(opcode)) {
+        final Opcode instr = state.current();
+        final int opcode = instr.opcode();
+        if (this.supported().isSupported(instr)) {
             final AstNode res;
             switch (opcode) {
                 case Opcodes.ICONST_M1:

--- a/src/main/java/org/eolang/opeo/decompilation/agents/ConstAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/ConstAgent.java
@@ -39,7 +39,7 @@ public final class ConstAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Supported SUPPORTED = new Supported(
+    private static final Supported OPCODES = new Supported(
         Opcodes.ICONST_M1,
         Opcodes.ICONST_0,
         Opcodes.ICONST_1,
@@ -58,7 +58,7 @@ public final class ConstAgent implements DecompilationAgent {
 
     @Override
     public Supported supported() {
-        return ConstAgent.SUPPORTED;
+        return ConstAgent.OPCODES;
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/decompilation/agents/DecompilationAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/DecompilationAgent.java
@@ -23,41 +23,23 @@
  */
 package org.eolang.opeo.decompilation.agents;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-import org.eolang.opeo.ast.AstNode;
-import org.eolang.opeo.ast.Substraction;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
-import org.objectweb.asm.Opcodes;
 
 /**
- * Substraction instruction handler.
- * @since 0.1
+ * An agent that tries to understand the current decompilation state and apply some changes to it.
+ * @since 0.4
  */
-public final class SubstractionAgent implements DecompilationAgent {
+public interface DecompilationAgent {
+
+    /**
+     * Handle the current state.
+     * @param state Current state to handle together with operand stack and variables.
+     */
+    void handle(DecompilerState state);
 
     /**
      * Supported opcodes.
+     * @return Supported opcodes.
      */
-    private static final Set<Integer> SUPPORTED = new HashSet<>(
-        Arrays.asList(
-            Opcodes.ISUB,
-            Opcodes.LSUB,
-            Opcodes.FSUB,
-            Opcodes.DSUB
-        )
-    );
-
-    @Override
-    public void handle(final DecompilerState state) {
-        final int opcode = state.instruction().opcode();
-        if (SubstractionAgent.SUPPORTED.contains(opcode)) {
-            final AstNode right = state.stack().pop();
-            final AstNode left = state.stack().pop();
-            state.stack().push(new Substraction(left, right));
-            state.popInstruction();
-        }
-    }
+    Supported supported();
 }

--- a/src/main/java/org/eolang/opeo/decompilation/agents/DupAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/DupAgent.java
@@ -37,11 +37,11 @@ public final class DupAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Supported SUPPORTED = new Supported(Opcodes.DUP);
+    private static final Supported OPCODES = new Supported(Opcodes.DUP);
 
     @Override
     public Supported supported() {
-        return DupAgent.SUPPORTED;
+        return DupAgent.OPCODES;
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/decompilation/agents/DupAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/DupAgent.java
@@ -23,11 +23,7 @@
  */
 package org.eolang.opeo.decompilation.agents;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import org.eolang.opeo.ast.Duplicate;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.eolang.opeo.decompilation.OperandStack;
 import org.objectweb.asm.Opcodes;
@@ -41,15 +37,16 @@ public final class DupAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Set<Integer> SUPPORTED = new HashSet<>(
-        Arrays.asList(
-            Opcodes.DUP
-        )
-    );
+    private static final Supported SUPPORTED = new Supported(Opcodes.DUP);
+
+    @Override
+    public Supported supported() {
+        return DupAgent.SUPPORTED;
+    }
 
     @Override
     public void handle(final DecompilerState state) {
-        if (DupAgent.SUPPORTED.contains(state.instruction().opcode())) {
+        if (this.supported().isSupported(state.current())) {
             final OperandStack stack = state.stack();
             final Duplicate ref = new Duplicate(stack.pop());
             stack.push(ref);

--- a/src/main/java/org/eolang/opeo/decompilation/agents/GetFieldAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/GetFieldAgent.java
@@ -25,7 +25,6 @@ package org.eolang.opeo.decompilation.agents;
 
 import org.eolang.opeo.ast.Attributes;
 import org.eolang.opeo.ast.FieldRetrieval;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 
@@ -36,8 +35,13 @@ import org.objectweb.asm.Opcodes;
 public final class GetFieldAgent implements DecompilationAgent {
 
     @Override
+    public Supported supported() {
+        return new Supported(Opcodes.GETFIELD);
+    }
+
+    @Override
     public void handle(final DecompilerState state) {
-        if (state.instruction().opcode() == Opcodes.GETFIELD) {
+        if (this.supported().isSupported(state.current())) {
             final String owner = (String) state.operand(0);
             final String name = (String) state.operand(1);
             final String descriptor = (String) state.operand(2);

--- a/src/main/java/org/eolang/opeo/decompilation/agents/GetStaticAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/GetStaticAgent.java
@@ -24,7 +24,6 @@
 package org.eolang.opeo.decompilation.agents;
 
 import org.eolang.opeo.ast.ClassField;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 
@@ -33,9 +32,15 @@ import org.objectweb.asm.Opcodes;
  * @since 0.1
  */
 public final class GetStaticAgent implements DecompilationAgent {
+
+    @Override
+    public Supported supported() {
+        return new Supported(Opcodes.GETSTATIC);
+    }
+
     @Override
     public void handle(final DecompilerState state) {
-        if (state.instruction().opcode() == Opcodes.GETSTATIC) {
+        if (this.supported().isSupported(state.current())) {
             final String klass = (String) state.operand(0);
             final String method = (String) state.operand(1);
             final String descriptor = (String) state.operand(2);

--- a/src/main/java/org/eolang/opeo/decompilation/agents/IfAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/IfAgent.java
@@ -42,11 +42,11 @@ public final class IfAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Supported SUPPORTED = new Supported(Opcodes.IF_ICMPGT);
+    private static final Supported OPCODES = new Supported(Opcodes.IF_ICMPGT);
 
     @Override
     public Supported supported() {
-        return IfAgent.SUPPORTED;
+        return IfAgent.OPCODES;
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/decompilation/agents/IfAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/IfAgent.java
@@ -23,12 +23,8 @@
  */
 package org.eolang.opeo.decompilation.agents;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.If;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.eolang.opeo.decompilation.OperandStack;
 import org.objectweb.asm.Label;
@@ -46,15 +42,16 @@ public final class IfAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Set<Integer> SUPPORTED = new HashSet<>(
-        Arrays.asList(
-            Opcodes.IF_ICMPGT
-        )
-    );
+    private static final Supported SUPPORTED = new Supported(Opcodes.IF_ICMPGT);
+
+    @Override
+    public Supported supported() {
+        return IfAgent.SUPPORTED;
+    }
 
     @Override
     public void handle(final DecompilerState state) {
-        if (IfAgent.SUPPORTED.contains(state.instruction().opcode())) {
+        if (this.supported().isSupported(state.current())) {
             final OperandStack stack = state.stack();
             final AstNode second = stack.pop();
             final AstNode first = stack.pop();

--- a/src/main/java/org/eolang/opeo/decompilation/agents/InvokedynamicAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/InvokedynamicAgent.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.List;
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.DynamicInvocation;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Opcodes;
@@ -40,9 +39,14 @@ import org.objectweb.asm.Type;
 public final class InvokedynamicAgent implements DecompilationAgent {
 
     @Override
+    public Supported supported() {
+        return new Supported(Opcodes.INVOKEDYNAMIC);
+    }
+
+    @Override
     public void handle(final DecompilerState state) {
-        if (state.instruction().opcode() == Opcodes.INVOKEDYNAMIC) {
-            final List<Object> operands = state.instruction().params();
+        if (this.supported().isSupported(state.current())) {
+            final List<Object> operands = state.current().params();
             final String descriptor = (String) operands.get(1);
             final List<AstNode> args = state.stack().pop(Type.getArgumentTypes(descriptor).length);
             Collections.reverse(args);

--- a/src/main/java/org/eolang/opeo/decompilation/agents/InvokeinterfaceAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/InvokeinterfaceAgent.java
@@ -28,7 +28,6 @@ import java.util.List;
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.Attributes;
 import org.eolang.opeo.ast.InterfaceInvocation;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -50,9 +49,15 @@ import org.objectweb.asm.Type;
  * @since 0.2
  */
 public final class InvokeinterfaceAgent implements DecompilationAgent {
+
+    @Override
+    public Supported supported() {
+        return new Supported(Opcodes.INVOKEINTERFACE);
+    }
+
     @Override
     public void handle(final DecompilerState state) {
-        if (state.instruction().opcode() == Opcodes.INVOKEINTERFACE) {
+        if (this.supported().isSupported(state.current())) {
             final String owner = (String) state.operand(0);
             final String method = (String) state.operand(1);
             final String descriptor = (String) state.operand(2);

--- a/src/main/java/org/eolang/opeo/decompilation/agents/InvokespecialAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/InvokespecialAgent.java
@@ -33,7 +33,6 @@ import org.eolang.opeo.ast.Labeled;
 import org.eolang.opeo.ast.NewAddress;
 import org.eolang.opeo.ast.Super;
 import org.eolang.opeo.ast.This;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -51,6 +50,11 @@ import org.objectweb.asm.Type;
  * @checkstyle MultilineJavadocTagsCheck (500 lines)
  */
 public final class InvokespecialAgent implements DecompilationAgent {
+
+    @Override
+    public Supported supported() {
+        return new Supported(Opcodes.INVOKESPECIAL);
+    }
 
     /**
      * Handle invokespecial instruction.
@@ -76,7 +80,7 @@ public final class InvokespecialAgent implements DecompilationAgent {
     @Override
     @SuppressWarnings("PMD.UnusedLocalVariable")
     public void handle(final DecompilerState state) {
-        if (state.instruction().opcode() == Opcodes.INVOKESPECIAL) {
+        if (this.supported().isSupported(state.current())) {
             final String type = (String) state.operand(0);
             final String name = (String) state.operand(1);
             final String descriptor = (String) state.operand(2);

--- a/src/main/java/org/eolang/opeo/decompilation/agents/InvokestaticAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/InvokestaticAgent.java
@@ -29,7 +29,6 @@ import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.Attributes;
 import org.eolang.opeo.ast.Owner;
 import org.eolang.opeo.ast.StaticInvocation;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -41,8 +40,13 @@ import org.objectweb.asm.Type;
 public final class InvokestaticAgent implements DecompilationAgent {
 
     @Override
+    public Supported supported() {
+        return new Supported(Opcodes.INVOKESTATIC);
+    }
+
+    @Override
     public void handle(final DecompilerState state) {
-        if (state.instruction().opcode() == Opcodes.INVOKESTATIC) {
+        if (this.supported().isSupported(state.current())) {
             final String owner = (String) state.operand(0);
             final String method = (String) state.operand(1);
             final String descriptor = (String) state.operand(2);

--- a/src/main/java/org/eolang/opeo/decompilation/agents/InvokevirtualAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/InvokevirtualAgent.java
@@ -28,7 +28,6 @@ import java.util.List;
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.Attributes;
 import org.eolang.opeo.ast.Invocation;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -51,8 +50,13 @@ import org.objectweb.asm.Type;
 public final class InvokevirtualAgent implements DecompilationAgent {
 
     @Override
+    public Supported supported() {
+        return new Supported(Opcodes.INVOKEVIRTUAL);
+    }
+
+    @Override
     public void handle(final DecompilerState state) {
-        if (state.instruction().opcode() == Opcodes.INVOKEVIRTUAL) {
+        if (this.supported().isSupported(state.current())) {
             final String owner = (String) state.operand(0);
             final String method = (String) state.operand(1);
             final String descriptor = (String) state.operand(2);

--- a/src/main/java/org/eolang/opeo/decompilation/agents/LabelAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/LabelAgent.java
@@ -27,7 +27,6 @@ import org.eolang.opeo.LabelInstruction;
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.Label;
 import org.eolang.opeo.ast.Labeled;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 
 /**
@@ -35,14 +34,21 @@ import org.eolang.opeo.decompilation.DecompilerState;
  * @since 0.1
  */
 public final class LabelAgent implements DecompilationAgent {
+
+    @Override
+    public Supported supported() {
+        return new Supported(LabelInstruction.LABEL_OPCODE);
+    }
+
     @Override
     public void handle(final DecompilerState state) {
-        if (state.instruction().opcode() == LabelInstruction.LABEL_OPCODE) {
-            final Labeled node = new Labeled(
-                state.stack().first().orElse(new AstNode.Empty()),
-                new Label(String.class.cast(state.operand(0)))
+        if (this.supported().isSupported(state.current())) {
+            state.stack().push(
+                new Labeled(
+                    state.stack().first().orElse(new AstNode.Empty()),
+                    new Label(String.class.cast(state.operand(0)))
+                )
             );
-            state.stack().push(node);
             state.popInstruction();
         }
     }

--- a/src/main/java/org/eolang/opeo/decompilation/agents/LdcAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/LdcAgent.java
@@ -24,7 +24,6 @@
 package org.eolang.opeo.decompilation.agents;
 
 import org.eolang.opeo.ast.Constant;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 
@@ -35,12 +34,16 @@ import org.objectweb.asm.Opcodes;
 public final class LdcAgent implements DecompilationAgent {
 
     @Override
+    public Supported supported() {
+        return new Supported(Opcodes.LDC);
+    }
+
+    @Override
     public void handle(final DecompilerState state) {
-        if (state.instruction().opcode() == Opcodes.LDC) {
+        if (this.supported().isSupported(state.current())) {
             final Object operand = state.operand(0);
             state.stack().push(new Constant(operand));
             state.popInstruction();
         }
     }
-
 }

--- a/src/main/java/org/eolang/opeo/decompilation/agents/LoadAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/LoadAgent.java
@@ -26,7 +26,7 @@ package org.eolang.opeo.decompilation.agents;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import org.eolang.opeo.decompilation.DecompilationAgent;
+import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -44,20 +44,24 @@ public final class LoadAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Set<Integer> SUPPORTED = new HashSet<>(
-        Arrays.asList(
-            Opcodes.ILOAD,
-            Opcodes.LLOAD,
-            Opcodes.FLOAD,
-            Opcodes.DLOAD,
-            Opcodes.ALOAD
-        )
+    private static final Supported SUPPORTED = new Supported(
+        Opcodes.ILOAD,
+        Opcodes.LLOAD,
+        Opcodes.FLOAD,
+        Opcodes.DLOAD,
+        Opcodes.ALOAD
     );
 
     @Override
+    public Supported supported() {
+        return LoadAgent.SUPPORTED;
+    }
+
+    @Override
     public void handle(final DecompilerState state) {
-        final int opcode = state.instruction().opcode();
-        if (LoadAgent.SUPPORTED.contains(opcode)) {
+        final Opcode instr = state.current();
+        final int opcode = instr.opcode();
+        if (this.supported().isSupported(instr)) {
             final Integer index = (Integer) state.operand(0);
             state.stack().push(
                 state.variable(index, LoadAgent.type(opcode))

--- a/src/main/java/org/eolang/opeo/decompilation/agents/LoadAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/LoadAgent.java
@@ -23,9 +23,6 @@
  */
 package org.eolang.opeo.decompilation.agents;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
@@ -44,7 +41,7 @@ public final class LoadAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Supported SUPPORTED = new Supported(
+    private static final Supported OPCODES = new Supported(
         Opcodes.ILOAD,
         Opcodes.LLOAD,
         Opcodes.FLOAD,
@@ -54,7 +51,7 @@ public final class LoadAgent implements DecompilationAgent {
 
     @Override
     public Supported supported() {
-        return LoadAgent.SUPPORTED;
+        return LoadAgent.OPCODES;
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/decompilation/agents/MulAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/MulAgent.java
@@ -37,7 +37,7 @@ public final class MulAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Supported SUPPORTED = new Supported(
+    private static final Supported OPCODES = new Supported(
         Opcodes.IMUL,
         Opcodes.LMUL,
         Opcodes.FMUL,
@@ -46,7 +46,7 @@ public final class MulAgent implements DecompilationAgent {
 
     @Override
     public Supported supported() {
-        return MulAgent.SUPPORTED;
+        return MulAgent.OPCODES;
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/decompilation/agents/MulAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/MulAgent.java
@@ -25,7 +25,6 @@ package org.eolang.opeo.decompilation.agents;
 
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.Multiplication;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 
@@ -46,8 +45,13 @@ public final class MulAgent implements DecompilationAgent {
     );
 
     @Override
+    public Supported supported() {
+        return MulAgent.SUPPORTED;
+    }
+
+    @Override
     public void handle(final DecompilerState state) {
-        if (MulAgent.SUPPORTED.isSupported(state.instruction())) {
+        if (this.supported().isSupported(state.current())) {
             final AstNode right = state.stack().pop();
             final AstNode left = state.stack().pop();
             state.stack().push(new Multiplication(left, right));

--- a/src/main/java/org/eolang/opeo/decompilation/agents/NewAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/NewAgent.java
@@ -36,11 +36,11 @@ public final class NewAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Supported SUPPORTED = new Supported(Opcodes.NEW);
+    private static final Supported OPCODES = new Supported(Opcodes.NEW);
 
     @Override
     public Supported supported() {
-        return NewAgent.SUPPORTED;
+        return NewAgent.OPCODES;
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/decompilation/agents/NewAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/NewAgent.java
@@ -23,11 +23,7 @@
  */
 package org.eolang.opeo.decompilation.agents;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import org.eolang.opeo.ast.NewAddress;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 
@@ -40,18 +36,18 @@ public final class NewAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Set<Integer> SUPPORTED = new HashSet<>(
-        Arrays.asList(
-            Opcodes.NEW
-        )
-    );
+    private static final Supported SUPPORTED = new Supported(Opcodes.NEW);
+
+    @Override
+    public Supported supported() {
+        return NewAgent.SUPPORTED;
+    }
 
     @Override
     public void handle(final DecompilerState state) {
-        if (NewAgent.SUPPORTED.contains(state.instruction().opcode())) {
+        if (this.supported().isSupported(state.current())) {
             state.stack().push(new NewAddress(state.operand(0).toString()));
             state.popInstruction();
         }
     }
-
 }

--- a/src/main/java/org/eolang/opeo/decompilation/agents/NewArrayAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/NewArrayAgent.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.Set;
 import org.eolang.opeo.ast.ArrayConstructor;
 import org.eolang.opeo.ast.AstNode;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.eolang.opeo.decompilation.OperandStack;
 import org.objectweb.asm.Opcodes;
@@ -42,15 +41,16 @@ public final class NewArrayAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Set<Integer> SUPPORTED = new HashSet<>(
-        Arrays.asList(
-            Opcodes.ANEWARRAY
-        )
-    );
+    private static final Supported SUPPORTED = new Supported(Opcodes.ANEWARRAY);
+
+    @Override
+    public Supported supported() {
+        return NewArrayAgent.SUPPORTED;
+    }
 
     @Override
     public void handle(final DecompilerState state) {
-        if (NewArrayAgent.SUPPORTED.contains(state.instruction().opcode())) {
+        if (this.supported().isSupported(state.current())) {
             final String type = (String) state.operand(0);
             final OperandStack stack = state.stack();
             final AstNode size = stack.pop();

--- a/src/main/java/org/eolang/opeo/decompilation/agents/NewArrayAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/NewArrayAgent.java
@@ -23,9 +23,6 @@
  */
 package org.eolang.opeo.decompilation.agents;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import org.eolang.opeo.ast.ArrayConstructor;
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.decompilation.DecompilerState;

--- a/src/main/java/org/eolang/opeo/decompilation/agents/NewArrayAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/NewArrayAgent.java
@@ -38,11 +38,11 @@ public final class NewArrayAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Supported SUPPORTED = new Supported(Opcodes.ANEWARRAY);
+    private static final Supported OPCODES = new Supported(Opcodes.ANEWARRAY);
 
     @Override
     public Supported supported() {
-        return NewArrayAgent.SUPPORTED;
+        return NewArrayAgent.OPCODES;
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/decompilation/agents/OpcodeAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/OpcodeAgent.java
@@ -1,0 +1,23 @@
+package org.eolang.opeo.decompilation.agents;
+
+import org.eolang.opeo.decompilation.DecompilerState;
+
+public final class OpcodeAgent implements DecompilationAgent {
+    private final DecompilationAgent original;
+
+    public OpcodeAgent(final DecompilationAgent original) {
+        this.original = original;
+    }
+
+    @Override
+    public void handle(final DecompilerState state) {
+        if (state.hasInstructions() && this.original.supported().isSupported(state.current())) {
+            this.original.handle(state);
+        }
+    }
+
+    @Override
+    public Supported supported() {
+        return this.original.supported();
+    }
+}

--- a/src/main/java/org/eolang/opeo/decompilation/agents/OpcodeAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/OpcodeAgent.java
@@ -1,10 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.opeo.decompilation.agents;
 
 import org.eolang.opeo.decompilation.DecompilerState;
 
+/**
+ * Agent that handles opcodes.
+ * @since 0.4
+ */
 public final class OpcodeAgent implements DecompilationAgent {
+
+    /**
+     * Original agent that supports some opcodes.
+     * If the agent does not support the current opcode, it will be skipped.
+     */
     private final DecompilationAgent original;
 
+    /**
+     * Constructor.
+     * @param original Original agent that supports some opcodes.
+     */
     public OpcodeAgent(final DecompilationAgent original) {
         this.original = original;
     }

--- a/src/main/java/org/eolang/opeo/decompilation/agents/PopAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/PopAgent.java
@@ -24,7 +24,6 @@
 package org.eolang.opeo.decompilation.agents;
 
 import org.eolang.opeo.ast.Popped;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.eolang.opeo.decompilation.OperandStack;
 import org.objectweb.asm.Opcodes;
@@ -36,8 +35,13 @@ import org.objectweb.asm.Opcodes;
 public final class PopAgent implements DecompilationAgent {
 
     @Override
+    public Supported supported() {
+        return new Supported(Opcodes.POP);
+    }
+
+    @Override
     public void handle(final DecompilerState state) {
-        if (state.instruction().opcode() == Opcodes.POP) {
+        if (this.supported().isSupported(state.current())) {
             final OperandStack stack = state.stack();
             stack.push(new Popped(stack.pop()));
             state.popInstruction();

--- a/src/main/java/org/eolang/opeo/decompilation/agents/PutFieldAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/PutFieldAgent.java
@@ -27,7 +27,6 @@ import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.Attributes;
 import org.eolang.opeo.ast.Field;
 import org.eolang.opeo.ast.FieldAssignment;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.objectweb.asm.Opcodes;
 
@@ -39,8 +38,13 @@ import org.objectweb.asm.Opcodes;
 public final class PutFieldAgent implements DecompilationAgent {
 
     @Override
+    public Supported supported() {
+        return new Supported(Opcodes.PUTFIELD);
+    }
+
+    @Override
     public void handle(final DecompilerState state) {
-        if (state.instruction().opcode() == Opcodes.PUTFIELD) {
+        if (this.supported().isSupported(state.current())) {
             final AstNode value = state.stack().pop();
             final String name = (String) state.operand(1);
             final String owner = (String) state.operand(0);

--- a/src/main/java/org/eolang/opeo/decompilation/agents/ReturnAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/ReturnAgent.java
@@ -39,7 +39,7 @@ public final class ReturnAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Supported SUPPORTED = new Supported(
+    private static final Supported OPCODES = new Supported(
         Opcodes.RETURN,
         Opcodes.IRETURN,
         Opcodes.LRETURN,
@@ -50,7 +50,7 @@ public final class ReturnAgent implements DecompilationAgent {
 
     @Override
     public Supported supported() {
-        return ReturnAgent.SUPPORTED;
+        return ReturnAgent.OPCODES;
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/decompilation/agents/ReturnAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/ReturnAgent.java
@@ -23,11 +23,8 @@
  */
 package org.eolang.opeo.decompilation.agents;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.ast.Return;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.eolang.opeo.decompilation.OperandStack;
 import org.objectweb.asm.Opcodes;
@@ -42,21 +39,25 @@ public final class ReturnAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Set<Integer> SUPPORTED = new HashSet<>(
-        Arrays.asList(
-            Opcodes.RETURN,
-            Opcodes.IRETURN,
-            Opcodes.LRETURN,
-            Opcodes.FRETURN,
-            Opcodes.DRETURN,
-            Opcodes.ARETURN
-        )
+    private static final Supported SUPPORTED = new Supported(
+        Opcodes.RETURN,
+        Opcodes.IRETURN,
+        Opcodes.LRETURN,
+        Opcodes.FRETURN,
+        Opcodes.DRETURN,
+        Opcodes.ARETURN
     );
 
     @Override
+    public Supported supported() {
+        return ReturnAgent.SUPPORTED;
+    }
+
+    @Override
     public void handle(final DecompilerState state) {
-        final int opcode = state.instruction().opcode();
-        if (ReturnAgent.SUPPORTED.contains(opcode)) {
+        final Opcode instr = state.current();
+        final int opcode = instr.opcode();
+        if (this.supported().isSupported(instr)) {
             final OperandStack stack = state.stack();
             if (opcode == Opcodes.RETURN) {
                 stack.push(new Return());

--- a/src/main/java/org/eolang/opeo/decompilation/agents/StoreAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/StoreAgent.java
@@ -42,7 +42,7 @@ public final class StoreAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Supported SUPPORTED = new Supported(
+    private static final Supported OPCODES = new Supported(
         Opcodes.ISTORE,
         Opcodes.LSTORE,
         Opcodes.FSTORE,
@@ -52,7 +52,7 @@ public final class StoreAgent implements DecompilationAgent {
 
     @Override
     public Supported supported() {
-        return StoreAgent.SUPPORTED;
+        return StoreAgent.OPCODES;
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/decompilation/agents/StoreAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/StoreAgent.java
@@ -23,14 +23,11 @@
  */
 package org.eolang.opeo.decompilation.agents;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.LocalVariable;
+import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.ast.Typed;
 import org.eolang.opeo.ast.VariableAssignment;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
 import org.eolang.opeo.decompilation.OperandStack;
 import org.objectweb.asm.Opcodes;
@@ -45,26 +42,29 @@ public final class StoreAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Set<Integer> SUPPORTED = new HashSet<>(
-        Arrays.asList(
-            Opcodes.ISTORE,
-            Opcodes.LSTORE,
-            Opcodes.FSTORE,
-            Opcodes.DSTORE,
-            Opcodes.ASTORE
-        )
+    private static final Supported SUPPORTED = new Supported(
+        Opcodes.ISTORE,
+        Opcodes.LSTORE,
+        Opcodes.FSTORE,
+        Opcodes.DSTORE,
+        Opcodes.ASTORE
     );
 
     @Override
+    public Supported supported() {
+        return StoreAgent.SUPPORTED;
+    }
+
+    @Override
     public void handle(final DecompilerState state) {
-        final int opcode = state.instruction().opcode();
-        if (StoreAgent.SUPPORTED.contains(opcode)) {
+        final Opcode instr = state.current();
+        if (this.supported().isSupported(instr)) {
             final OperandStack stack = state.stack();
             final AstNode value = stack.pop();
             stack.push(
                 new VariableAssignment(
                     (LocalVariable) state.variable(
-                        (Integer) state.operand(0), StoreAgent.infer(value, opcode)
+                        (Integer) state.operand(0), StoreAgent.infer(value, instr.opcode())
                     ),
                     value
                 )

--- a/src/main/java/org/eolang/opeo/decompilation/agents/StoreToArrayAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/StoreToArrayAgent.java
@@ -23,13 +23,10 @@
  */
 package org.eolang.opeo.decompilation.agents;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import org.eolang.opeo.ast.AstNode;
 import org.eolang.opeo.ast.StoreArray;
-import org.eolang.opeo.decompilation.DecompilationAgent;
 import org.eolang.opeo.decompilation.DecompilerState;
+import org.objectweb.asm.Opcodes;
 
 /**
  * Store to array instruction handler.
@@ -52,15 +49,16 @@ public final class StoreToArrayAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Set<Integer> SUPPORTED = new HashSet<>(
-        Arrays.asList(
-            org.objectweb.asm.Opcodes.AASTORE
-        )
-    );
+    private static final Supported SUPPORTED = new Supported(Opcodes.AASTORE);
+
+    @Override
+    public Supported supported() {
+        return StoreToArrayAgent.SUPPORTED;
+    }
 
     @Override
     public void handle(final DecompilerState state) {
-        if (StoreToArrayAgent.SUPPORTED.contains(state.instruction().opcode())) {
+        if (this.supported().isSupported(state.current())) {
             final AstNode value = state.stack().pop();
             final AstNode index = state.stack().pop();
             final AstNode array = state.stack().pop();

--- a/src/main/java/org/eolang/opeo/decompilation/agents/StoreToArrayAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/StoreToArrayAgent.java
@@ -49,11 +49,11 @@ public final class StoreToArrayAgent implements DecompilationAgent {
     /**
      * Supported opcodes.
      */
-    private static final Supported SUPPORTED = new Supported(Opcodes.AASTORE);
+    private static final Supported OPCODES = new Supported(Opcodes.AASTORE);
 
     @Override
     public Supported supported() {
-        return StoreToArrayAgent.SUPPORTED;
+        return StoreToArrayAgent.OPCODES;
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/decompilation/agents/SubAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/SubAgent.java
@@ -21,18 +21,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.opeo.decompilation;
+package org.eolang.opeo.decompilation.agents;
+
+import org.eolang.opeo.ast.AstNode;
+import org.eolang.opeo.ast.Substraction;
+import org.eolang.opeo.decompilation.DecompilerState;
+import org.objectweb.asm.Opcodes;
 
 /**
- * An agent that tries to understand the current decompilation state and apply some changes to it.
+ * Substraction instruction handler.
  * @since 0.1
  */
-@FunctionalInterface
-public interface DecompilationAgent {
+public final class SubAgent implements DecompilationAgent {
 
     /**
-     * Handle the current state.
-     * @param state Current state to handle together with operand stack and variables.
+     * Supported opcodes.
      */
-    void handle(DecompilerState state);
+    private static final Supported SUPPORTED = new Supported(
+        Opcodes.ISUB,
+        Opcodes.LSUB,
+        Opcodes.FSUB,
+        Opcodes.DSUB
+    );
+
+    @Override
+    public Supported supported() {
+        return SubAgent.SUPPORTED;
+    }
+
+    @Override
+    public void handle(final DecompilerState state) {
+        if (this.supported().isSupported(state.current())) {
+            final AstNode right = state.stack().pop();
+            final AstNode left = state.stack().pop();
+            state.stack().push(new Substraction(left, right));
+            state.popInstruction();
+        }
+    }
 }

--- a/src/main/java/org/eolang/opeo/decompilation/agents/Supported.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/Supported.java
@@ -24,6 +24,7 @@
 package org.eolang.opeo.decompilation.agents;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.eolang.opeo.ast.Opcode;
@@ -63,5 +64,16 @@ final class Supported {
      */
     boolean isSupported(final Opcode opcode) {
         return this.all.contains(opcode.opcode());
+    }
+
+    /**
+     * Merge two supported sets.
+     * @param supported Supported to merge.
+     * @return Merged supported set.
+     */
+    Supported merge(final Supported supported) {
+        final Set<Integer> merged = new HashSet<>(this.all);
+        merged.addAll(supported.all);
+        return new Supported(merged);
     }
 }

--- a/src/main/java/org/eolang/opeo/decompilation/agents/Supported.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/Supported.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.eolang.opeo.ast.Opcode;
+import org.eolang.opeo.ast.OpcodeName;
 
 /**
  * Supported opcodes.
@@ -76,4 +77,16 @@ final class Supported {
         merged.addAll(supported.all);
         return new Supported(merged);
     }
+
+    /**
+     * Simplified names of supported opcodes.
+     * @return Names of supported opcodes.
+     */
+    String[] names() {
+        return this.all.stream()
+            .map(OpcodeName::new)
+            .map(OpcodeName::simplified)
+            .toArray(String[]::new);
+    }
+
 }

--- a/src/main/java/org/eolang/opeo/decompilation/agents/UnimplementedAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/UnimplementedAgent.java
@@ -23,39 +23,45 @@
  */
 package org.eolang.opeo.decompilation.agents;
 
-import org.eolang.opeo.ast.AstNode;
-import org.eolang.opeo.ast.Substraction;
+import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.decompilation.DecompilerState;
-import org.objectweb.asm.Opcodes;
 
 /**
- * Substraction instruction handler.
+ * Unimplemented instruction handler.
  * @since 0.1
  */
-public final class SubAgent implements DecompilationAgent {
+final class UnimplementedAgent implements DecompilationAgent {
 
     /**
-     * Supported opcodes.
+     * Do we put numbers to opcodes?
      */
-    private static final Supported OPCODES = new Supported(
-        Opcodes.ISUB,
-        Opcodes.LSUB,
-        Opcodes.FSUB,
-        Opcodes.DSUB
-    );
+    private final boolean counting;
 
-    @Override
-    public Supported supported() {
-        return SubAgent.OPCODES;
+    /**
+     * Constructor.
+     * @param counting Flag which decides if we need to count opcodes.
+     */
+    UnimplementedAgent(final boolean counting) {
+        this.counting = counting;
     }
 
     @Override
     public void handle(final DecompilerState state) {
-        if (this.supported().isSupported(state.current())) {
-            final AstNode right = state.stack().pop();
-            final AstNode left = state.stack().pop();
-            state.stack().push(new Substraction(left, right));
+        final Supported supported = new AllAgents().supported();
+        if (state.hasInstructions() && !supported.isSupported(state.current())) {
+            state.stack().push(
+                new Opcode(
+                    state.current().opcode(),
+                    state.current().params(),
+                    this.counting
+                )
+            );
             state.popInstruction();
         }
+    }
+
+    @Override
+    public Supported supported() {
+        return new Supported();
     }
 }

--- a/src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/SelectiveDecompilerTest.java
@@ -161,7 +161,7 @@ final class SelectiveDecompilerTest {
     void identifiesUnsupportedOpcodes() {
         MatcherAssert.assertThat(
             "We expect that the supported opcodes won't contain the 'GOTO' opcode since we don't support it yet.",
-            new AllAgents(false).supportedOpcodes(),
+            new AllAgents().supportedOpcodes(),
             Matchers.not(Matchers.arrayContaining("GOTO"))
         );
     }


### PR DESCRIPTION
In this PR I removed outdated map of agents with corresponding opcodes. Now each agent provide information about supported opcodes and migh decide itself when to decompile some instruction if needed.

Closes: #391.
History:
- **feat(#391): replace ugly sets with the new 'Supported' object**
- **feat(#391): remove the puzzle for #391 issue**
- **feat(#391): simplify UnimplementedAgent class a bit**
- **feat(#391): remove the ugly map with agents**

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the codebase by introducing a `Supported` class to handle opcode support checks efficiently.

### Detailed summary
- Refactored multiple classes to use the `Supported` class for opcode support checks
- Introduced `Supported` class to handle opcode support efficiently
- Updated constructors in various classes to use `new AllAgents().supportedOpcodes()` instead of `new AllAgents(false).supportedOpcodes()` for consistency

> The following files were skipped due to too many changes: `src/main/java/org/eolang/opeo/decompilation/agents/MulAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/LabelAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/InvokedynamicAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/NewAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/DupAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/InvokespecialAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/IfAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/NewArrayAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/StoreToArrayAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/CheckCastAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/AddAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/LoadAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/ReturnAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/SubstractionAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/StoreAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/ConstAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/CastAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/OpcodeAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/UnimplementedAgent.java`, `src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->