### PR TITLE
feat(#410): Redundant Aliases

### DIFF
--- a/src/it/simple/README.md
+++ b/src/it/simple/README.md
@@ -1,0 +1,12 @@
+# Simple Integration Test
+
+This integration test verifies all the phases of the `opeo-maven-plugin` along
+with the `jeo-maven-plugin` and `eo-maven-plugin:xmir-to-phi`.
+In this test, we use a simple "Hello World" application.
+
+
+To exclusively run this test, execute the command below:
+
+```shell
+mvn clean integration-test -Dinvoker.test=simple -DskipTests
+```

--- a/src/it/simple/invoker.properties
+++ b/src/it/simple/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean package -e

--- a/src/it/simple/pom.xml
+++ b/src/it/simple/pom.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2023 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <!--
+      The version of 3.2.0 and similar requires rather high java
+      version: 17 or higher. So we intentionally use the version 2.7.18
+      here that requires java 11 since our plugin should be compatible with
+      java 11.
+    -->
+    <version>2.7.18</version>
+    <relativePath/>
+  </parent>
+  <groupId>org.eolang</groupId>
+  <artifactId>opeo-spring-it</artifactId>
+  <version>@project.version@</version>
+  <packaging>jar</packaging>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <jeo.version>0.5.4</jeo.version>
+    <ineo.version>0.3.2</ineo.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>jeo-maven-plugin</artifactId>
+        <version>${jeo.version}</version>
+        <executions>
+          <execution>
+            <id>bytecode-to-eo</id>
+            <goals>
+              <goal>disassemble</goal>
+            </goals>
+            <configuration>
+              <outputDir>${project.build.directory}/generated-sources/jeo-disassemble-xmir</outputDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>opeo-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>opeo-decompile</id>
+            <goals>
+              <goal>decompile</goal>
+            </goals>
+            <configuration>
+              <sourcesDir>${project.build.directory}/generated-sources/jeo-disassemble-xmir</sourcesDir>
+              <outputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</outputDir>
+            </configuration>
+          </execution>
+          <execution>
+            <id>opeo-compile</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <sourcesDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</sourcesDir>
+              <outputDir>${project.build.directory}/generated-sources/opeo-compile-xmir</outputDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>eo-maven-plugin</artifactId>
+        <version>0.39.0</version>
+        <executions>
+          <execution>
+            <id>convert-xmir-to-phi</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>xmir-to-phi</goal>
+            </goals>
+            <configuration>
+              <phiInputDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</phiInputDir>
+              <phiOutputDir>${project.build.directory}/generated-sources/phi-expressions</phiOutputDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.4.1</version>
+        <executions>
+          <execution>
+            <id>jeo-to-bytecode</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+            <executable>mvn</executable>
+              <arguments combine.children="append">
+                <argument>org.eolang:jeo-maven-plugin:${jeo.version}:assemble</argument>
+                <argument>-Djeo.assemble.sourcesDir=${project.build.directory}/generated-sources/opeo-compile-xmir</argument>
+                <argument>-Djeo.assemble.skip.verification=true</argument>
+                <argument>-e</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/simple/pom.xml
+++ b/src/it/simple/pom.xml
@@ -134,13 +134,23 @@ SOFTWARE.
               <goal>exec</goal>
             </goals>
             <configuration>
-            <executable>mvn</executable>
+              <executable>mvn</executable>
               <arguments combine.children="append">
                 <argument>org.eolang:jeo-maven-plugin:${jeo.version}:assemble</argument>
                 <argument>-Djeo.assemble.sourcesDir=${project.build.directory}/generated-sources/opeo-compile-xmir</argument>
                 <argument>-Djeo.assemble.skip.verification=true</argument>
                 <argument>-e</argument>
               </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>run-app</id>
+            <phase>package</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <configuration>
+              <mainClass>org.eolang.opeo.simple.App</mainClass>
             </configuration>
           </execution>
         </executions>

--- a/src/it/simple/src/main/java/org/eolang/opeo/simple/App.java
+++ b/src/it/simple/src/main/java/org/eolang/opeo/simple/App.java
@@ -1,0 +1,34 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.simple;
+
+/**
+ * App.
+ * @since 0.1
+ */
+public class App {
+    public static void main(String[] args) {
+        System.out.println("Hello, world!");
+    }
+}

--- a/src/it/simple/verify.groovy
+++ b/src/it/simple/verify.groovy
@@ -1,0 +1,28 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+//Check logs first.
+String log = new File(basedir, 'build.log').text;
+assert log.contains("BUILD SUCCESS")
+assert log.contains("Hello, world!")
+true

--- a/src/main/java/org/eolang/opeo/decompilation/NaiveDecompiler.java
+++ b/src/main/java/org/eolang/opeo/decompilation/NaiveDecompiler.java
@@ -93,7 +93,11 @@ public final class NaiveDecompiler implements Decompiler {
      */
     private int decompile(final XmirEntry entry) {
         this.storage.save(
-            entry.transform(xml -> new JeoDecompiler(xml, entry.relative()).decompile())
+            entry.transform(
+                xml -> new WithoutAliases(
+                    new JeoDecompiler(xml, entry.relative()).decompile()
+                ).toXml()
+            )
         );
         return 1;
     }

--- a/src/main/java/org/eolang/opeo/decompilation/WithoutAliases.java
+++ b/src/main/java/org/eolang/opeo/decompilation/WithoutAliases.java
@@ -52,12 +52,44 @@ public final class WithoutAliases {
      * @return Xmir without aliases.
      */
     public XML toXml() {
-        return new XMLDocument(
-            new Xembler(
-                new Directives()
-                    .xpath("./program/metas/meta[head[text()='alias']]")
-                    .remove()
-            ).applyQuietly(this.original.node())
-        );
+        System.out.println(this.original.toString());
+        final boolean hasLabels = !this.original.xpath(".//o[@base='label']/@base").isEmpty();
+        final boolean hasOpcodes = !this.original.xpath(".//o[@base='opcode']/@base").isEmpty();
+        if (hasOpcodes && hasLabels) {
+            return this.original;
+        } else if (hasOpcodes) {
+            return new XMLDocument(
+                new Xembler(
+                    new Directives()
+                        .xpath(
+                            "./program/metas/meta[head='alias' and tail='org.eolang.jeo.label']")
+                        .remove()
+                ).applyQuietly(this.original.node())
+            );
+        } else if (hasLabels) {
+            return new XMLDocument(
+                new Xembler(
+                    new Directives()
+                        .xpath(
+                            "./program/metas/meta[head='alias' and tail='org.eolang.jeo.opcode']")
+                        .remove()
+                ).applyQuietly(this.original.node())
+            );
+        } else {
+            return new XMLDocument(
+                new Xembler(
+                    new Directives()
+                        .xpath("./program/metas/meta[head[text()='alias']]")
+                        .remove()
+                ).applyQuietly(this.original.node())
+            );
+        }
+//        return new XMLDocument(
+//            new Xembler(
+//                new Directives()
+//                    .xpath("./program/metas/meta[head[text()='alias']]")
+//                    .remove()
+//            ).applyQuietly(this.original.node())
+//        );
     }
 }

--- a/src/main/java/org/eolang/opeo/decompilation/WithoutAliases.java
+++ b/src/main/java/org/eolang/opeo/decompilation/WithoutAliases.java
@@ -52,7 +52,7 @@ public final class WithoutAliases {
      * @return Xmir without aliases.
      */
     public XML toXml() {
-        System.out.println(this.original.toString());
+        //todo: refactor this ugly method!
         final boolean hasLabels = !this.original.xpath(".//o[@base='label']/@base").isEmpty();
         final boolean hasOpcodes = !this.original.xpath(".//o[@base='opcode']/@base").isEmpty();
         if (hasOpcodes && hasLabels) {
@@ -84,12 +84,5 @@ public final class WithoutAliases {
                 ).applyQuietly(this.original.node())
             );
         }
-//        return new XMLDocument(
-//            new Xembler(
-//                new Directives()
-//                    .xpath("./program/metas/meta[head[text()='alias']]")
-//                    .remove()
-//            ).applyQuietly(this.original.node())
-//        );
     }
 }

--- a/src/test/java/org/eolang/opeo/decompilation/WithoutAliasesTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/WithoutAliasesTest.java
@@ -1,0 +1,139 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.decompilation;
+
+import com.jcabi.matchers.XPathMatcher;
+import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import java.util.Arrays;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link WithoutAliases}
+ *
+ * @since 0.4
+ */
+class WithoutAliasesTest {
+
+    @Test
+    void removesAllAliases() {
+        MatcherAssert.assertThat(
+            "We expect that all aliases are removed since the program doesn't have labels or opcodes",
+            new WithoutAliases(WithoutAliasesTest.program()).toXml(),
+            Matchers.not(XhtmlMatchers.hasXPath("/program/metas/meta[head='alias']"))
+        );
+    }
+
+    @Test
+    void removesOnlyLabelAlias() {
+        MatcherAssert.assertThat(
+            "We expect that only the label alias is removed since the program has an object",
+            new WithoutAliases(
+                WithoutAliasesTest.program(WithoutAliasesTest.object("opcode"))
+            ).toXml(),
+            Matchers.allOf(
+                Matchers.not(
+                    XhtmlMatchers.hasXPath(
+                        "/program/metas/meta[head='alias' and tail='org.eolang.jeo.label']"
+                    )
+                ),
+                XhtmlMatchers.hasXPaths(
+                    "/program/metas/meta[head='alias' and tail='org.eolang.jeo.opcode']"
+                )
+            )
+        );
+    }
+
+    @Test
+    void removesOnlyOpcodeAlias() {
+        MatcherAssert.assertThat(
+            "We expect that only the opcode alias is removed since the program has a label",
+            new WithoutAliases(
+                WithoutAliasesTest.program(WithoutAliasesTest.object("label"))
+            ).toXml(),
+            Matchers.allOf(
+                Matchers.not(
+                    XhtmlMatchers.hasXPath(
+                        "/program/metas/meta[head='alias' and tail='org.eolang.jeo.opcode']"
+                    )
+                ),
+                XhtmlMatchers.hasXPaths(
+                    "/program/metas/meta[head='alias' and tail='org.eolang.jeo.label']"
+                )
+            )
+        );
+    }
+
+
+    /**
+     * A simple XMIR program that contains aliases and some objects.
+     * @param objects Objects to add to the program.
+     * @return XMIR program.
+     */
+    private static XML program(final Directives... objects) {
+        return new XMLDocument(
+            new Xembler(
+                new Directives()
+                    .add("program")
+                    .add("metas")
+                    .append(WithoutAliasesTest.alias("org.eolang.jeo.label"))
+                    .append(WithoutAliasesTest.alias("org.eolang.jeo.opcode"))
+                    .up()
+                    .add("objects")
+                    .append(Arrays.stream(objects).reduce(new Directives(), Directives::append))
+                    .up()
+                    .up()
+            ).xmlQuietly()
+        );
+    }
+
+    /**
+     * Alias directive.
+     * @param name Alias name.
+     * @return Alias directive.
+     */
+    private static Directives alias(final String name) {
+        return new Directives()
+            .add("meta")
+            .add("head").set("alias").up()
+            .add("tail").set(name).up()
+            .add("part").set(name).up()
+            .up();
+    }
+
+    /**
+     * Object directive.
+     * @param base Base of the object.
+     * @return Object directive.
+     */
+    private static Directives object(final String base) {
+        return new Directives().add("o").attr("base", base).up();
+    }
+
+}

