### PR TITLE
feat(#381): Add Agents Integration Test Examples

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>0.39.0</version>
     </dependency>
     <dependency>
       <groupId>org.eolang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
-      <version>0.39.0</version>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.eolang</groupId>

--- a/src/main/java/org/eolang/opeo/ast/OpcodeName.java
+++ b/src/main/java/org/eolang/opeo/ast/OpcodeName.java
@@ -110,7 +110,7 @@ public final class OpcodeName {
      * @return Opcode.
      */
     public int code() {
-        return opcode;
+        return this.opcode;
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/ast/OpcodeName.java
+++ b/src/main/java/org/eolang/opeo/ast/OpcodeName.java
@@ -70,6 +70,25 @@ public final class OpcodeName {
 
     /**
      * Constructor.
+     * @param name Opcode name.
+     */
+    public OpcodeName(final String name) {
+        this(
+            OpcodeName.NAMES.entrySet()
+                .stream().filter(e -> e.getValue().equals(name))
+                .findFirst()
+                .orElseThrow(
+                    () -> new IllegalArgumentException(
+                        String.format("Opcode name '%s' not found", name)
+                    )
+                )
+                .getKey(),
+            OpcodeName.DEFAULT
+        );
+    }
+
+    /**
+     * Constructor.
      * @param opcode Bytecode operation code.
      * @param counter Opcode counter.
      */
@@ -84,6 +103,14 @@ public final class OpcodeName {
      */
     public String simplified() {
         return OpcodeName.NAMES.getOrDefault(this.opcode, "UNKNOWN");
+    }
+
+    /**
+     * Get opcode.
+     * @return Opcode.
+     */
+    public int code() {
+        return opcode;
     }
 
     /**

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
@@ -33,6 +33,7 @@ import org.eolang.opeo.Instruction;
 import org.eolang.opeo.ast.Opcode;
 import org.eolang.opeo.ast.Root;
 import org.eolang.opeo.decompilation.agents.AllAgents;
+import org.eolang.opeo.decompilation.agents.TracedAgent;
 import org.xembly.Directive;
 
 /**
@@ -64,7 +65,7 @@ public final class DecompilerMachine {
      *
      * @param args Arguments provided to decompiler.
      */
-    public DecompilerMachine(final Map<String, String> args) {
+    public DecompilerMachine(final Map<String, Object> args) {
         this(new LocalVariables(), args);
     }
 
@@ -74,10 +75,11 @@ public final class DecompilerMachine {
      * @param locals Local variables.
      * @param arguments Arguments provided to decompiler.
      */
-    public DecompilerMachine(final LocalVariables locals, final Map<String, String> arguments) {
+    public DecompilerMachine(final LocalVariables locals, final Map<String, Object> arguments) {
         this.locals = locals;
         this.agents = new AllAgents(
-            "true".equals(arguments.getOrDefault("counting", "true"))
+            "true".equals(arguments.getOrDefault("counting", "true")),
+            TracedAgent.Output.class.cast(arguments.getOrDefault("output", new TracedAgent.Log()))
         );
     }
 

--- a/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
+++ b/src/main/java/org/eolang/opeo/decompilation/DecompilerMachine.java
@@ -55,7 +55,7 @@ public final class DecompilerMachine {
     /**
      * Constructor.
      */
-    DecompilerMachine() {
+    public DecompilerMachine() {
         this(new HashMap<>(0));
     }
 
@@ -64,7 +64,7 @@ public final class DecompilerMachine {
      *
      * @param args Arguments provided to decompiler.
      */
-    DecompilerMachine(final Map<String, String> args) {
+    public DecompilerMachine(final Map<String, String> args) {
         this(new LocalVariables(), args);
     }
 

--- a/src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java
@@ -56,6 +56,7 @@ public final class AllAgents implements DecompilationAgent {
     /**
      * Constructor.
      * @param counting Do we put numbers to opcodes?
+     * @param output Where do we save output logs?
      */
     public AllAgents(final boolean counting, final TracedAgent.Output output) {
         this(

--- a/src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/AllAgents.java
@@ -50,44 +50,44 @@ public final class AllAgents implements DecompilationAgent {
      * Constructor.
      */
     public AllAgents() {
-        this(false);
+        this(false, new TracedAgent.Log());
     }
 
     /**
      * Constructor.
      * @param counting Do we put numbers to opcodes?
      */
-    public AllAgents(final boolean counting) {
+    public AllAgents(final boolean counting, final TracedAgent.Output output) {
         this(
             new HashSet<>(
                 Arrays.asList(
-                    new TracedAgent(new ConstAgent()),
-                    new TracedAgent(new AddAgent()),
-                    new TracedAgent(new SubAgent()),
-                    new TracedAgent(new MulAgent()),
-                    new TracedAgent(new IfAgent()),
-                    new TracedAgent(new CastAgent()),
-                    new TracedAgent(new LoadAgent()),
-                    new TracedAgent(new StoreAgent()),
-                    new TracedAgent(new StoreToArrayAgent()),
-                    new TracedAgent(new NewArrayAgent()),
-                    new TracedAgent(new CheckCastAgent()),
-                    new TracedAgent(new NewAgent()),
-                    new TracedAgent(new DupAgent()),
-                    new TracedAgent(new BipushAgent()),
-                    new TracedAgent(new InvokespecialAgent()),
-                    new TracedAgent(new InvokevirtualAgent()),
-                    new TracedAgent(new InvokestaticAgent()),
-                    new TracedAgent(new InvokeinterfaceAgent()),
-                    new TracedAgent(new InvokedynamicAgent()),
-                    new TracedAgent(new GetFieldAgent()),
-                    new TracedAgent(new PutFieldAgent()),
-                    new TracedAgent(new GetStaticAgent()),
-                    new TracedAgent(new LdcAgent()),
-                    new TracedAgent(new PopAgent()),
-                    new TracedAgent(new ReturnAgent()),
-                    new TracedAgent(new LabelAgent()),
-                    new TracedAgent(new UnimplementedAgent(counting))
+                    new TracedAgent(new ConstAgent(), output),
+                    new TracedAgent(new AddAgent(), output),
+                    new TracedAgent(new SubAgent(), output),
+                    new TracedAgent(new MulAgent(), output),
+                    new TracedAgent(new IfAgent(), output),
+                    new TracedAgent(new CastAgent(), output),
+                    new TracedAgent(new LoadAgent(), output),
+                    new TracedAgent(new StoreAgent(), output),
+                    new TracedAgent(new StoreToArrayAgent(), output),
+                    new TracedAgent(new NewArrayAgent(), output),
+                    new TracedAgent(new CheckCastAgent(), output),
+                    new TracedAgent(new NewAgent(), output),
+                    new TracedAgent(new DupAgent(), output),
+                    new TracedAgent(new BipushAgent(), output),
+                    new TracedAgent(new InvokespecialAgent(), output),
+                    new TracedAgent(new InvokevirtualAgent(), output),
+                    new TracedAgent(new InvokestaticAgent(), output),
+                    new TracedAgent(new InvokeinterfaceAgent(), output),
+                    new TracedAgent(new InvokedynamicAgent(), output),
+                    new TracedAgent(new GetFieldAgent(), output),
+                    new TracedAgent(new PutFieldAgent(), output),
+                    new TracedAgent(new GetStaticAgent(), output),
+                    new TracedAgent(new LdcAgent(), output),
+                    new TracedAgent(new PopAgent(), output),
+                    new TracedAgent(new ReturnAgent(), output),
+                    new TracedAgent(new LabelAgent(), output),
+                    new TracedAgent(new UnimplementedAgent(counting), output)
                 )
             )
         );

--- a/src/main/java/org/eolang/opeo/decompilation/agents/TracedAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/TracedAgent.java
@@ -116,7 +116,7 @@ public final class TracedAgent implements DecompilationAgent {
      * Target for the output of the traced agent.
      * @since 0.4
      */
-    private interface Output {
+    public interface Output {
 
         /**
          * Write a message.
@@ -154,7 +154,7 @@ public final class TracedAgent implements DecompilationAgent {
         /**
          * Default constructor.
          */
-        Container() {
+        public Container() {
             this(new LinkedList<>());
         }
 
@@ -175,7 +175,7 @@ public final class TracedAgent implements DecompilationAgent {
          * Get all messages.
          * @return All messages.
          */
-        Collection<String> messages() {
+        public Collection<String> messages() {
             return Collections.unmodifiableCollection(this.queue);
         }
     }

--- a/src/main/java/org/eolang/opeo/decompilation/agents/TracedAgent.java
+++ b/src/main/java/org/eolang/opeo/decompilation/agents/TracedAgent.java
@@ -209,7 +209,7 @@ public final class TracedAgent implements DecompilationAgent {
          * Get all agents used.
          * @return All agents used.
          */
-        public List<String> agents() {
+        public List<String> agentsUsed() {
             return this.agents.stream().map(Class::getSimpleName).collect(Collectors.toList());
         }
     }

--- a/src/test/java/it/AgentsIT.java
+++ b/src/test/java/it/AgentsIT.java
@@ -25,6 +25,7 @@ package it;
 
 import com.jcabi.xml.XMLDocument;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,6 +37,7 @@ import org.eolang.opeo.Instruction;
 import org.eolang.opeo.OpcodeInstruction;
 import org.eolang.opeo.ast.OpcodeName;
 import org.eolang.opeo.decompilation.DecompilerMachine;
+import org.eolang.opeo.decompilation.agents.TracedAgent;
 import org.eolang.parser.xmir.Xmir;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -63,18 +65,24 @@ final class AgentsIT {
     @ClasspathSource(value = "agents", glob = "**.yaml")
     void verifiesAgents(final String yaml) {
         final InstructionPack pack = new InstructionPack(yaml);
+        final TracedAgent.Container output = new TracedAgent.Container();
         final Iterable<Directive> xmir =
             new Directives().add("program")
                 .add("objects")
-
                 .append(
-                    new DecompilerMachine().decompile(pack.instructions())
+                    new DecompilerMachine(Collections.singletonMap("output", output))
+                        .decompile(pack.instructions())
 
                 ).up().up();
         final String xml = new Xembler(xmir).xmlQuietly();
         final String actual = new Xmir.Default(new XMLDocument(xml)).toEO();
         final String expected = pack.expected();
+        System.out.println("EXPECTED");
         final List<String> expectedAgents = pack.agents();
+        System.out.println(expectedAgents);
+        System.out.println("ACTUAL");
+        System.out.println(output.messages());
+        System.out.println("______");
         MatcherAssert.assertThat(
             "Agents should decompile instructions correctly, according to the YAML pack",
             actual,

--- a/src/test/java/it/AgentsIT.java
+++ b/src/test/java/it/AgentsIT.java
@@ -81,10 +81,9 @@ final class AgentsIT {
         );
         MatcherAssert.assertThat(
             "We expect that agents is used in the same order as expected, but they didn't",
-            output.agents(),
+            output.agentsUsed(),
             Matchers.equalTo(pack.agents())
         );
-
     }
 
     /**
@@ -149,7 +148,9 @@ final class AgentsIT {
          * Get Yaml value by key.
          * @param key Yaml key.
          * @return Yaml value.
+         * @checkstyle IllegalCatchCheck (6 lines)
          */
+        @SuppressWarnings("PMD.AvoidCatchingGenericException")
         private Object value(final String key) {
             try {
                 return this.pack.value().get(key);
@@ -157,6 +158,5 @@ final class AgentsIT {
                 throw new IllegalStateException("Failed to parse YAML pack", exception);
             }
         }
-
     }
 }

--- a/src/test/java/it/AgentsIT.java
+++ b/src/test/java/it/AgentsIT.java
@@ -28,8 +28,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Stream;
 import org.cactoos.Scalar;
 import org.cactoos.scalar.Sticky;
 import org.eolang.jucs.ClasspathSource;
@@ -74,19 +72,15 @@ final class AgentsIT {
                         .decompile(pack.instructions())
 
                 ).up().up();
-        final String xml = new Xembler(xmir).xmlQuietly();
-        final String actual = new Xmir.Default(new XMLDocument(xml)).toEO();
-        final String expected = pack.expected();
-        System.out.println("EXPECTED");
-        final List<String> expectedAgents = pack.agents();
-        System.out.println(expectedAgents);
-        System.out.println("ACTUAL");
-        System.out.println(output.messages());
-        System.out.println("______");
         MatcherAssert.assertThat(
             "Agents should decompile instructions correctly, according to the YAML pack",
-            actual,
-            Matchers.equalTo(expected)
+            new Xmir.Default(new XMLDocument(new Xembler(xmir).xmlQuietly())).toEO(),
+            Matchers.equalTo(pack.expected())
+        );
+        MatcherAssert.assertThat(
+            "We expect that agents is used in the same order as expected, but they didn't",
+            output.agents(),
+            Matchers.equalTo(pack.agents())
         );
 
     }
@@ -104,13 +98,10 @@ final class AgentsIT {
 
         Instruction[] instructions() {
             try {
-                final List<String> opcodes1 = (List<String>) this.pack.value().get("opcodes");
-                final Stream<OpcodeInstruction> opcodes = opcodes1
+                return ((Collection<String>) this.pack.value().get("opcodes"))
                     .stream()
-                    .map(s -> new OpcodeInstruction(new OpcodeName(s).code()));
-                final Instruction[] array = opcodes
+                    .map(s -> new OpcodeInstruction(new OpcodeName(s).code()))
                     .toArray(Instruction[]::new);
-                return array;
             } catch (final Exception exception) {
                 throw new IllegalStateException("Failed to parse YAML pack", exception);
             }

--- a/src/test/java/it/AgentsIT.java
+++ b/src/test/java/it/AgentsIT.java
@@ -47,9 +47,17 @@ import org.yaml.snakeyaml.Yaml;
 
 /**
  * Test pack that checks how separate agents decompile instructions.
+ * @since 0.4
+ * @todo #381:30min Remove `program` and `object` elements.
+ *  We added this elements to the test to make it pass.
+ *  Currently {@link Xmir.Default} does not support the decompilation of partial XMIR documents.
+ *  So, by adding these elements we mimic the full XMIR document.
+ *  When the related issue is fixed, remove these elements.
+ *  You can follow the progress of the issue
+ *  <a href="https://github.com/objectionary/eo/issues/3343">here.</a>
  */
 @SuppressWarnings("JTCOP.RuleCorrectTestName")
-public final class AgentsIT {
+final class AgentsIT {
 
     @ParameterizedTest
     @ClasspathSource(value = "agents", glob = "**.yaml")
@@ -64,7 +72,7 @@ public final class AgentsIT {
 
                 ).up().up();
         final String xml = new Xembler(xmir).xmlQuietly();
-        final String actual = new Xmir.Simplified(new XMLDocument(xml)).toEO();
+        final String actual = new Xmir.Default(new XMLDocument(xml)).toEO();
         final String expected = pack.expected();
         final List<String> expectedAgents = pack.agents();
         MatcherAssert.assertThat(

--- a/src/test/java/it/AgentsIT.java
+++ b/src/test/java/it/AgentsIT.java
@@ -1,0 +1,122 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package it;
+
+import com.jcabi.xml.XMLDocument;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.cactoos.Scalar;
+import org.cactoos.scalar.Sticky;
+import org.eolang.jucs.ClasspathSource;
+import org.eolang.opeo.Instruction;
+import org.eolang.opeo.OpcodeInstruction;
+import org.eolang.opeo.ast.OpcodeName;
+import org.eolang.opeo.decompilation.DecompilerMachine;
+import org.eolang.parser.xmir.Xmir;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.xembly.Directive;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Test pack that checks how separate agents decompile instructions.
+ */
+@SuppressWarnings("JTCOP.RuleCorrectTestName")
+public final class AgentsIT {
+
+    @ParameterizedTest
+    @ClasspathSource(value = "agents", glob = "**.yaml")
+    void verifiesAgents(final String yaml) {
+        final InstructionPack pack = new InstructionPack(yaml);
+        final Iterable<Directive> xmir =
+            new Directives().add("program")
+                .add("objects")
+
+                .append(
+                    new DecompilerMachine().decompile(pack.instructions())
+
+                ).up().up();
+        final String xml = new Xembler(xmir).xmlQuietly();
+        final String actual = new Xmir.Simplified(new XMLDocument(xml)).toEO();
+        final String expected = pack.expected();
+        final List<String> expectedAgents = pack.agents();
+        MatcherAssert.assertThat(
+            "Agents should decompile instructions correctly, according to the YAML pack",
+            actual,
+            Matchers.equalTo(expected)
+        );
+
+    }
+
+    private static final class InstructionPack {
+        private final Scalar<Map<String, Object>> pack;
+
+        InstructionPack(final String yaml) {
+            this(new Sticky<>(() -> new Yaml().load(yaml)));
+        }
+
+        private InstructionPack(final Scalar<Map<String, Object>> pack) {
+            this.pack = pack;
+        }
+
+        Instruction[] instructions() {
+            try {
+                final List<String> opcodes1 = (List<String>) this.pack.value().get("opcodes");
+                final Stream<OpcodeInstruction> opcodes = opcodes1
+                    .stream()
+                    .map(s -> new OpcodeInstruction(new OpcodeName(s).code()));
+                final Instruction[] array = opcodes
+                    .toArray(Instruction[]::new);
+                return array;
+            } catch (final Exception exception) {
+                throw new IllegalStateException("Failed to parse YAML pack", exception);
+            }
+        }
+
+        List<String> agents() {
+            try {
+                final List<String> agents = (List<String>) this.pack.value().get("agents");
+                return agents;
+            } catch (final Exception exception) {
+                throw new IllegalStateException("Failed to parse YAML pack", exception);
+            }
+        }
+
+        String expected() {
+            try {
+                final String strings = (String) this.pack.value().get("eo");
+                return strings;
+            } catch (final Exception exception) {
+                throw new IllegalStateException("Failed to parse YAML pack", exception);
+            }
+        }
+
+    }
+}

--- a/src/test/java/it/AgentsIT.java
+++ b/src/test/java/it/AgentsIT.java
@@ -54,6 +54,10 @@ import org.yaml.snakeyaml.Yaml;
  *  When the related issue is fixed, remove these elements.
  *  You can follow the progress of the issue
  *  <a href="https://github.com/objectionary/eo/issues/3343">here.</a>
+ * @todo #381:90min Add More Tests With Instructions That Have Params.
+ *  Currently, we only have tests with instructions that do not have parameters.
+ *  This is an extremely limited number of instructions.
+ *  We need to add more tests with instructions that have parameters.
  */
 @SuppressWarnings("JTCOP.RuleCorrectTestName")
 final class AgentsIT {

--- a/src/test/resources/agents/add.yaml
+++ b/src/test/resources/agents/add.yaml
@@ -3,6 +3,13 @@ opcodes:
   - ICONST_2
   - IADD
 agents:
+  - ConstAgent
+  - ConstAgent
   - AddAgent
-eo:
-  1.add 2
+eo: |
+  *
+    int
+      00-00-00-00-00-00-00-01
+    .plus
+      int
+        00-00-00-00-00-00-00-02

--- a/src/test/resources/agents/add.yaml
+++ b/src/test/resources/agents/add.yaml
@@ -1,0 +1,8 @@
+opcodes:
+  - ICONST_1
+  - ICONST_2
+  - IADD
+agents:
+  - AddAgent
+eo:
+  1.add 2

--- a/src/test/resources/agents/mul.yaml
+++ b/src/test/resources/agents/mul.yaml
@@ -1,0 +1,15 @@
+opcodes:
+  - LCONST_0
+  - LCONST_1
+  - LMUL
+agents:
+  - ConstAgent
+  - ConstAgent
+  - MulAgent
+eo: |
+  *
+    times
+      long
+        00-00-00-00-00-00-00-00
+      long
+        00-00-00-00-00-00-00-01


### PR DESCRIPTION
In this PR I added `AgentsIT` - the integration test that checks how different aggents work with the instruction set and how they change the decompilation output.

Closes: #381.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the decompilation process by adding a `TracedAgent` that logs agents used during decompilation. 

### Detailed summary
- Added `TracedAgent` to log agents used during decompilation
- Updated `DecompilerMachine` to accept `TracedAgent` output
- Updated `AllAgents` to include `TracedAgent` with output
- Added methods to `TracedAgent` to register and retrieve agents used
- Added tests to verify agents' decompilation behavior

> The following files were skipped due to too many changes: `src/test/java/it/AgentsIT.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->