### PR TITLE
feat(#404): Add Params For Instructions in AgentsIT

### DIFF
--- a/src/test/java/it/AgentsIT.java
+++ b/src/test/java/it/AgentsIT.java
@@ -60,10 +60,9 @@ import org.yaml.snakeyaml.Yaml;
  *  When the related issue is fixed, remove these elements.
  *  You can follow the progress of the issue
  *  <a href="https://github.com/objectionary/eo/issues/3343">here.</a>
- * @todo #381:90min Add More Tests With Instructions That Have Params.
- *  Currently, we only have tests with instructions that do not have parameters.
- *  This is an extremely limited number of instructions.
- *  We need to add more tests with instructions that have parameters.
+ * @todo #404:90min Add More Tests.
+ *  Currently, we have only the small number of test packs that checks instructions decompilation.
+ *  We need to add more complicated tests that involve more agents.
  */
 @SuppressWarnings("JTCOP.RuleCorrectTestName")
 final class AgentsIT {

--- a/src/test/java/it/AgentsIT.java
+++ b/src/test/java/it/AgentsIT.java
@@ -34,6 +34,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.cactoos.Scalar;
 import org.cactoos.scalar.Sticky;
+import org.eolang.jeo.representation.xmir.AllLabels;
 import org.eolang.jucs.ClasspathSource;
 import org.eolang.opeo.Instruction;
 import org.eolang.opeo.OpcodeInstruction;
@@ -44,6 +45,7 @@ import org.eolang.parser.xmir.Xmir;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.objectweb.asm.Label;
 import org.xembly.Directives;
 import org.xembly.Xembler;
 import org.yaml.snakeyaml.Yaml;
@@ -110,10 +112,11 @@ final class AgentsIT {
          * 3. Long values. Example: 100L.
          * 4. Integer values. Example: 100.
          * 5. String values. Example: "Hello world!".
-         * 6. Instruction names. Example: LDC.
+         * 6. Label. Example: LABEL:labelid.
+         * 7. Instruction names. Example: LDC.
          */
         private static final Pattern INSTRUCTION = Pattern.compile(
-            "(\\bfalse|true\\b)|(\\d+\\.\\d+)|(\\d+L)|(\\d+)|\"([^\"]*)\"|(\\S+)"
+            "(\\bfalse|true\\b)|(\\d+\\.\\d+)|(\\d+L)|(\\d+)|\"([^\"]*)\"|\\bLABEL\\b:(\\S+)|(\\S+)"
         );
 
         /**
@@ -187,8 +190,10 @@ final class AgentsIT {
                 } else if (matcher.group(5) != null) {
                     final String group = matcher.group(5);
                     arguments.add(group);
+                } else if (matcher.group(6) != null) {
+                    arguments.add(new AllLabels().label(matcher.group(6)));
                 } else {
-                    opcode.set(new OpcodeName(matcher.group(6)).code());
+                    opcode.set(new OpcodeName(matcher.group(7)).code());
                 }
             }
             return new OpcodeInstruction(opcode.get(), arguments.toArray());

--- a/src/test/java/it/AgentsIT.java
+++ b/src/test/java/it/AgentsIT.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -45,7 +46,6 @@ import org.eolang.parser.xmir.Xmir;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.objectweb.asm.Label;
 import org.xembly.Directives;
 import org.xembly.Xembler;
 import org.yaml.snakeyaml.Yaml;
@@ -179,18 +179,18 @@ final class AgentsIT {
             final AtomicInteger opcode = new AtomicInteger();
             final List<Object> arguments = new ArrayList<>(0);
             while (matcher.find()) {
-                if (matcher.group(1) != null) {
+                if (Objects.nonNull(matcher.group(1))) {
                     arguments.add(Boolean.parseBoolean(matcher.group(1)));
-                } else if (matcher.group(2) != null) {
+                } else if (Objects.nonNull(matcher.group(2))) {
                     arguments.add(Double.parseDouble(matcher.group(2)));
-                } else if (matcher.group(3) != null) {
+                } else if (Objects.nonNull(matcher.group(3))) {
                     arguments.add(Long.parseLong(matcher.group(3)));
-                } else if (matcher.group(4) != null) {
+                } else if (Objects.nonNull(matcher.group(4))) {
                     arguments.add(Integer.parseInt(matcher.group(4)));
-                } else if (matcher.group(5) != null) {
+                } else if (Objects.nonNull(matcher.group(5))) {
                     final String group = matcher.group(5);
                     arguments.add(group);
-                } else if (matcher.group(6) != null) {
+                } else if (Objects.nonNull(matcher.group(6))) {
                     arguments.add(new AllLabels().label(matcher.group(6)));
                 } else {
                     opcode.set(new OpcodeName(matcher.group(7)).code());

--- a/src/test/resources/agents/bipush.yaml
+++ b/src/test/resources/agents/bipush.yaml
@@ -3,13 +3,13 @@ opcodes:
   - BIPUSH 20
   - IADD
 agents:
-  - ConstAgent
-  - ConstAgent
+  - BipushAgent
+  - BipushAgent
   - AddAgent
 eo: |
   *
     int
-      00-00-00-00-00-00-00-10
+      00-00-00-00-00-00-00-0A
     .plus
       int
-        00-00-00-00-00-00-00-20
+        00-00-00-00-00-00-00-14

--- a/src/test/resources/agents/bipush.yaml
+++ b/src/test/resources/agents/bipush.yaml
@@ -1,0 +1,15 @@
+opcodes:
+  - BIPUSH 10
+  - BIPUSH 20
+  - IADD
+agents:
+  - ConstAgent
+  - ConstAgent
+  - AddAgent
+eo: |
+  *
+    int
+      00-00-00-00-00-00-00-10
+    .plus
+      int
+        00-00-00-00-00-00-00-20

--- a/src/test/resources/agents/hello_world.yaml
+++ b/src/test/resources/agents/hello_world.yaml
@@ -1,0 +1,16 @@
+opcodes:
+  - GETSTATIC "java/lang/System" "out" "Ljava/io/PrintStream;"
+  - LDC "Hello world!"
+  - INVOKEVIRTUAL "java/io/PrintStream" "println" "(Ljava/lang/String;)V" false
+agents:
+  - GetStaticAgent
+  - LdcAgent
+  - InvokevirtualAgent
+eo: |
+  *
+    static-field
+      "descriptor=Ljava/io/PrintStream;|name=out|owner=java/lang/System"
+    .println
+      "descriptor=(Ljava/lang/String;)V|interfaced=false|name=println|owner=java/io/PrintStream|type=method"
+      load-constant
+        "Hello world!"

--- a/src/test/resources/agents/if.yaml
+++ b/src/test/resources/agents/if.yaml
@@ -1,0 +1,20 @@
+opcodes:
+  - LCONST_0
+  - LCONST_1
+  - IF_ICMPGT LABEL:iftrue
+agents:
+  - ConstAgent
+  - ConstAgent
+  - IfAgent
+# @todo
+eo: |
+  *
+    long
+      00-00-00-00-00-00-00-00
+    .gt
+      long
+        00-00-00-00-00-00-00-01
+    .if
+      label
+        69-66-74-72-75-65
+      nop

--- a/src/test/resources/agents/if.yaml
+++ b/src/test/resources/agents/if.yaml
@@ -6,7 +6,11 @@ agents:
   - ConstAgent
   - ConstAgent
   - IfAgent
-# @todo
+# @todo #404:30min Strange Output of the IfAgent.
+#  The output of the IfAgent looks strange.
+#  We should investigate if the IfAgent is working correctly.
+#  If it is not working correctly, we should fix it.
+#  Otherwise just remove this puzzle.
 eo: |
   *
     long


### PR DESCRIPTION
In this PR I added more test packs to `AgentsIT` that demonstrate decompilation process.
What is the most important, now we can specify instruction arguments directly in yaml packs.

Closes: #404.
History:
- **feat(#404): add 'bipush' test that describes the problem**
- **feat(#404): make 'bipush' pack to pass**
- **feat(#404): add hello-world pack test**
- **feat(#404): add 'if' integration test**
- **feat(#404): add one more puzzle**
- **feat(#404): add one more test**


<!-- start pr-codex -->

---

## PR-Codex overview
### Summary
This PR enhances the testing capabilities of the project by adding more complex test cases involving different agents and instructions.

### Detailed summary
- Added complex test cases with multiple agents and instructions
- Improved parsing of instructions from YAML files
- Updated comments and todos for better code maintenance

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->