--- a/src/test/java/org/eolang/opeo/decompilation/WithoutAliasesTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/WithoutAliasesTest.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.opeo.decompilation;
 
-import com.jcabi.matchers.XPathMatcher;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
@@ -43,9 +42,11 @@ class WithoutAliasesTest {
 
     @Test
     void removesAllAliases() {
+        final XML program = WithoutAliasesTest.program();
+        System.out.println(program);
         MatcherAssert.assertThat(
             "We expect that all aliases are removed since the program doesn't have labels or opcodes",
-            new WithoutAliases(WithoutAliasesTest.program()).toXml(),
+            new WithoutAliases(program).toXml(),
             Matchers.not(XhtmlMatchers.hasXPath("/program/metas/meta[head='alias']"))
         );
     }
@@ -89,7 +90,6 @@ class WithoutAliasesTest {
             )
         );
     }
-
 
     /**
      * A simple XMIR program that contains aliases and some objects.

--- a/src/test/java/org/eolang/opeo/decompilation/WithoutAliasesTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/WithoutAliasesTest.java
@@ -34,19 +34,17 @@ import org.xembly.Directives;
 import org.xembly.Xembler;
 
 /**
- * Test cases for {@link WithoutAliases}
+ * Test cases for {@link WithoutAliases}.
  *
  * @since 0.4
  */
