### PR TITLE
#520: raise a clean exception for a malformed variable identifier

### DIFF
--- a/src/main/java/org/eolang/opeo/ast/LocalVariable.java
+++ b/src/main/java/org/eolang/opeo/ast/LocalVariable.java
@@ -150,15 +150,24 @@ public final class LocalVariable implements AstNode, Typed {
      * @return The identifier.
      */
     private static int videntifier(final XmlNode node) {
-        return Integer.parseInt(
-            node.attribute("base").orElseThrow(
-                () -> new IllegalArgumentException(
-                    String.format(
-                        "Can't recognize variable node: %n%s%nWe expected to find 'base' attribute",
-                        node
-                    )
+        final String suffix = node.attribute("base").orElseThrow(
+            () -> new IllegalArgumentException(
+                String.format(
+                    "Can't recognize variable node: %n%s%nWe expected to find 'base' attribute",
+                    node
                 )
-            ).substring(LocalVariable.PREFIX.length())
-        );
+            )
+        ).substring(LocalVariable.PREFIX.length());
+        try {
+            return Integer.parseInt(suffix);
+        } catch (final NumberFormatException cause) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Can't recognize variable node: %n%s%nThe numeric suffix '%s' after '%s' is not a valid integer",
+                    node, suffix, LocalVariable.PREFIX
+                ),
+                cause
+            );
+        }
     }
 }

--- a/src/test/java/org/eolang/opeo/ast/LocalVariableTest.java
+++ b/src/test/java/org/eolang/opeo/ast/LocalVariableTest.java
@@ -31,6 +31,7 @@ import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.opeo.compilation.HasInstructions;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -79,6 +80,15 @@ final class LocalVariableTest {
             "Can't correctly create variable from XMIR. We expect the variable to be equal to the original, but it wasn't",
             new LocalVariable(new XmlNode(new Xembler(original.toXmir()).xml())),
             Matchers.equalTo(original)
+        );
+    }
+
+    @Test
+    void rejectsAMalformedVariableIdentifierWithACleanException() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new LocalVariable(new XmlNode("<o base='local-abc'/>")),
+            "A malformed numeric suffix must raise a clean IllegalArgumentException"
         );
     }
 


### PR DESCRIPTION
`LocalVariable.videntifier` parsed the numeric suffix of a `local-N` base attribute with `Integer.parseInt`, but only guarded against a missing `base` attribute (via `orElseThrow`). A present but malformed suffix, e.g. `local-abc`, threw an uncaught `NumberFormatException` instead of a clean error.

Wrapped the parse in a try/catch that rethrows the same kind of `IllegalArgumentException` this method already uses for a missing `base` attribute, naming the offending node and the bad suffix.

Added `rejectsAMalformedVariableIdentifierWithACleanException` to `LocalVariableTest`.

Ran `LocalVariableTest` and `qulice:check -Pqulice`, both green.

Closes #520
