### PR TITLE
feat(#432): prove that opeo keeps packages

### DIFF
--- a/src/test/java/org/eolang/opeo/decompilation/WithoutAliasesTest.java
+++ b/src/test/java/org/eolang/opeo/decompilation/WithoutAliasesTest.java
@@ -50,6 +50,15 @@ final class WithoutAliasesTest {
     }
 
     @Test
+    void keepsPackage() {
+        MatcherAssert.assertThat(
+            "We expect that package is kept, even if the program doesn't have labels or opcodes",
+            new WithoutAliases(WithoutAliasesTest.program()).toXml(),
+            XhtmlMatchers.hasXPath("/program/metas/meta[head='package']")
+        );
+    }
+
+    @Test
     void removesOnlyLabelAlias() {
         MatcherAssert.assertThat(
             "We expect that only the label alias is removed since the program has an object",
@@ -117,6 +126,14 @@ final class WithoutAliasesTest {
                 new Directives()
                     .add("program")
                     .add("metas")
+                    .append(
+                        new Directives()
+                            .add("meta")
+                            .add("head").set("package").up()
+                            .add("tail").set("org.eolang.opeo").up()
+                            .add("part").set("org.eolang.opeo").up()
+                            .up()
+                    )
                     .append(WithoutAliasesTest.alias("org.eolang.jeo.label"))
                     .append(WithoutAliasesTest.alias("org.eolang.jeo.opcode"))
                     .up()


### PR DESCRIPTION
I added one more unit test to check that `opeo-maven-plugin` keeps packages.

Closes #432.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a test method to ensure that the package is kept even without labels or opcodes.

### Detailed summary
- Added a test method `keepsPackage` to verify package preservation
- Updated the `program` method to include package meta information

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->