### PR TITLE
feat(#389): Replace `[]` With `@` 

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/TypedName.java
+++ b/src/main/java/org/eolang/opeo/ast/TypedName.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.opeo.ast;
 
+import java.util.regex.Pattern;
 import org.objectweb.asm.Type;
 
 /**
@@ -42,6 +43,11 @@ public final class TypedName {
      * Delimiter.
      */
     private static final char DELIMITER = '$';
+
+    /**
+     * Array pattern.
+     */
+    private static final Pattern ARRAY = Pattern.compile("\\[]");
 
     /**
      * Original name with or without a type.
@@ -78,7 +84,11 @@ public final class TypedName {
         }
         return String.join(
             String.format("%s", TypedName.DELIMITER),
-            Type.getReturnType(descriptor).getClassName().replace('.', '_'),
+            TypedName.ARRAY.matcher(
+                Type.getReturnType(descriptor)
+                    .getClassName()
+                    .replace('.', '_')
+            ).replaceAll("@"),
             this.original
         );
     }

--- a/src/test/java/org/eolang/opeo/ast/TypedNameTest.java
+++ b/src/test/java/org/eolang/opeo/ast/TypedNameTest.java
@@ -98,19 +98,19 @@ final class TypedNameTest {
             ),
             Arguments.of(
                 "toArray",
-                "java_lang_Object[]$toArray",
+                "java_lang_Object@$toArray",
                 new Attributes()
                     .descriptor("()[Ljava/lang/Object;")
             ),
             Arguments.of(
                 "copyOf",
-                "java_lang_Object[]$copyOf",
+                "java_lang_Object@$copyOf",
                 new Attributes()
                     .descriptor("([Ljava/lang/Object;I)[Ljava/lang/Object;")
             ),
             Arguments.of(
                 "split",
-                "java_lang_String[]$split",
+                "java_lang_String@$split",
                 new Attributes()
                     .descriptor("(Ljava/lang/String;)[Ljava/lang/String;")
             )

--- a/src/test/java/org/eolang/opeo/ast/TypedNameTest.java
+++ b/src/test/java/org/eolang/opeo/ast/TypedNameTest.java
@@ -95,6 +95,24 @@ final class TypedNameTest {
                 "java_lang_Object$collect",
                 new Attributes()
                     .descriptor("(Ljava/util/stream/Collector;)Ljava/lang/Object;")
+            ),
+            Arguments.of(
+                "toArray",
+                "java_lang_Object[]$toArray",
+                new Attributes()
+                    .descriptor("()[Ljava/lang/Object;")
+            ),
+            Arguments.of(
+                "copyOf",
+                "java_lang_Object[]$copyOf",
+                new Attributes()
+                    .descriptor("([Ljava/lang/Object;I)[Ljava/lang/Object;")
+            ),
+            Arguments.of(
+                "split",
+                "java_lang_String[]$split",
+                new Attributes()
+                    .descriptor("(Ljava/lang/String;)[Ljava/lang/String;")
             )
         );
     }


### PR DESCRIPTION
Replace `[]` array symbols to `@` to make normalizer work.

Related to: #389.
History:
- **feat(#389): add examples that shows the problem**
- **feat(#389): replace [] with @**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add array pattern functionality to `TypedName` class for handling array types in method descriptors.

### Detailed summary
- Added `ARRAY` pattern for handling array types in method descriptors
- Modified `withType` method to replace array type names with `@` symbol

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->