### PR TITLE
feat(#389): Add Type Information to Method Calls

### DIFF
--- a/src/it/streams/pom.xml
+++ b/src/it/streams/pom.xml
@@ -108,24 +108,24 @@ SOFTWARE.
           </execution>
         </executions>
       </plugin>
-       <plugin>
-              <groupId>org.eolang</groupId>
-              <artifactId>eo-maven-plugin</artifactId>
-              <version>0.39.0</version>
-              <executions>
-                <execution>
-                  <id>convert-xmir-to-eo</id>
-                  <phase>process-classes</phase>
-                  <goals>
-                    <goal>print</goal>
-                  </goals>
-                  <configuration>
-                    <printSourcesDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</printSourcesDir>
-                    <printOutputDir>${project.build.directory}/generated-sources/eo-representation</printOutputDir>
-                  </configuration>
-                </execution>
-              </executions>
-            </plugin>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>eo-maven-plugin</artifactId>
+        <version>0.39.0</version>
+        <executions>
+          <execution>
+            <id>convert-xmir-to-eo</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>print</goal>
+            </goals>
+            <configuration>
+              <printSourcesDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</printSourcesDir>
+              <printOutputDir>${project.build.directory}/generated-sources/eo-representation</printOutputDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/src/it/streams/pom.xml
+++ b/src/it/streams/pom.xml
@@ -109,24 +109,6 @@ SOFTWARE.
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eolang</groupId>
-        <artifactId>eo-maven-plugin</artifactId>
-        <version>0.39.0</version>
-        <executions>
-          <execution>
-            <id>convert-xmir-to-eo</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>print</goal>
-            </goals>
-            <configuration>
-              <printSourcesDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</printSourcesDir>
-              <printOutputDir>${project.build.directory}/generated-sources/eo-representation</printOutputDir>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.4.1</version>

--- a/src/it/streams/pom.xml
+++ b/src/it/streams/pom.xml
@@ -108,6 +108,24 @@ SOFTWARE.
           </execution>
         </executions>
       </plugin>
+       <plugin>
+              <groupId>org.eolang</groupId>
+              <artifactId>eo-maven-plugin</artifactId>
+              <version>0.39.0</version>
+              <executions>
+                <execution>
+                  <id>convert-xmir-to-eo</id>
+                  <phase>process-classes</phase>
+                  <goals>
+                    <goal>print</goal>
+                  </goals>
+                  <configuration>
+                    <printSourcesDir>${project.build.directory}/generated-sources/opeo-decompile-xmir</printSourcesDir>
+                    <printOutputDir>${project.build.directory}/generated-sources/eo-representation</printOutputDir>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/src/it/streams/src/main/java/org/eolang/streams/Main.java
+++ b/src/it/streams/src/main/java/org/eolang/streams/Main.java
@@ -25,6 +25,8 @@ package org.eolang.streams;
 
 import java.util.Arrays;
 import java.util.stream.IntStream;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class Main {
     public static void main(String... args) {
@@ -39,5 +41,11 @@ public class Main {
         System.out.printf("sum=%d time=%d%n", sum, System.currentTimeMillis() - start);
         // Here I test {@link Playground} class.
         System.out.printf("Playground is available %b%n", new Playground(0).isAvailable());
+    }
+
+    public String map(){
+        return Stream.of("a", "b", "c")
+            .map(String::toUpperCase)
+            .collect(Collectors.joining(", "));
     }
 }

--- a/src/it/streams/verify.groovy
+++ b/src/it/streams/verify.groovy
@@ -33,7 +33,14 @@ assert new File(basedir, 'target/generated-sources/opeo-decompile-xmir/org/eolan
 // Compilation output.
 assert new File(basedir, 'target/generated-sources/opeo-compile-xmir/org/eolang/streams/Main.xmir').exists()
 // Phi expressions output.
-//assert new File(basedir, 'target/generated-sources/phi-expressions/org/eolang/streams/Main.phi').exists()
+assert new File(basedir, 'target/generated-sources/phi-expressions/org/eolang/streams/Main.phi').exists()
 // Check that we honestly decompiled and compiled the same file.
 //assert new File(basedir, 'target/generated-sources/opeo-decompile-modified-xmir/org/eolang/streams/Main.xmir').exists()
+// Check that PHI expression contains types for method invocations:
+def phi = new File(basedir, 'target/generated-sources/phi-expressions/org/eolang/streams/Main.phi').text
+assert phi.contains('.java_util_stream_Stream$of')
+assert phi.contains('.java_util_stream_Stream$map')
+assert phi.contains('.java_lang_Object$collect')
+
+
 true

--- a/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/InterfaceInvocation.java
@@ -137,7 +137,9 @@ public final class InterfaceInvocation implements AstNode, Typed {
         }
         final Directives directives = new Directives();
         directives.add("o")
-            .attr("base", String.format(".%s", this.attrs.name()))
+            .attr(
+                "base", String.format(".%s", new TypedName(this.attrs.name()).withType(this.attrs))
+            )
             .append(this.source.toXmir())
             .append(this.attrs.toXmir());
         this.arguments.stream().map(AstNode::toXmir).forEach(directives::append);
@@ -161,7 +163,7 @@ public final class InterfaceInvocation implements AstNode, Typed {
             new Opcode(
                 Opcodes.INVOKEINTERFACE,
                 this.attrs.owner(),
-                this.attrs.name(),
+                new TypedName(this.attrs.name()).withoutType(),
                 this.attrs.descriptor(),
                 this.attrs.interfaced()
             )

--- a/src/main/java/org/eolang/opeo/ast/Invocation.java
+++ b/src/main/java/org/eolang/opeo/ast/Invocation.java
@@ -112,7 +112,7 @@ public final class Invocation implements AstNode, Typed {
         final String method,
         final List<AstNode> arguments
     ) {
-        this(source, method, arguments, "V()");
+        this(source, method, arguments, "()V");
     }
 
     /**
@@ -160,8 +160,13 @@ public final class Invocation implements AstNode, Typed {
         }
         final Directives directives = new Directives();
         directives.add("o")
-            .attr("base", String.format(".%s", this.attributes.name()))
-            .append(this.source.toXmir())
+            .attr(
+                "base",
+                String.format(
+                    ".%s",
+                    new TypedName(this.attributes.name()).withType(this.attributes)
+                )
+            ).append(this.source.toXmir())
             .append(this.attributes.toXmir());
         this.arguments.stream().map(AstNode::toXmir)
             .forEach(directives::append);
@@ -196,7 +201,7 @@ public final class Invocation implements AstNode, Typed {
             new Opcode(
                 Opcodes.INVOKEVIRTUAL,
                 owner.replace('.', '/'),
-                this.attributes.name(),
+                new TypedName(this.attributes.name()).withoutType(),
                 this.attributes.descriptor(),
                 this.attributes.interfaced()
             )

--- a/src/main/java/org/eolang/opeo/ast/StaticInvocation.java
+++ b/src/main/java/org/eolang/opeo/ast/StaticInvocation.java
@@ -161,7 +161,13 @@ public final class StaticInvocation implements AstNode, Typed {
     @Override
     public Iterable<Directive> toXmir() {
         final Directives directives = new Directives();
-        directives.add("o").attr("base", String.format(".%s", this.attributes.name()));
+        directives.add("o").attr(
+            "base",
+            String.format(
+                ".%s",
+                new TypedName(this.attributes.name()).withType(this.attributes)
+            )
+        );
         directives.append(this.owner.toXmir());
         directives.append(this.attributes.toXmir());
         this.args.stream().map(AstNode::toXmir).forEach(directives::append);
@@ -176,7 +182,7 @@ public final class StaticInvocation implements AstNode, Typed {
             new Opcode(
                 Opcodes.INVOKESTATIC,
                 this.owner.toString().replace('.', '/'),
-                this.attributes.name(),
+                new TypedName(this.attributes.name()).withoutType(),
                 this.attributes.descriptor(),
                 this.attributes.interfaced()
             )

--- a/src/main/java/org/eolang/opeo/ast/TypedName.java
+++ b/src/main/java/org/eolang/opeo/ast/TypedName.java
@@ -23,6 +23,8 @@
  */
 package org.eolang.opeo.ast;
 
+import org.objectweb.asm.Type;
+
 /**
  * Method name with a type.
  * This class adds a type to a method name.
@@ -40,6 +42,7 @@ public final class TypedName {
      * Original name with or without a type.
      */
     private final String original;
+    private char DELIMITER = '$';
 
     /**
      * Constructor.
@@ -54,7 +57,7 @@ public final class TypedName {
      * @return Name without a type.
      */
     public String withoutType() {
-        return this.original;
+        return this.original.substring(this.original.indexOf(this.DELIMITER) + 1);
     }
 
     /**
@@ -63,6 +66,10 @@ public final class TypedName {
      * @return Name with a type.
      */
     public String withType(final Attributes attributes) {
-        return this.original;
+        return String.join(
+            String.format("%s", this.DELIMITER),
+            Type.getReturnType(attributes.descriptor()).getClassName().replace('.', '_'),
+            this.original
+        );
     }
 }

--- a/src/main/java/org/eolang/opeo/ast/TypedName.java
+++ b/src/main/java/org/eolang/opeo/ast/TypedName.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+/**
+ * Method name with a type.
+ * This class adds a type to a method name.
+ * Also, it can be used to remove a type from a method name.
+ * In other words, it allows the following translations:
+ * `foo` <-> `java_lang_utils_Stream$foo`
+ * `of` <-> `java_util_Stream$of`
+ * `map` <-> `java_util_Stream$map`
+ * You can find more examples in unit tests.
+ * @since 0.4
+ */
+public final class TypedName {
+
+    /**
+     * Original name with or without a type.
+     */
+    private final String original;
+
+    /**
+     * Constructor.
+     * @param original Original name with or without a type.
+     */
+    public TypedName(final String original) {
+        this.original = original;
+    }
+
+    /**
+     * Remove a type from the name.
+     * @return Name without a type.
+     */
+    public String withoutType() {
+        return this.original;
+    }
+
+    /**
+     * Add a type to the name.
+     * @param attributes Attributes that have the type information.
+     * @return Name with a type.
+     */
+    public String withType(final Attributes attributes) {
+        return this.original;
+    }
+}

--- a/src/main/java/org/eolang/opeo/ast/TypedName.java
+++ b/src/main/java/org/eolang/opeo/ast/TypedName.java
@@ -39,10 +39,14 @@ import org.objectweb.asm.Type;
 public final class TypedName {
 
     /**
+     * Delimiter.
+     */
+    private static final char DELIMITER = '$';
+
+    /**
      * Original name with or without a type.
      */
     private final String original;
-    private char DELIMITER = '$';
 
     /**
      * Constructor.
@@ -57,7 +61,7 @@ public final class TypedName {
      * @return Name without a type.
      */
     public String withoutType() {
-        return this.original.substring(this.original.indexOf(this.DELIMITER) + 1);
+        return this.original.substring(this.original.indexOf(TypedName.DELIMITER) + 1);
     }
 
     /**
@@ -72,11 +76,9 @@ public final class TypedName {
                 String.format("Descriptor in attributes '%s' is empty", attributes)
             );
         }
-        final Type type = Type.getReturnType(descriptor);
-        final String className = type.getClassName();
         return String.join(
-            String.format("%s", this.DELIMITER),
-            className.replace('.', '_'),
+            String.format("%s", TypedName.DELIMITER),
+            Type.getReturnType(descriptor).getClassName().replace('.', '_'),
             this.original
         );
     }

--- a/src/main/java/org/eolang/opeo/ast/TypedName.java
+++ b/src/main/java/org/eolang/opeo/ast/TypedName.java
@@ -66,9 +66,17 @@ public final class TypedName {
      * @return Name with a type.
      */
     public String withType(final Attributes attributes) {
+        final String descriptor = attributes.descriptor();
+        if (descriptor.isEmpty()) {
+            throw new IllegalStateException(
+                String.format("Descriptor in attributes '%s' is empty", attributes)
+            );
+        }
+        final Type type = Type.getReturnType(descriptor);
+        final String className = type.getClassName();
         return String.join(
             String.format("%s", this.DELIMITER),
-            Type.getReturnType(attributes.descriptor()).getClassName().replace('.', '_'),
+            className.replace('.', '_'),
             this.original
         );
     }

--- a/src/test/java/org/eolang/opeo/ast/InterfaceInvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InterfaceInvocationTest.java
@@ -42,11 +42,11 @@ final class InterfaceInvocationTest {
      */
     private static final String XMIR = String.join(
         "",
-        "<o base='.foo'>",
+        "<o base='.int$foo'>",
         "   <o base='$'>",
         "      <o base='string' data='bytes'>64 65 73 63 72 69 70 74 6F 72 3D 6A 61 76 61 2E 6C 61 6E 67 2E 4F 62 6A 65 63 74</o>",
         "   </o>",
-        "   <o base='string' data='bytes'>6E 61 6D 65 3D 66 6F 6F 7C 74 79 70 65 3D 69 6E 74 65 72 66 61 63 65</o>",
+        "   <o base='string' data='bytes'>64 65 73 63 72 69 70 74 6F 72 3D 28 29 49 7C 6E 61 6D 65 3D 66 6F 6F 7C 74 79 70 65 3D 69 6E 74 65 72 66 61 63 65</o>",
         "</o>"
     );
 
@@ -55,7 +55,7 @@ final class InterfaceInvocationTest {
         final String xml = new Xembler(
             new InterfaceInvocation(
                 new This(),
-                new Attributes("name=foo")
+                new Attributes("name=foo").descriptor("()I")
             ).toXmir()
         ).xml();
         MatcherAssert.assertThat(
@@ -76,7 +76,7 @@ final class InterfaceInvocationTest {
             Matchers.equalTo(
                 new InterfaceInvocation(
                     new This(),
-                    new Attributes("name=foo")
+                    new Attributes("name=foo").descriptor("()I")
                 )
             )
         );

--- a/src/test/java/org/eolang/opeo/ast/InvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/InvocationTest.java
@@ -48,14 +48,14 @@ final class InvocationTest {
      */
     private static final String XMIR = String.join(
         "",
-        "<o base='.bar'>",
+        "<o base='.void$bar'>",
         "   <o base='.new'>",
         "      <o base='.new-type'>",
         "         <o base='string' data='bytes'>66 6F 6F</o>",
         "      </o>",
         "      <o base='string' data='bytes'/>",
         "   </o>",
-        "   <o base='string' data='bytes'>64 65 73 63 72 69 70 74 6F 72 3D 56 28 29 7C 6E 61 6D 65 3D 62 61 72 7C 74 79 70 65 3D 6D 65 74 68 6F 64</o>",
+        "   <o base='string' data='bytes'>64 65 73 63 72 69 70 74 6F 72 3D 28 29 56 7C 6E 61 6D 65 3D 62 61 72 7C 74 79 70 65 3D 6D 65 74 68 6F 64</o>",
         "   <o base='string' data='bytes'>62 61 7A</o>",
         "</o>"
     );
@@ -118,7 +118,7 @@ final class InvocationTest {
             String.format("Can't save descriptor to '.bar' invocation attribute %s", xml),
             xml,
             XhtmlMatchers.hasXPaths(
-                "./o[@base='.bar']/o[@base='string' and contains(text(),'28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B')]"
+                "./o[@base='.java_lang_String$bar']/o[@base='string' and contains(text(),'28 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B 29 4C 6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67 3B')]"
             )
         );
     }

--- a/src/test/java/org/eolang/opeo/ast/StaticInvocationTest.java
+++ b/src/test/java/org/eolang/opeo/ast/StaticInvocationTest.java
@@ -47,8 +47,8 @@ final class StaticInvocationTest {
             ),
             new Xembler(invocation.toXmir()).xml(),
             XhtmlMatchers.hasXPaths(
-                "./o[@base='.get']",
-                "./o[@base='.get']/o[@base='java.lang.j$A']"
+                "./o[@base='.int$get']",
+                "./o[@base='.int$get']/o[@base='java.lang.j$A']"
             )
         );
     }

--- a/src/test/java/org/eolang/opeo/ast/TypedNameTest.java
+++ b/src/test/java/org/eolang/opeo/ast/TypedNameTest.java
@@ -61,8 +61,11 @@ final class TypedNameTest {
      * Methods that use this test cases:
      * - {@link #appendsType(String, String, Attributes)}
      * - {@link #removesType(String, String)}
+     * Don't remove PMD warning!
+     * This method is used.
      * @return Test cases.
      */
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static Stream<Arguments> types() {
         return Stream.of(
             Arguments.of(
@@ -95,5 +98,4 @@ final class TypedNameTest {
             )
         );
     }
-
 }

--- a/src/test/java/org/eolang/opeo/ast/TypedNameTest.java
+++ b/src/test/java/org/eolang/opeo/ast/TypedNameTest.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import java.util.stream.Stream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test case for {@link TypedName}.
+ * @since 0.4
+ */
+final class TypedNameTest {
+
+    @ParameterizedTest
+    @MethodSource("types")
+    void appendsType(final String name, final String expected, final Attributes attrs) {
+        MatcherAssert.assertThat(
+            "We expect that the type will be appended to the name",
+            new TypedName(name).withType(attrs),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("types")
+    void removesType(final String expected, final String name) {
+        MatcherAssert.assertThat(
+            "We expect that the type will be removed from the name",
+            new TypedName(name).withoutType(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    /**
+     * Test cases for all methods.
+     * Methods that use this test cases:
+     * - {@link #appendsType(String, String, Attributes)}
+     * - {@link #removesType(String, String)}
+     * @return Test cases.
+     */
+    private static Stream<Arguments> types() {
+        return Stream.of(
+            Arguments.of(
+                "foo",
+                "java_lang_Object$foo",
+                new Attributes().descriptor("()Ljava/lang/Object;")
+            ),
+            Arguments.of(
+                "of",
+                "java_lang_util_Stream$of",
+                new Attributes().descriptor("()Ljava/lang/util/Stream;")
+            ),
+            Arguments.of(
+                "map",
+                "java_lang_util_Stream$map",
+                new Attributes()
+                    .descriptor("(Ljava/util/function/Function;)Ljava/util/stream/Stream;")
+            ),
+            Arguments.of(
+                "filter",
+                "java_lang_util_Stream$filter",
+                new Attributes()
+                    .descriptor("(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;")
+            ),
+            Arguments.of(
+                "collect",
+                "java_lang_util_Stream$collect",
+                new Attributes()
+                    .descriptor("(Ljava/util/stream/Collector;)Ljava/lang/Object;")
+            )
+        );
+    }
+
+}

--- a/src/test/java/org/eolang/opeo/ast/TypedNameTest.java
+++ b/src/test/java/org/eolang/opeo/ast/TypedNameTest.java
@@ -77,19 +77,19 @@ final class TypedNameTest {
             ),
             Arguments.of(
                 "map",
-                "java_lang_util_Stream$map",
+                "java_util_stream_Stream$map",
                 new Attributes()
                     .descriptor("(Ljava/util/function/Function;)Ljava/util/stream/Stream;")
             ),
             Arguments.of(
                 "filter",
-                "java_lang_util_Stream$filter",
+                "java_util_stream_Stream$filter",
                 new Attributes()
                     .descriptor("(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;")
             ),
             Arguments.of(
                 "collect",
-                "java_lang_util_Stream$collect",
+                "java_lang_Object$collect",
                 new Attributes()
                     .descriptor("(Ljava/util/stream/Collector;)Ljava/lang/Object;")
             )

--- a/src/test/resources/agents/hello_world.yaml
+++ b/src/test/resources/agents/hello_world.yaml
@@ -10,7 +10,7 @@ eo: |
   *
     static-field
       "descriptor=Ljava/io/PrintStream;|name=out|owner=java/lang/System"
-    .println
+    .void$println
       "descriptor=(Ljava/lang/String;)V|interfaced=false|name=println|owner=java/io/PrintStream|type=method"
       load-constant
         "Hello world!"


### PR DESCRIPTION
In this PR I added types for most of the important method calls. 

**Was:**

```phi
   α1 ↦ ξ.java.util.stream.j$Stream.of(
                          ....
                        ).map(
                          ....
                        ).collect(...)
```

**Become:**
```phi
   α1 ↦ ξ.java.util.stream.j$Stream.java_util_Stream$of(
                          ....
                        ).java_util_Stream$map(
                          ....
                        ).java_util_Stream$collect(...)
```

Additionally:
- Added a simple example that uses `Stream.map` statement in the `streams` integration test. 

Related to #389.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a `TypedName` class to add/remove types from method names in OPEO. It also updates method invocations and tests in OPEO AST.

### Detailed summary
- Added `TypedName` class for method names with types
- Updated method invocations with `TypedName`
- Updated tests for method invocations in OPEO AST

> The following files were skipped due to too many changes: `src/test/java/org/eolang/opeo/ast/TypedNameTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->