### PR TITLE
#518: raise a clean exception for a malformed hex byte in a constant node

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/Const.java
+++ b/src/main/java/org/eolang/opeo/ast/Const.java
@@ -354,7 +354,17 @@ public final class Const implements AstNode, Typed {
         final int length = split.length;
         final byte[] res = new byte[length];
         for (int index = 0; index < length; ++index) {
-            res[index] = (byte) Integer.parseInt(split[index], 16);
+            try {
+                res[index] = (byte) Integer.parseInt(split[index], 16);
+            } catch (final NumberFormatException cause) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        "Can't parse '%s' as a hex byte in constant node text '%s'",
+                        split[index], hex
+                    ),
+                    cause
+                );
+            }
         }
         return res;
     }

--- a/src/test/java/org/eolang/opeo/ast/ConstParseBytesTest.java
+++ b/src/test/java/org/eolang/opeo/ast/ConstParseBytesTest.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.opeo.ast;
+
+import org.eolang.jeo.representation.xmir.XmlNode;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Const#xvalue(XmlNode)} rejecting a malformed hex byte.
+ * @since 0.1
+ */
+final class ConstParseBytesTest {
+
+    @Test
+    void rejectsAMalformedHexByteWithACleanException() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new Const(
+                new XmlNode("<o base='int' data='bytes'>00 00 00 ZZ</o>")
+            ),
+            "A malformed hex byte token must raise a clean IllegalArgumentException"
+        );
+    }
+}


### PR DESCRIPTION
`Const.parseBytes` called `Integer.parseInt(split[index], 16)` on each space-separated hex token with no try/catch, so a malformed token (a stray non-hex character introduced by a hand-edit or an earlier pipeline bug) threw an uncaught `NumberFormatException` and aborted the whole Maven build with a raw stack trace.

Wrapped the parse in a try/catch that rethrows a clean `IllegalArgumentException` naming the offending token and the full constant-node text, matching the exception style `Const.xtype` already uses for its own malformed-input case.

Added `ConstParseBytesTest` (a separate file, since `ConstTest` was already at qulice's `TooManyMethods` limit) with a malformed hex byte (`ZZ`), asserting `IllegalArgumentException` instead of the uncaught `NumberFormatException`.

Ran `ConstTest`, `ConstParseBytesTest` and `qulice:check -Pqulice`, both green.

Closes #518
