### PR TITLE
feat(#420): Add `j$` Prefix For Class Names

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/Handle.java
+++ b/src/main/java/org/eolang/opeo/ast/Handle.java
@@ -130,7 +130,7 @@ public final class Handle implements Xmir {
     ) {
         this.tag = tag;
         this.name = name;
-        this.owner = owner;
+        this.owner = new PrefixedName(owner).withoutPrefix();
         this.desc = desc;
         this.itf = itf;
     }
@@ -138,7 +138,13 @@ public final class Handle implements Xmir {
     @Override
     public Iterable<Directive> toXmir() {
         return new Directives().add("o")
-            .attr("base", String.format("%s.%s", this.owner.replace('/', '.'), this.name))
+            .attr(
+                "base",
+                String.format("%s.%s",
+                    new PrefixedName(this.owner.replace('/', '.')).withPrefix(),
+                    this.name
+                )
+            )
             .append(new DirectivesData("", this.tag))
             .append(new DirectivesData("", this.desc))
             .append(new DirectivesData("", this.itf))

--- a/src/main/java/org/eolang/opeo/ast/Handle.java
+++ b/src/main/java/org/eolang/opeo/ast/Handle.java
@@ -140,7 +140,8 @@ public final class Handle implements Xmir {
         return new Directives().add("o")
             .attr(
                 "base",
-                String.format("%s.%s",
+                String.format(
+                    "%s.%s",
                     new PrefixedName(this.owner.replace('/', '.')).withPrefix(),
                     this.name
                 )

--- a/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
@@ -126,6 +126,25 @@ public final class InterfaceInvocation implements AstNode, Typed {
     }
 
     @Override
+    public Iterable<Directive> toXmir() {
+        if (Objects.isNull(this.source)) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Source and method must not be null, but they are %s",
+                    this
+                )
+            );
+        }
+        final Directives directives = new Directives();
+        directives.add("o")
+            .attr("base", String.format(".%s", this.attrs.name()))
+            .append(this.source.toXmir())
+            .append(this.attrs.toXmir());
+        this.arguments.stream().map(AstNode::toXmir).forEach(directives::append);
+        return directives.up();
+    }
+
+    @Override
     public List<AstNode> opcodes() {
         final List<AstNode> res = new ArrayList<>(0);
         res.addAll(this.source.opcodes());
@@ -148,25 +167,6 @@ public final class InterfaceInvocation implements AstNode, Typed {
             )
         );
         return res;
-    }
-
-    @Override
-    public Iterable<Directive> toXmir() {
-        if (Objects.isNull(this.source)) {
-            throw new IllegalArgumentException(
-                String.format(
-                    "Source and method must not be null, but they are %s",
-                    this
-                )
-            );
-        }
-        final Directives directives = new Directives();
-        directives.add("o")
-            .attr("base", String.format(".%s", this.attrs.name()))
-            .append(this.source.toXmir())
-            .append(this.attrs.toXmir());
-        this.arguments.stream().map(AstNode::toXmir).forEach(directives::append);
-        return directives.up();
     }
 
     @Override

--- a/src/main/java/org/eolang/opeo/ast/Owner.java
+++ b/src/main/java/org/eolang/opeo/ast/Owner.java
@@ -48,7 +48,7 @@ public final class Owner implements Xmir {
      * @param type Owner type.
      */
     public Owner(final String type) {
-        this(Type.getObjectType(type));
+        this(Type.getObjectType(new PrefixedName(type).withoutPrefix()));
     }
 
     /**
@@ -63,7 +63,7 @@ public final class Owner implements Xmir {
     public Iterable<Directive> toXmir() {
         return new Directives()
             .add("o")
-            .attr("base", this.toString())
+            .attr("base", new PrefixedName(this.toString()).withPrefix())
             .up();
     }
 

--- a/src/main/java/org/eolang/opeo/ast/PrefixedName.java
+++ b/src/main/java/org/eolang/opeo/ast/PrefixedName.java
@@ -1,0 +1,83 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import java.util.regex.Pattern;
+
+/**
+ * Prefixed name.
+ * @since 0.1
+ */
+public final class PrefixedName {
+
+    private static final Pattern PREFIX = Pattern.compile("j$", Pattern.LITERAL);
+
+    /**
+     * Original name.
+     */
+    private final String original;
+
+    /**
+     * Constructor.
+     * @param original Original name.
+     */
+    public PrefixedName(final String original) {
+        this.original = original;
+    }
+
+
+    public String withPrefix() {
+        final String delimiter = delimiter();
+        final String[] split = this.original.split(String.format("[%s]", delimiter));
+        if (split.length < 1) {
+            throw new IllegalArgumentException(String.format("Invalid name '%s'", this.original));
+        } else {
+            split[split.length - 1] = String.format("j$%s", split[split.length - 1]);
+        }
+        return String.join(delimiter, split);
+    }
+
+    public String withoutPrefix() {
+        final String delimiter = delimiter();
+        final String[] split = this.original.split(String.format("[%s]", delimiter));
+        if (split.length < 1) {
+            throw new IllegalArgumentException(String.format("Invalid name '%s'", this.original));
+        } else {
+            split[split.length - 1] = PrefixedName.PREFIX
+                .matcher(split[split.length - 1])
+                .replaceAll("");
+        }
+        return String.join(delimiter, split);
+    }
+
+    private String delimiter() {
+        final String delimiter;
+        if (this.original.contains(".")) {
+            delimiter = ".";
+        } else {
+            delimiter = "/";
+        }
+        return delimiter;
+    }
+}

--- a/src/main/java/org/eolang/opeo/ast/PrefixedName.java
+++ b/src/main/java/org/eolang/opeo/ast/PrefixedName.java
@@ -31,6 +31,9 @@ import java.util.regex.Pattern;
  */
 public final class PrefixedName {
 
+    /**
+     * Pattern to remove prefix.
+     */
     private static final Pattern PREFIX = Pattern.compile("j$", Pattern.LITERAL);
 
     /**
@@ -46,9 +49,12 @@ public final class PrefixedName {
         this.original = original;
     }
 
-
+    /**
+     * The class name with prefix.
+     * @return Name with prefix.
+     */
     public String withPrefix() {
-        final String delimiter = delimiter();
+        final String delimiter = this.delimiter();
         final String[] split = this.original.split(String.format("[%s]", delimiter));
         if (split.length < 1) {
             throw new IllegalArgumentException(String.format("Invalid name '%s'", this.original));
@@ -58,8 +64,12 @@ public final class PrefixedName {
         return String.join(delimiter, split);
     }
 
+    /**
+     * Without prefix.
+     * @return Name without prefix.
+     */
     public String withoutPrefix() {
-        final String delimiter = delimiter();
+        final String delimiter = this.delimiter();
         final String[] split = this.original.split(String.format("[%s]", delimiter));
         if (split.length < 1) {
             throw new IllegalArgumentException(String.format("Invalid name '%s'", this.original));
@@ -71,6 +81,10 @@ public final class PrefixedName {
         return String.join(delimiter, split);
     }
 
+    /**
+     * Find delimiter.
+     * @return Delimiter.
+     */
     private String delimiter() {
         final String delimiter;
         if (this.original.contains(".")) {

--- a/src/main/java/org/eolang/opeo/ast/StaticInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/StaticInvocation.java
@@ -161,8 +161,7 @@ public final class StaticInvocation implements AstNode, Typed {
     @Override
     public Iterable<Directive> toXmir() {
         final Directives directives = new Directives();
-        directives.add("o")
-            .attr("base", String.format(".%s", this.attributes.name()));
+        directives.add("o").attr("base", String.format(".%s", this.attributes.name()));
         directives.append(this.owner.toXmir());
         directives.append(this.attributes.toXmir());
         this.args.stream().map(AstNode::toXmir).forEach(directives::append);

--- a/src/test/java/org/eolang/opeo/ast/DynamicInvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/DynamicInvocationTest.java
@@ -47,14 +47,14 @@ final class DynamicInvocationTest {
     private static final String XMIR = String.join(
         "",
         "<o base='.run'>",
-        "   <o base='java.lang.invoke.LambdaMetafactory.meafactory'>",
+        "   <o base='java.lang.invoke.j$LambdaMetafactory.meafactory'>",
         "      <o base='int' data='bytes' line='74325437'>00 00 00 00 00 00 00 06</o>",
         "      <o base='string' data='bytes' line='981153864'>28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 73 24 4C 6F 6F 6B 75 70 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 48 61 6E 64 6C 65 3B 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 4D 65 74 68 6F 64 54 79 70 65 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 69 6E 76 6F 6B 65 2F 43 61 6C 6C 53 69 74 65 3B</o>",
         "      <o base='bool' data='bytes' line='623874038'>00</o>",
         "   </o>",
         "   <o base='string' data='bytes' line='306231171'>64 65 73 63 72 69 70 74 6F 72 3D 28 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 52 75 6E 6E 61 62 6C 65 3B 7C 74 79 70 65 3D 64 79 6E 61 6D 69 63</o>",
         "   <o base='type' data='bytes' line='1809304796'>28 29 56</o>",
-        "   <o base='org.eolang.streams.Lambda.lambda$run$0'>",
+        "   <o base='org.eolang.streams.j$Lambda.lambda$run$0'>",
         "      <o base='int' data='bytes' line='631518845'>00 00 00 00 00 00 00 06</o>",
         "      <o base='string' data='bytes' line='1214403213'>28 29 56</o>",
         "      <o base='bool' data='bytes' line='1030902856'>00</o>",
@@ -73,7 +73,7 @@ final class DynamicInvocationTest {
                     new Handle(
                         6,
                         "meafactory",
-                        "java/lang/invoke/LambdaMetafactory",
+                        "java/lang/invoke/j$LambdaMetafactory",
                         "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
                         false
                     ),
@@ -82,7 +82,7 @@ final class DynamicInvocationTest {
                         Type.getType("()V"),
                         new org.objectweb.asm.Handle(
                             6,
-                            "org/eolang/streams/Lambda",
+                            "org/eolang/streams/j$Lambda",
                             "lambda$run$0",
                             "()V",
                             false

--- a/src/test/java/org/eolang/opeo/ast/PrefixedNameTest.java
+++ b/src/test/java/org/eolang/opeo/ast/PrefixedNameTest.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Tests for {@link PrefixedName}.
+ * @since 0.1
+ */
+final class PrefixedNameTest {
+
+    @ParameterizedTest(name = "adds 'j$' prefix to {0}, expected {1}")
+    @CsvSource({
+        "java.util.Arrays,java.util.j$Arrays",
+        "java.util.stream.IntStream,java.util.stream.j$IntStream",
+        "java.util.stream.Stream,java.util.stream.j$Stream",
+        "java.util.stream.Collectors,java.util.stream.j$Collectors",
+        "java.util.stream.StreamSupport,java.util.stream.j$StreamSupport",
+        "ArrayList,j$ArrayList",
+        "java.util.List,java.util.j$List",
+        "java/util/Arrays,java/util/j$Arrays",
+        "java/util/stream/IntStream,java/util/stream/j$IntStream",
+        "java/util/stream/Stream,java/util/stream/j$Stream",
+        "java/util/stream/Collectors,java/util/stream/j$Collectors"
+    })
+    void addsPrefixes(final String initial, final String expected) {
+        MatcherAssert.assertThat(
+            "We expect that 'j$' prefix is added to the name",
+            new PrefixedName(initial).withPrefix(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @ParameterizedTest(name = "removes 'j$' prefix from {0}, expected {1}")
+    @CsvSource({
+        "java.util.j$Arrays,java.util.Arrays",
+        "java.util.stream.j$IntStream,java.util.stream.IntStream",
+        "java.util.stream.j$Stream,java.util.stream.Stream",
+        "java.util.stream.j$Collectors,java.util.stream.Collectors",
+        "java.util.stream.j$StreamSupport,java.util.stream.StreamSupport",
+        "j$ArrayList,ArrayList",
+        "java.util.j$List,java.util.List",
+        "java/util/j$Arrays,java/util/Arrays",
+        "java/util/stream/j$IntStream,java/util/stream/IntStream",
+        "java/util/stream/j$Stream,java/util/stream/Stream",
+        "java/util/stream/j$Collectors,java/util/stream/Collectors"
+    })
+    void removesPrefix(final String initial, final String expected) {
+        MatcherAssert.assertThat(
+            "We expect that 'j$' prefix is removed from the name",
+            new PrefixedName(initial).withoutPrefix(),
+            Matchers.equalTo(expected)
+        );
+    }
+}

--- a/src/test/java/org/eolang/opeo/ast/StaticInvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/StaticInvocationTest.java
@@ -48,7 +48,7 @@ final class StaticInvocationTest {
             new Xembler(invocation.toXmir()).xml(),
             XhtmlMatchers.hasXPaths(
                 "./o[@base='.get']",
-                "./o[@base='.get']/o[@base='java.lang.A']"
+                "./o[@base='.get']/o[@base='java.lang.j$A']"
             )
         );
     }


### PR DESCRIPTION
Add `j$` prefix for class names. This change fix the problem with the normalizer.

Closes: #420.
History: 
- **feat(#420): add Prefixed class**
- **feat(#420): apply PrefixedName to Owner**
- **feat(#420): use PrefixedName in Handle class**
- **feat(#420): fix all the qulice suggestions**
- **feat(#420): fix all unit tests**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `PrefixedName` class to handle prefixes in class names. It updates multiple files to use this class for prefix manipulation.

### Detailed summary
- Added `PrefixedName` class for handling prefixes in class names
- Updated multiple files to use `PrefixedName` for prefix manipulation
- Modified `StaticInvocation`, `Owner`, `Handle`, and `InterfaceInvocation` classes to utilize `PrefixedName`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->