-class WithoutAliasesTest {
+final class WithoutAliasesTest {
 
     @Test
     void removesAllAliases() {
-        final XML program = WithoutAliasesTest.program();
-        System.out.println(program);
         MatcherAssert.assertThat(
             "We expect that all aliases are removed since the program doesn't have labels or opcodes",
-            new WithoutAliases(program).toXml(),
+            new WithoutAliases(WithoutAliasesTest.program()).toXml(),
             Matchers.not(XhtmlMatchers.hasXPath("/program/metas/meta[head='alias']"))
         );
     }
@@ -87,6 +85,23 @@ class WithoutAliasesTest {
                 XhtmlMatchers.hasXPaths(
                     "/program/metas/meta[head='alias' and tail='org.eolang.jeo.label']"
                 )
+            )
+        );
+    }
+
+    @Test
+    void keepsAllAliases() {
+        MatcherAssert.assertThat(
+            "We expect that all aliases are kept since the program has both labels and opcodes",
+            new WithoutAliases(
+                WithoutAliasesTest.program(
+                    WithoutAliasesTest.object("label"),
+                    WithoutAliasesTest.object("opcode")
+                )
+            ).toXml(),
+            XhtmlMatchers.hasXPaths(
+                "/program/metas/meta[head='alias' and tail='org.eolang.jeo.label']",
+                "/program/metas/meta[head='alias' and tail='org.eolang.jeo.opcode']"
             )
         );
     }


### PR DESCRIPTION
In this PR I solve the problem with redundant aliases for `opcode` and `label`.
Also I added a new integration test `simple` that proves that now printint to phi expressions works fine.

Related to: #410

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the decompilation process in `NaiveDecompiler` by introducing `WithoutAliases`. It also adds integration tests and updates licensing information.

### Detailed summary
- Added `WithoutAliases` class for decompilation process
- Updated `NaiveDecompiler` to use `WithoutAliases`
- Added integration tests for `opeo-maven-plugin`
- Updated licensing information in multiple files

> The following files were skipped due to too many changes: `src/it/simple/pom.xml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->